### PR TITLE
#86 Handle dialogs accept/dismiss

### DIFF
--- a/lib/api.json
+++ b/lib/api.json
@@ -13128,7 +13128,7 @@
     "tags": [
       {
         "title": "example",
-        "description": "alert('Message', async alert => await alert.dismiss())",
+        "description": "alert('Message', async () => await dismiss())",
         "lineNumber": 3
       },
       {
@@ -13143,17 +13143,11 @@
       },
       {
         "title": "param",
-        "description": "Operation to perform.",
+        "description": "Operation to perform. Accept/Dismiss",
         "lineNumber": 7,
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "alert"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         },
         "name": "callback"
       }
@@ -13183,7 +13177,7 @@
     "augments": [],
     "examples": [
       {
-        "description": "alert('Message', async alert => await alert.dismiss())"
+        "description": "alert('Message', async () => await dismiss())"
       }
     ],
     "params": [
@@ -13260,7 +13254,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Operation to perform.",
+                  "value": "Operation to perform. Accept/Dismiss",
                   "position": {
                     "start": {
                       "line": 1,
@@ -13269,8 +13263,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 22,
-                      "offset": 21
+                      "column": 37,
+                      "offset": 36
                     },
                     "indent": []
                   }
@@ -13284,8 +13278,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 22,
-                  "offset": 21
+                  "column": 37,
+                  "offset": 36
                 },
                 "indent": []
               }
@@ -13299,20 +13293,14 @@
             },
             "end": {
               "line": 1,
-              "column": 22,
-              "offset": 21
+              "column": 37,
+              "offset": 36
             }
           }
         },
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "alert"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         }
       }
     ],
@@ -13431,7 +13419,7 @@
     "tags": [
       {
         "title": "example",
-        "description": "prompt('Message', async prompt => await prompt.dismiss())",
+        "description": "prompt('Message', async () => await dismiss())",
         "lineNumber": 3
       },
       {
@@ -13446,17 +13434,11 @@
       },
       {
         "title": "param",
-        "description": "Operation to perform.",
+        "description": "Operation to perform.Accept/Dismiss",
         "lineNumber": 7,
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "prompt"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         },
         "name": "callback"
       }
@@ -13486,7 +13468,7 @@
     "augments": [],
     "examples": [
       {
-        "description": "prompt('Message', async prompt => await prompt.dismiss())"
+        "description": "prompt('Message', async () => await dismiss())"
       }
     ],
     "params": [
@@ -13563,7 +13545,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Operation to perform.",
+                  "value": "Operation to perform.Accept/Dismiss",
                   "position": {
                     "start": {
                       "line": 1,
@@ -13572,8 +13554,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 22,
-                      "offset": 21
+                      "column": 36,
+                      "offset": 35
                     },
                     "indent": []
                   }
@@ -13587,8 +13569,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 22,
-                  "offset": 21
+                  "column": 36,
+                  "offset": 35
                 },
                 "indent": []
               }
@@ -13602,20 +13584,14 @@
             },
             "end": {
               "line": 1,
-              "column": 22,
-              "offset": 21
+              "column": 36,
+              "offset": 35
             }
           }
         },
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "prompt"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         }
       }
     ],
@@ -13734,7 +13710,7 @@
     "tags": [
       {
         "title": "example",
-        "description": "confirm('Message', async confirm => await confirm.dismiss())",
+        "description": "confirm('Message', async () => await dismiss())",
         "lineNumber": 3
       },
       {
@@ -13749,17 +13725,11 @@
       },
       {
         "title": "param",
-        "description": "Operation to perform.",
+        "description": "Operation to perform.Accept/Dismiss",
         "lineNumber": 7,
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "confirm"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         },
         "name": "callback"
       }
@@ -13789,7 +13759,7 @@
     "augments": [],
     "examples": [
       {
-        "description": "confirm('Message', async confirm => await confirm.dismiss())"
+        "description": "confirm('Message', async () => await dismiss())"
       }
     ],
     "params": [
@@ -13866,7 +13836,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Operation to perform.",
+                  "value": "Operation to perform.Accept/Dismiss",
                   "position": {
                     "start": {
                       "line": 1,
@@ -13875,8 +13845,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 22,
-                      "offset": 21
+                      "column": 36,
+                      "offset": 35
                     },
                     "indent": []
                   }
@@ -13890,8 +13860,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 22,
-                  "offset": 21
+                  "column": 36,
+                  "offset": 35
                 },
                 "indent": []
               }
@@ -13905,20 +13875,14 @@
             },
             "end": {
               "line": 1,
-              "column": 22,
-              "offset": 21
+              "column": 36,
+              "offset": 35
             }
           }
         },
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "confirm"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         }
       }
     ],
@@ -14037,7 +14001,7 @@
     "tags": [
       {
         "title": "example",
-        "description": "beforeunload('Message', async beforeunload => await beforeunload.dismiss())",
+        "description": "beforeunload('Message', async () => await dismiss())",
         "lineNumber": 3
       },
       {
@@ -14052,17 +14016,11 @@
       },
       {
         "title": "param",
-        "description": "Operation to perform.",
+        "description": "Operation to perform.Accept/Dismiss",
         "lineNumber": 7,
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "beforeunload"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         },
         "name": "callback"
       }
@@ -14092,7 +14050,7 @@
     "augments": [],
     "examples": [
       {
-        "description": "beforeunload('Message', async beforeunload => await beforeunload.dismiss())"
+        "description": "beforeunload('Message', async () => await dismiss())"
       }
     ],
     "params": [
@@ -14169,7 +14127,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "Operation to perform.",
+                  "value": "Operation to perform.Accept/Dismiss",
                   "position": {
                     "start": {
                       "line": 1,
@@ -14178,8 +14136,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 22,
-                      "offset": 21
+                      "column": 36,
+                      "offset": 35
                     },
                     "indent": []
                   }
@@ -14193,8 +14151,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 22,
-                  "offset": 21
+                  "column": 36,
+                  "offset": 35
                 },
                 "indent": []
               }
@@ -14208,20 +14166,14 @@
             },
             "end": {
               "line": 1,
-              "column": 22,
-              "offset": 21
+              "column": 36,
+              "offset": 35
             }
           }
         },
         "type": {
-          "type": "FunctionType",
-          "params": [
-            {
-              "type": "NameExpression",
-              "name": "beforeunload"
-            }
-          ],
-          "result": null
+          "type": "NameExpression",
+          "name": "function"
         }
       }
     ],
@@ -14249,6 +14201,214 @@
       }
     ],
     "namespace": ".beforeunload"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Accept callback for dialogs",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 28,
+                  "offset": 27
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 28,
+              "offset": 27
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 28,
+          "offset": 27
+        }
+      }
+    },
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 1075,
+        "column": 0
+      },
+      "end": {
+        "line": 1077,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 1078,
+          "column": 0
+        },
+        "end": {
+          "line": 1082,
+          "column": 2
+        }
+      }
+    },
+    "augments": [],
+    "examples": [],
+    "params": [],
+    "properties": [],
+    "returns": [],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "accept",
+    "kind": "function",
+    "memberof": "taiko",
+    "scope": "static",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "accept",
+        "kind": "function",
+        "scope": "static"
+      }
+    ],
+    "namespace": ".accept"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Dismiss callback for dialogs",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 29,
+                  "offset": 28
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 29,
+              "offset": 28
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 29,
+          "offset": 28
+        }
+      }
+    },
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 1084,
+        "column": 0
+      },
+      "end": {
+        "line": 1086,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 1087,
+          "column": 0
+        },
+        "end": {
+          "line": 1091,
+          "column": 2
+        }
+      }
+    },
+    "augments": [],
+    "examples": [],
+    "params": [],
+    "properties": [],
+    "returns": [],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "dismiss",
+    "kind": "function",
+    "memberof": "taiko",
+    "scope": "static",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "dismiss",
+        "kind": "function",
+        "scope": "static"
+      }
+    ],
+    "namespace": ".dismiss"
   },
   {
     "description": {
@@ -14331,22 +14491,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1075,
+        "line": 1093,
         "column": 0
       },
       "end": {
-        "line": 1083,
+        "line": 1101,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1084,
+          "line": 1102,
           "column": 0
         },
         "end": {
-          "line": 1084,
+          "line": 1102,
           "column": 50
         }
       }
@@ -14586,22 +14746,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1086,
+        "line": 1104,
         "column": 0
       },
       "end": {
-        "line": 1094,
+        "line": 1112,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1095,
+          "line": 1113,
           "column": 0
         },
         "end": {
-          "line": 1095,
+          "line": 1113,
           "column": 49
         }
       }
@@ -14841,22 +15001,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1097,
+        "line": 1115,
         "column": 0
       },
       "end": {
-        "line": 1105,
+        "line": 1123,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1106,
+          "line": 1124,
           "column": 0
         },
         "end": {
-          "line": 1106,
+          "line": 1124,
           "column": 42
         }
       }
@@ -15029,22 +15189,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1108,
+        "line": 1126,
         "column": 0
       },
       "end": {
-        "line": 1116,
+        "line": 1134,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1117,
+          "line": 1135,
           "column": 0
         },
         "end": {
-          "line": 1117,
+          "line": 1135,
           "column": 27
         }
       }
@@ -15059,7 +15219,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1117
+        "lineNumber": 1135
       }
     ],
     "properties": [],
@@ -15222,22 +15382,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1119,
+        "line": 1137,
         "column": 0
       },
       "end": {
-        "line": 1127,
+        "line": 1145,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1128,
+          "line": 1146,
           "column": 0
         },
         "end": {
-          "line": 1128,
+          "line": 1146,
           "column": 29
         }
       }
@@ -15252,7 +15412,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1128
+        "lineNumber": 1146
       }
     ],
     "properties": [],
@@ -15406,22 +15566,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1130,
+        "line": 1148,
         "column": 0
       },
       "end": {
-        "line": 1138,
+        "line": 1156,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1139,
+          "line": 1157,
           "column": 0
         },
         "end": {
-          "line": 1139,
+          "line": 1157,
           "column": 33
         }
       }
@@ -15576,22 +15736,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1341,
+        "line": 1359,
         "column": 0
       },
       "end": {
-        "line": 1353,
+        "line": 1371,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1379,
+          "line": 1397,
           "column": 0
         },
         "end": {
-          "line": 1408,
+          "line": 1426,
           "column": 1
         }
       }
@@ -15804,22 +15964,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1355,
+        "line": 1373,
         "column": 0
       },
       "end": {
-        "line": 1368,
+        "line": 1386,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1379,
+          "line": 1397,
           "column": 0
         },
         "end": {
-          "line": 1408,
+          "line": 1426,
           "column": 1
         }
       }
@@ -16049,22 +16209,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1370,
+        "line": 1388,
         "column": 0
       },
       "end": {
-        "line": 1378,
+        "line": 1396,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1379,
+          "line": 1397,
           "column": 0
         },
         "end": {
-          "line": 1408,
+          "line": 1426,
           "column": 1
         }
       }
@@ -16105,26 +16265,26 @@
       ],
       "loc": {
         "start": {
-          "line": 1380,
+          "line": 1398,
           "column": 4
         },
         "end": {
-          "line": 1383,
+          "line": 1401,
           "column": 7
         }
       },
       "context": {
         "loc": {
           "start": {
-            "line": 1384,
+            "line": 1402,
             "column": 4
           },
           "end": {
-            "line": 1388,
+            "line": 1406,
             "column": 5
           }
         },
-        "sortKey": "undefined 00001384",
+        "sortKey": "undefined 00001402",
         "code": "{\n    /**\n     * @class\n     * @ignore\n     */\n    constructor(condition, value, desc) {\n        this.condition = condition;\n        this.value = value;\n        this.desc = desc;\n    }\n\n    async validNodes(nodeId) {\n        let matchingNode, minDiff = Infinity;\n        const results = await this.value;\n        for (const result of results) {\n            if(await this.condition(nodeId, result.result)){\n                const diff = await boundingBox.getPositionalDifference(dom,nodeId,result.elem);\n                if(diff < minDiff){\n                    minDiff = diff;\n                    matchingNode = {elem:result.elem, dist:diff};\n                }\n            }    \n        }\n        return matchingNode;\n    }\n\n    toString() {\n        return this.desc;\n    }\n}"
       },
       "augments": [],
@@ -16890,22 +17050,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1410,
+        "line": 1428,
         "column": 0
       },
       "end": {
-        "line": 1429,
+        "line": 1447,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1431,
+          "line": 1449,
           "column": 0
         },
         "end": {
-          "line": 1438,
+          "line": 1456,
           "column": 2
         }
       }

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1032,10 +1032,10 @@ module.exports.near = (selector) => {
  * Lets you perform an operation when an `alert` with given text is shown.
  *
  * @example
- * alert('Message', async alert => await alert.dismiss())
+ * alert('Message', async () => await dismiss())
  *
  * @param {string} message - Identify alert based on this message.
- * @param {function(alert)} callback - Operation to perform.
+ * @param {function} callback - Operation to perform. Accept/Dismiss
  */
 module.exports.alert = (message, callback) => dialog('alert', message, callback);
 
@@ -1043,10 +1043,10 @@ module.exports.alert = (message, callback) => dialog('alert', message, callback)
  * Lets you perform an operation when a `prompt` with given text is shown.
  *
  * @example
- * prompt('Message', async prompt => await prompt.dismiss())
+ * prompt('Message', async () => await dismiss())
  *
  * @param {string} message - Identify prompt based on this message.
- * @param {function(prompt)} callback - Operation to perform.
+ * @param {function} callback - Operation to perform.Accept/Dismiss
  */
 module.exports.prompt = (message, callback) => dialog('prompt', message, callback);
 
@@ -1054,10 +1054,10 @@ module.exports.prompt = (message, callback) => dialog('prompt', message, callbac
  * Lets you perform an operation when a `confirm` with given text is shown.
  *
  * @example
- * confirm('Message', async confirm => await confirm.dismiss())
+ * confirm('Message', async () => await dismiss())
  *
  * @param {string} message - Identify confirm based on this message.
- * @param {function(confirm)} callback - Operation to perform.
+ * @param {function} callback - Operation to perform.Accept/Dismiss
  */
 module.exports.confirm = (message, callback) => dialog('confirm', message, callback);
 
@@ -1065,12 +1065,30 @@ module.exports.confirm = (message, callback) => dialog('confirm', message, callb
  * Lets you perform an operation when a `beforeunload` with given text is shown.
  *
  * @example
- * beforeunload('Message', async beforeunload => await beforeunload.dismiss())
+ * beforeunload('Message', async () => await dismiss())
  *
  * @param {string} message - Identify beforeunload based on this message.
- * @param {function(beforeunload)} callback - Operation to perform.
+ * @param {function} callback - Operation to perform.Accept/Dismiss
  */
 module.exports.beforeunload = (message, callback) => dialog('beforeunload', message, callback);
+
+/**
+ * Accept callback for dialogs
+ */
+module.exports.accept = async () => {
+    await page.handleJavaScriptDialog({
+        accept: true,
+    });
+};
+
+/**
+ * Dismiss callback for dialogs
+ */
+module.exports.dismiss = async () => {
+    await page.handleJavaScriptDialog({
+        accept: false
+    });
+};
 
 /**
  * Converts seconds to milliseconds.
@@ -1195,7 +1213,7 @@ const dialog = (dialogType, dialogMessage, callback) => {
     validate();
     page.javascriptDialogOpening(async ({ message, type }) => {
         if (dialogType === type && dialogMessage === message)
-            await callback(dialog);
+            await callback();
     });
 };
 
@@ -1434,5 +1452,5 @@ module.exports.metadata = {
     'Selectors': ['$', 'image', 'link', 'listItem', 'button', 'inputField', 'fileField', 'textField', 'comboBox', 'checkBox', 'radioButton', 'text', 'contains'],
     'Proximity selectors': ['toLeftOf', 'toRightOf', 'above', 'below', 'near'],
     'Events': ['alert', 'prompt', 'confirm', 'beforeunload'],
-    'Helpers': ['intervalSecs', 'timeoutSecs', 'waitForNavigation', 'to', 'into', 'waitFor'],
+    'Helpers': ['intervalSecs', 'timeoutSecs', 'waitForNavigation', 'to', 'into', 'waitFor','accept','dismiss'],
 };


### PR DESCRIPTION
Can be tested by updating `step_implementation.js` in `js-taiko` with alert step as below 

```
step('Alert', async() => {
    alert('Message 1', async () => await dismiss());
    alert('Message 2', async () => await accept());

    await click(button("Alert"));
    await click(button("Alert1"));
});
```