### PR TITLE
Handle new target

### DIFF
--- a/lib/api.json
+++ b/lib/api.json
@@ -89,22 +89,22 @@
     ],
     "loc": {
       "start": {
-        "line": 44,
+        "line": 47,
         "column": 0
       },
       "end": {
-        "line": 53,
+        "line": 56,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 54,
+          "line": 57,
           "column": 0
         },
         "end": {
-          "line": 66,
+          "line": 69,
           "column": 2
         }
       }
@@ -348,22 +348,22 @@
     ],
     "loc": {
       "start": {
-        "line": 68,
+        "line": 71,
         "column": 0
       },
       "end": {
-        "line": 72,
+        "line": 75,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 73,
+          "line": 76,
           "column": 0
         },
         "end": {
-          "line": 80,
+          "line": 83,
           "column": 2
         }
       }
@@ -504,22 +504,22 @@
     ],
     "loc": {
       "start": {
-        "line": 82,
+        "line": 85,
         "column": 0
       },
       "end": {
-        "line": 86,
+        "line": 89,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 87,
+          "line": 90,
           "column": 0
         },
         "end": {
-          "line": 87,
+          "line": 90,
           "column": 37
         }
       }
@@ -665,22 +665,22 @@
     ],
     "loc": {
       "start": {
-        "line": 89,
+        "line": 92,
         "column": 0
       },
       "end": {
-        "line": 96,
+        "line": 99,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 97,
+          "line": 100,
           "column": 0
         },
         "end": {
-          "line": 105,
+          "line": 108,
           "column": 2
         }
       }
@@ -920,22 +920,22 @@
     ],
     "loc": {
       "start": {
-        "line": 107,
+        "line": 110,
         "column": 0
       },
       "end": {
-        "line": 117,
+        "line": 120,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 118,
+          "line": 121,
           "column": 0
         },
         "end": {
-          "line": 131,
+          "line": 134,
           "column": 2
         }
       }
@@ -1245,22 +1245,22 @@
     ],
     "loc": {
       "start": {
-        "line": 133,
+        "line": 136,
         "column": 0
       },
       "end": {
-        "line": 141,
+        "line": 144,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 142,
+          "line": 145,
           "column": 0
         },
         "end": {
-          "line": 146,
+          "line": 149,
           "column": 2
         }
       }
@@ -1275,7 +1275,7 @@
       {
         "title": "param",
         "name": "url",
-        "lineNumber": 142
+        "lineNumber": 145
       }
     ],
     "properties": [],
@@ -1447,22 +1447,22 @@
     ],
     "loc": {
       "start": {
-        "line": 148,
+        "line": 151,
         "column": 0
       },
       "end": {
-        "line": 152,
+        "line": 155,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 153,
+          "line": 156,
           "column": 0
         },
         "end": {
-          "line": 160,
+          "line": 163,
           "column": 2
         }
       }
@@ -1693,22 +1693,22 @@
     ],
     "loc": {
       "start": {
-        "line": 173,
+        "line": 176,
         "column": 0
       },
       "end": {
-        "line": 187,
+        "line": 190,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 188,
+          "line": 191,
           "column": 0
         },
         "end": {
-          "line": 188,
+          "line": 191,
           "column": 29
         }
       }
@@ -2470,22 +2470,22 @@
     ],
     "loc": {
       "start": {
-        "line": 223,
+        "line": 226,
         "column": 0
       },
       "end": {
-        "line": 234,
+        "line": 237,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 235,
+          "line": 238,
           "column": 0
         },
         "end": {
-          "line": 246,
+          "line": 249,
           "column": 2
         }
       }
@@ -2764,7 +2764,7 @@
       {
         "title": "param",
         "name": "args",
-        "lineNumber": 235,
+        "lineNumber": 238,
         "type": {
           "type": "RestType"
         }
@@ -2987,22 +2987,22 @@
     ],
     "loc": {
       "start": {
-        "line": 248,
+        "line": 251,
         "column": 0
       },
       "end": {
-        "line": 259,
+        "line": 262,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 260,
+          "line": 263,
           "column": 0
         },
         "end": {
-          "line": 271,
+          "line": 274,
           "column": 2
         }
       }
@@ -3281,7 +3281,7 @@
       {
         "title": "param",
         "name": "args",
-        "lineNumber": 260,
+        "lineNumber": 263,
         "type": {
           "type": "RestType"
         }
@@ -3480,22 +3480,22 @@
     ],
     "loc": {
       "start": {
-        "line": 273,
+        "line": 276,
         "column": 0
       },
       "end": {
-        "line": 282,
+        "line": 285,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 283,
+          "line": 286,
           "column": 0
         },
         "end": {
-          "line": 299,
+          "line": 302,
           "column": 2
         }
       }
@@ -3771,22 +3771,22 @@
     ],
     "loc": {
       "start": {
-        "line": 301,
+        "line": 304,
         "column": 0
       },
       "end": {
-        "line": 309,
+        "line": 312,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 310,
+          "line": 313,
           "column": 0
         },
         "end": {
-          "line": 314,
+          "line": 317,
           "column": 2
         }
       }
@@ -4098,22 +4098,22 @@
     ],
     "loc": {
       "start": {
-        "line": 316,
+        "line": 319,
         "column": 0
       },
       "end": {
-        "line": 329,
+        "line": 332,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 330,
+          "line": 333,
           "column": 0
         },
         "end": {
-          "line": 347,
+          "line": 350,
           "column": 2
         }
       }
@@ -4539,22 +4539,22 @@
     ],
     "loc": {
       "start": {
-        "line": 356,
+        "line": 359,
         "column": 0
       },
       "end": {
-        "line": 366,
+        "line": 369,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 367,
+          "line": 370,
           "column": 0
         },
         "end": {
-          "line": 383,
+          "line": 386,
           "column": 2
         }
       }
@@ -4916,22 +4916,22 @@
     ],
     "loc": {
       "start": {
-        "line": 385,
+        "line": 388,
         "column": 0
       },
       "end": {
-        "line": 397,
+        "line": 400,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 398,
+          "line": 401,
           "column": 0
         },
         "end": {
-          "line": 404,
+          "line": 407,
           "column": 2
         }
       }
@@ -5386,22 +5386,22 @@
     ],
     "loc": {
       "start": {
-        "line": 406,
+        "line": 409,
         "column": 0
       },
       "end": {
-        "line": 415,
+        "line": 418,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 416,
+          "line": 419,
           "column": 0
         },
         "end": {
-          "line": 425,
+          "line": 428,
           "column": 2
         }
       }
@@ -5677,22 +5677,22 @@
     ],
     "loc": {
       "start": {
-        "line": 427,
+        "line": 430,
         "column": 0
       },
       "end": {
-        "line": 436,
+        "line": 439,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 437,
+          "line": 440,
           "column": 0
         },
         "end": {
-          "line": 437,
+          "line": 440,
           "column": 35
         }
       }
@@ -5988,22 +5988,22 @@
     ],
     "loc": {
       "start": {
-        "line": 466,
+        "line": 469,
         "column": 0
       },
       "end": {
-        "line": 478,
+        "line": 481,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 479,
+          "line": 482,
           "column": 0
         },
         "end": {
-          "line": 482,
+          "line": 485,
           "column": 2
         }
       }
@@ -6264,22 +6264,22 @@
     ],
     "loc": {
       "start": {
-        "line": 484,
+        "line": 487,
         "column": 0
       },
       "end": {
-        "line": 496,
+        "line": 499,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 497,
+          "line": 500,
           "column": 0
         },
         "end": {
-          "line": 500,
+          "line": 503,
           "column": 2
         }
       }
@@ -6540,22 +6540,22 @@
     ],
     "loc": {
       "start": {
-        "line": 502,
+        "line": 505,
         "column": 0
       },
       "end": {
-        "line": 514,
+        "line": 517,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 515,
+          "line": 518,
           "column": 0
         },
         "end": {
-          "line": 518,
+          "line": 521,
           "column": 2
         }
       }
@@ -6816,22 +6816,22 @@
     ],
     "loc": {
       "start": {
-        "line": 520,
+        "line": 523,
         "column": 0
       },
       "end": {
-        "line": 532,
+        "line": 535,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 533,
+          "line": 536,
           "column": 0
         },
         "end": {
-          "line": 536,
+          "line": 539,
           "column": 2
         }
       }
@@ -7061,22 +7061,22 @@
     ],
     "loc": {
       "start": {
-        "line": 538,
+        "line": 541,
         "column": 0
       },
       "end": {
-        "line": 546,
+        "line": 549,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 547,
+          "line": 550,
           "column": 0
         },
         "end": {
-          "line": 554,
+          "line": 557,
           "column": 2
         }
       }
@@ -7091,7 +7091,7 @@
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 547,
+        "lineNumber": 550,
         "default": "{}"
       },
       {
@@ -7386,22 +7386,22 @@
     ],
     "loc": {
       "start": {
-        "line": 556,
+        "line": 559,
         "column": 0
       },
       "end": {
-        "line": 565,
+        "line": 568,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 566,
+          "line": 569,
           "column": 0
         },
         "end": {
-          "line": 570,
+          "line": 573,
           "column": 2
         }
       }
@@ -7682,22 +7682,22 @@
     ],
     "loc": {
       "start": {
-        "line": 617,
+        "line": 620,
         "column": 0
       },
       "end": {
-        "line": 628,
+        "line": 631,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 629,
+          "line": 632,
           "column": 0
         },
         "end": {
-          "line": 634,
+          "line": 637,
           "column": 2
         }
       }
@@ -8039,22 +8039,22 @@
     ],
     "loc": {
       "start": {
-        "line": 636,
+        "line": 639,
         "column": 0
       },
       "end": {
-        "line": 647,
+        "line": 650,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 648,
+          "line": 651,
           "column": 0
         },
         "end": {
-          "line": 653,
+          "line": 656,
           "column": 2
         }
       }
@@ -8430,22 +8430,22 @@
     ],
     "loc": {
       "start": {
-        "line": 655,
+        "line": 658,
         "column": 0
       },
       "end": {
-        "line": 666,
+        "line": 669,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 667,
+          "line": 670,
           "column": 0
         },
         "end": {
-          "line": 672,
+          "line": 675,
           "column": 2
         }
       }
@@ -8787,22 +8787,22 @@
     ],
     "loc": {
       "start": {
-        "line": 674,
+        "line": 677,
         "column": 0
       },
       "end": {
-        "line": 685,
+        "line": 688,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 686,
+          "line": 689,
           "column": 0
         },
         "end": {
-          "line": 691,
+          "line": 694,
           "column": 2
         }
       }
@@ -9134,22 +9134,22 @@
     ],
     "loc": {
       "start": {
-        "line": 693,
+        "line": 696,
         "column": 0
       },
       "end": {
-        "line": 703,
+        "line": 706,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 704,
+          "line": 707,
           "column": 0
         },
         "end": {
-          "line": 715,
+          "line": 718,
           "column": 2
         }
       }
@@ -9430,22 +9430,22 @@
     ],
     "loc": {
       "start": {
-        "line": 717,
+        "line": 720,
         "column": 0
       },
       "end": {
-        "line": 729,
+        "line": 732,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 730,
+          "line": 733,
           "column": 0
         },
         "end": {
-          "line": 730,
+          "line": 733,
           "column": 37
         }
       }
@@ -9785,22 +9785,22 @@
     ],
     "loc": {
       "start": {
-        "line": 745,
+        "line": 748,
         "column": 0
       },
       "end": {
-        "line": 756,
+        "line": 759,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 757,
+          "line": 760,
           "column": 0
         },
         "end": {
-          "line": 757,
+          "line": 760,
           "column": 37
         }
       }
@@ -10144,22 +10144,22 @@
     ],
     "loc": {
       "start": {
-        "line": 773,
+        "line": 776,
         "column": 0
       },
       "end": {
-        "line": 786,
+        "line": 789,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 787,
+          "line": 790,
           "column": 0
         },
         "end": {
-          "line": 825,
+          "line": 828,
           "column": 2
         }
       }
@@ -10501,22 +10501,22 @@
     ],
     "loc": {
       "start": {
-        "line": 827,
+        "line": 830,
         "column": 0
       },
       "end": {
-        "line": 840,
+        "line": 843,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 841,
+          "line": 844,
           "column": 0
         },
         "end": {
-          "line": 855,
+          "line": 858,
           "column": 2
         }
       }
@@ -10531,7 +10531,7 @@
       {
         "title": "param",
         "name": "attrValuePairs",
-        "lineNumber": 841
+        "lineNumber": 844
       },
       {
         "title": "param",
@@ -10863,22 +10863,22 @@
     ],
     "loc": {
       "start": {
-        "line": 857,
+        "line": 860,
         "column": 0
       },
       "end": {
-        "line": 870,
+        "line": 873,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 871,
+          "line": 874,
           "column": 0
         },
         "end": {
-          "line": 886,
+          "line": 889,
           "column": 2
         }
       }
@@ -10893,7 +10893,7 @@
       {
         "title": "param",
         "name": "attrValuePairs",
-        "lineNumber": 871
+        "lineNumber": 874
       },
       {
         "title": "param",
@@ -11215,22 +11215,22 @@
     ],
     "loc": {
       "start": {
-        "line": 888,
+        "line": 891,
         "column": 0
       },
       "end": {
-        "line": 898,
+        "line": 901,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 899,
+          "line": 902,
           "column": 0
         },
         "end": {
-          "line": 903,
+          "line": 906,
           "column": 2
         }
       }
@@ -11501,22 +11501,22 @@
     ],
     "loc": {
       "start": {
-        "line": 905,
+        "line": 908,
         "column": 0
       },
       "end": {
-        "line": 914,
+        "line": 917,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 915,
+          "line": 918,
           "column": 0
         },
         "end": {
-          "line": 915,
+          "line": 918,
           "column": 35
         }
       }
@@ -11781,22 +11781,22 @@
     ],
     "loc": {
       "start": {
-        "line": 939,
+        "line": 942,
         "column": 0
       },
       "end": {
-        "line": 947,
+        "line": 950,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 948,
+          "line": 951,
           "column": 0
         },
         "end": {
-          "line": 954,
+          "line": 957,
           "column": 2
         }
       }
@@ -12060,22 +12060,22 @@
     ],
     "loc": {
       "start": {
-        "line": 956,
+        "line": 959,
         "column": 0
       },
       "end": {
-        "line": 964,
+        "line": 967,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 965,
+          "line": 968,
           "column": 0
         },
         "end": {
-          "line": 973,
+          "line": 976,
           "column": 2
         }
       }
@@ -12339,22 +12339,22 @@
     ],
     "loc": {
       "start": {
-        "line": 975,
+        "line": 978,
         "column": 0
       },
       "end": {
-        "line": 983,
+        "line": 986,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 984,
+          "line": 987,
           "column": 0
         },
         "end": {
-          "line": 992,
+          "line": 995,
           "column": 2
         }
       }
@@ -12618,22 +12618,22 @@
     ],
     "loc": {
       "start": {
-        "line": 994,
+        "line": 997,
         "column": 0
       },
       "end": {
-        "line": 1002,
+        "line": 1005,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1003,
+          "line": 1006,
           "column": 0
         },
         "end": {
-          "line": 1011,
+          "line": 1014,
           "column": 2
         }
       }
@@ -12897,22 +12897,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1013,
+        "line": 1016,
         "column": 0
       },
       "end": {
-        "line": 1021,
+        "line": 1024,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1022,
+          "line": 1025,
           "column": 0
         },
         "end": {
-          "line": 1032,
+          "line": 1035,
           "column": 2
         }
       }
@@ -13160,22 +13160,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1034,
+        "line": 1037,
         "column": 0
       },
       "end": {
-        "line": 1042,
+        "line": 1045,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1043,
+          "line": 1046,
           "column": 0
         },
         "end": {
-          "line": 1043,
+          "line": 1046,
           "column": 81
         }
       }
@@ -13451,22 +13451,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1045,
+        "line": 1048,
         "column": 0
       },
       "end": {
-        "line": 1053,
+        "line": 1056,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1054,
+          "line": 1057,
           "column": 0
         },
         "end": {
-          "line": 1054,
+          "line": 1057,
           "column": 83
         }
       }
@@ -13742,22 +13742,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1056,
+        "line": 1059,
         "column": 0
       },
       "end": {
-        "line": 1064,
+        "line": 1067,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1065,
+          "line": 1068,
           "column": 0
         },
         "end": {
-          "line": 1065,
+          "line": 1068,
           "column": 85
         }
       }
@@ -14033,22 +14033,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1067,
+        "line": 1070,
         "column": 0
       },
       "end": {
-        "line": 1075,
+        "line": 1078,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1076,
+          "line": 1079,
           "column": 0
         },
         "end": {
-          "line": 1076,
+          "line": 1079,
           "column": 95
         }
       }
@@ -14264,22 +14264,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 1078,
+        "line": 1081,
         "column": 0
       },
       "end": {
-        "line": 1080,
+        "line": 1083,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1081,
+          "line": 1084,
           "column": 0
         },
         "end": {
-          "line": 1085,
+          "line": 1088,
           "column": 2
         }
       }
@@ -14368,22 +14368,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 1087,
+        "line": 1090,
         "column": 0
       },
       "end": {
-        "line": 1089,
+        "line": 1092,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1090,
+          "line": 1093,
           "column": 0
         },
         "end": {
-          "line": 1094,
+          "line": 1097,
           "column": 2
         }
       }
@@ -14497,22 +14497,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1096,
+        "line": 1099,
         "column": 0
       },
       "end": {
-        "line": 1104,
+        "line": 1107,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1105,
+          "line": 1108,
           "column": 0
         },
         "end": {
-          "line": 1105,
+          "line": 1108,
           "column": 50
         }
       }
@@ -14752,22 +14752,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1107,
+        "line": 1110,
         "column": 0
       },
       "end": {
-        "line": 1115,
+        "line": 1118,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1116,
+          "line": 1119,
           "column": 0
         },
         "end": {
-          "line": 1116,
+          "line": 1119,
           "column": 49
         }
       }
@@ -15007,22 +15007,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1118,
+        "line": 1121,
         "column": 0
       },
       "end": {
-        "line": 1126,
+        "line": 1129,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1127,
+          "line": 1130,
           "column": 0
         },
         "end": {
-          "line": 1127,
+          "line": 1130,
           "column": 42
         }
       }
@@ -15195,22 +15195,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1129,
+        "line": 1132,
         "column": 0
       },
       "end": {
-        "line": 1137,
+        "line": 1140,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1138,
+          "line": 1141,
           "column": 0
         },
         "end": {
-          "line": 1138,
+          "line": 1141,
           "column": 27
         }
       }
@@ -15225,7 +15225,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1138
+        "lineNumber": 1141
       }
     ],
     "properties": [],
@@ -15388,22 +15388,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1140,
+        "line": 1143,
         "column": 0
       },
       "end": {
-        "line": 1148,
+        "line": 1151,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1149,
+          "line": 1152,
           "column": 0
         },
         "end": {
-          "line": 1149,
+          "line": 1152,
           "column": 29
         }
       }
@@ -15418,7 +15418,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1149
+        "lineNumber": 1152
       }
     ],
     "properties": [],
@@ -15572,22 +15572,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1151,
+        "line": 1154,
         "column": 0
       },
       "end": {
-        "line": 1159,
+        "line": 1162,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1160,
+          "line": 1163,
           "column": 0
         },
         "end": {
-          "line": 1160,
+          "line": 1163,
           "column": 33
         }
       }
@@ -15742,22 +15742,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1362,
+        "line": 1365,
         "column": 0
       },
       "end": {
-        "line": 1374,
+        "line": 1377,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1400,
+          "line": 1403,
           "column": 0
         },
         "end": {
-          "line": 1429,
+          "line": 1432,
           "column": 1
         }
       }
@@ -15970,22 +15970,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1376,
+        "line": 1379,
         "column": 0
       },
       "end": {
-        "line": 1389,
+        "line": 1392,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1400,
+          "line": 1403,
           "column": 0
         },
         "end": {
-          "line": 1429,
+          "line": 1432,
           "column": 1
         }
       }
@@ -16215,22 +16215,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1391,
+        "line": 1394,
         "column": 0
       },
       "end": {
-        "line": 1399,
+        "line": 1402,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1400,
+          "line": 1403,
           "column": 0
         },
         "end": {
-          "line": 1429,
+          "line": 1432,
           "column": 1
         }
       }
@@ -16271,26 +16271,26 @@
       ],
       "loc": {
         "start": {
-          "line": 1401,
+          "line": 1404,
           "column": 4
         },
         "end": {
-          "line": 1404,
+          "line": 1407,
           "column": 7
         }
       },
       "context": {
         "loc": {
           "start": {
-            "line": 1405,
+            "line": 1408,
             "column": 4
           },
           "end": {
-            "line": 1409,
+            "line": 1412,
             "column": 5
           }
         },
-        "sortKey": "undefined 00001405",
+        "sortKey": "undefined 00001408",
         "code": "{\n    /**\n     * @class\n     * @ignore\n     */\n    constructor(condition, value, desc) {\n        this.condition = condition;\n        this.value = value;\n        this.desc = desc;\n    }\n\n    async validNodes(nodeId) {\n        let matchingNode, minDiff = Infinity;\n        const results = await this.value;\n        for (const result of results) {\n            if(await this.condition(nodeId, result.result)){\n                const diff = await boundingBox.getPositionalDifference(dom,nodeId,result.elem);\n                if(diff < minDiff){\n                    minDiff = diff;\n                    matchingNode = {elem:result.elem, dist:diff};\n                }\n            }    \n        }\n        return matchingNode;\n    }\n\n    toString() {\n        return this.desc;\n    }\n}"
       },
       "augments": [],
@@ -17056,22 +17056,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1431,
+        "line": 1434,
         "column": 0
       },
       "end": {
-        "line": 1450,
+        "line": 1453,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1452,
+          "line": 1455,
           "column": 0
         },
         "end": {
-          "line": 1459,
+          "line": 1462,
           "column": 2
         }
       }

--- a/lib/api.json
+++ b/lib/api.json
@@ -282,7 +282,7 @@
           "children": [
             {
               "type": "text",
-              "value": "Allows to switch between targets using URL.",
+              "value": "Allows to switch between tabs using URL.",
               "position": {
                 "start": {
                   "line": 1,
@@ -291,8 +291,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 44,
-                  "offset": 43
+                  "column": 41,
+                  "offset": 40
                 },
                 "indent": []
               }
@@ -306,8 +306,8 @@
             },
             "end": {
               "line": 1,
-              "column": 44,
-              "offset": 43
+              "column": 41,
+              "offset": 40
             },
             "indent": []
           }
@@ -321,8 +321,8 @@
         },
         "end": {
           "line": 1,
-          "column": 44,
-          "offset": 43
+          "column": 41,
+          "offset": 40
         }
       }
     },
@@ -517,7 +517,7 @@
     "sees": [],
     "throws": [],
     "todos": [],
-    "name": "switchToTarget",
+    "name": "switchTo",
     "kind": "function",
     "memberof": "taiko",
     "scope": "static",
@@ -530,12 +530,12 @@
     },
     "path": [
       {
-        "name": "switchToTarget",
+        "name": "switchTo",
         "kind": "function",
         "scope": "static"
       }
     ],
-    "namespace": ".switchToTarget"
+    "namespace": ".switchTo"
   },
   {
     "description": {

--- a/lib/api.json
+++ b/lib/api.json
@@ -89,22 +89,22 @@
     ],
     "loc": {
       "start": {
-        "line": 47,
+        "line": 46,
         "column": 0
       },
       "end": {
-        "line": 56,
+        "line": 55,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 57,
+          "line": 56,
           "column": 0
         },
         "end": {
-          "line": 69,
+          "line": 68,
           "column": 2
         }
       }
@@ -282,7 +282,7 @@
           "children": [
             {
               "type": "text",
-              "value": "Gives the browser version packaged with Taiko.",
+              "value": "Allows to switch between targets using URL.",
               "position": {
                 "start": {
                   "line": 1,
@@ -291,8 +291,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 47,
-                  "offset": 46
+                  "column": 44,
+                  "offset": 43
                 },
                 "indent": []
               }
@@ -306,8 +306,8 @@
             },
             "end": {
               "line": 1,
-              "column": 47,
-              "offset": 46
+              "column": 44,
+              "offset": 43
             },
             "indent": []
           }
@@ -321,16 +321,26 @@
         },
         "end": {
           "line": 1,
-          "column": 47,
-          "offset": 46
+          "column": 44,
+          "offset": 43
         }
       }
     },
     "tags": [
       {
-        "title": "returns",
-        "description": null,
+        "title": "param",
+        "description": "URL to the target to switch.",
         "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "targetUrl"
+      },
+      {
+        "title": "returns",
+        "description": "Object with the description of the action performed.",
+        "lineNumber": 4,
         "type": {
           "type": "TypeApplication",
           "expression": {
@@ -340,7 +350,7 @@
           "applications": [
             {
               "type": "NameExpression",
-              "name": "string"
+              "name": "Object"
             }
           ]
         }
@@ -348,7 +358,7 @@
     ],
     "loc": {
       "start": {
-        "line": 71,
+        "line": 70,
         "column": 0
       },
       "end": {
@@ -363,20 +373,57 @@
           "column": 0
         },
         "end": {
-          "line": 83,
+          "line": 82,
           "column": 2
         }
       }
     },
     "augments": [],
     "examples": [],
-    "params": [],
-    "properties": [],
-    "returns": [
+    "params": [
       {
+        "title": "param",
+        "name": "targetUrl",
+        "lineNumber": 3,
         "description": {
           "type": "root",
-          "children": [],
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "URL to the target to switch.",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 29,
+                      "offset": 28
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 29,
+                  "offset": 28
+                },
+                "indent": []
+              }
+            }
+          ],
           "position": {
             "start": {
               "line": 1,
@@ -385,8 +432,69 @@
             },
             "end": {
               "line": 1,
+              "column": 29,
+              "offset": 28
+            }
+          }
+        },
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        }
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Object with the description of the action performed.",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 53,
+                      "offset": 52
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 53,
+                  "offset": 52
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
               "column": 1,
               "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 53,
+              "offset": 52
             }
           }
         },
@@ -400,7 +508,7 @@
           "applications": [
             {
               "type": "NameExpression",
-              "name": "string"
+              "name": "Object"
             }
           ]
         }
@@ -409,7 +517,7 @@
     "sees": [],
     "throws": [],
     "todos": [],
-    "name": "getBrowserVersion",
+    "name": "switchToTarget",
     "kind": "function",
     "memberof": "taiko",
     "scope": "static",
@@ -422,12 +530,12 @@
     },
     "path": [
       {
-        "name": "getBrowserVersion",
+        "name": "switchToTarget",
         "kind": "function",
         "scope": "static"
       }
     ],
-    "namespace": ".getBrowserVersion"
+    "namespace": ".switchToTarget"
   },
   {
     "description": {
@@ -504,22 +612,22 @@
     ],
     "loc": {
       "start": {
-        "line": 85,
+        "line": 84,
         "column": 0
       },
       "end": {
-        "line": 89,
+        "line": 88,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 90,
+          "line": 89,
           "column": 0
         },
         "end": {
-          "line": 90,
+          "line": 89,
           "column": 37
         }
       }
@@ -665,22 +773,22 @@
     ],
     "loc": {
       "start": {
-        "line": 92,
+        "line": 91,
         "column": 0
       },
       "end": {
-        "line": 99,
+        "line": 98,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 100,
+          "line": 99,
           "column": 0
         },
         "end": {
-          "line": 108,
+          "line": 107,
           "column": 2
         }
       }
@@ -920,22 +1028,22 @@
     ],
     "loc": {
       "start": {
-        "line": 110,
+        "line": 109,
         "column": 0
       },
       "end": {
-        "line": 120,
+        "line": 119,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 121,
+          "line": 120,
           "column": 0
         },
         "end": {
-          "line": 134,
+          "line": 133,
           "column": 2
         }
       }
@@ -1245,22 +1353,22 @@
     ],
     "loc": {
       "start": {
-        "line": 136,
+        "line": 135,
         "column": 0
       },
       "end": {
-        "line": 144,
+        "line": 143,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 145,
+          "line": 144,
           "column": 0
         },
         "end": {
-          "line": 149,
+          "line": 148,
           "column": 2
         }
       }
@@ -1275,7 +1383,7 @@
       {
         "title": "param",
         "name": "url",
-        "lineNumber": 145
+        "lineNumber": 144
       }
     ],
     "properties": [],
@@ -1447,22 +1555,22 @@
     ],
     "loc": {
       "start": {
-        "line": 151,
+        "line": 150,
         "column": 0
       },
       "end": {
-        "line": 155,
+        "line": 154,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 156,
+          "line": 155,
           "column": 0
         },
         "end": {
-          "line": 163,
+          "line": 162,
           "column": 2
         }
       }
@@ -1693,22 +1801,22 @@
     ],
     "loc": {
       "start": {
-        "line": 176,
+        "line": 175,
         "column": 0
       },
       "end": {
-        "line": 190,
+        "line": 189,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 191,
+          "line": 190,
           "column": 0
         },
         "end": {
-          "line": 191,
+          "line": 190,
           "column": 29
         }
       }
@@ -2470,22 +2578,22 @@
     ],
     "loc": {
       "start": {
-        "line": 226,
+        "line": 225,
         "column": 0
       },
       "end": {
-        "line": 237,
+        "line": 236,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 238,
+          "line": 237,
           "column": 0
         },
         "end": {
-          "line": 249,
+          "line": 248,
           "column": 2
         }
       }
@@ -2764,7 +2872,7 @@
       {
         "title": "param",
         "name": "args",
-        "lineNumber": 238,
+        "lineNumber": 237,
         "type": {
           "type": "RestType"
         }
@@ -2987,22 +3095,22 @@
     ],
     "loc": {
       "start": {
-        "line": 251,
+        "line": 250,
         "column": 0
       },
       "end": {
-        "line": 262,
+        "line": 261,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 263,
+          "line": 262,
           "column": 0
         },
         "end": {
-          "line": 274,
+          "line": 273,
           "column": 2
         }
       }
@@ -3281,7 +3389,7 @@
       {
         "title": "param",
         "name": "args",
-        "lineNumber": 263,
+        "lineNumber": 262,
         "type": {
           "type": "RestType"
         }
@@ -3480,22 +3588,22 @@
     ],
     "loc": {
       "start": {
-        "line": 276,
+        "line": 275,
         "column": 0
       },
       "end": {
-        "line": 285,
+        "line": 284,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 286,
+          "line": 285,
           "column": 0
         },
         "end": {
-          "line": 302,
+          "line": 301,
           "column": 2
         }
       }
@@ -3771,22 +3879,22 @@
     ],
     "loc": {
       "start": {
-        "line": 304,
+        "line": 303,
         "column": 0
       },
       "end": {
-        "line": 312,
+        "line": 311,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 313,
+          "line": 312,
           "column": 0
         },
         "end": {
-          "line": 317,
+          "line": 316,
           "column": 2
         }
       }
@@ -4098,22 +4206,22 @@
     ],
     "loc": {
       "start": {
-        "line": 319,
+        "line": 318,
         "column": 0
       },
       "end": {
-        "line": 332,
+        "line": 331,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 333,
+          "line": 332,
           "column": 0
         },
         "end": {
-          "line": 350,
+          "line": 349,
           "column": 2
         }
       }
@@ -4539,22 +4647,22 @@
     ],
     "loc": {
       "start": {
-        "line": 359,
+        "line": 358,
         "column": 0
       },
       "end": {
-        "line": 369,
+        "line": 368,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 370,
+          "line": 369,
           "column": 0
         },
         "end": {
-          "line": 386,
+          "line": 385,
           "column": 2
         }
       }
@@ -4916,22 +5024,22 @@
     ],
     "loc": {
       "start": {
-        "line": 388,
+        "line": 387,
         "column": 0
       },
       "end": {
-        "line": 400,
+        "line": 399,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 401,
+          "line": 400,
           "column": 0
         },
         "end": {
-          "line": 407,
+          "line": 406,
           "column": 2
         }
       }
@@ -5386,22 +5494,22 @@
     ],
     "loc": {
       "start": {
-        "line": 409,
+        "line": 408,
         "column": 0
       },
       "end": {
-        "line": 418,
+        "line": 417,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 419,
+          "line": 418,
           "column": 0
         },
         "end": {
-          "line": 428,
+          "line": 427,
           "column": 2
         }
       }
@@ -5677,22 +5785,22 @@
     ],
     "loc": {
       "start": {
-        "line": 430,
+        "line": 429,
         "column": 0
       },
       "end": {
-        "line": 439,
+        "line": 438,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 440,
+          "line": 439,
           "column": 0
         },
         "end": {
-          "line": 440,
+          "line": 439,
           "column": 35
         }
       }
@@ -5988,22 +6096,22 @@
     ],
     "loc": {
       "start": {
-        "line": 469,
+        "line": 468,
         "column": 0
       },
       "end": {
-        "line": 481,
+        "line": 480,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 482,
+          "line": 481,
           "column": 0
         },
         "end": {
-          "line": 485,
+          "line": 484,
           "column": 2
         }
       }
@@ -6264,22 +6372,22 @@
     ],
     "loc": {
       "start": {
-        "line": 487,
+        "line": 486,
         "column": 0
       },
       "end": {
-        "line": 499,
+        "line": 498,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 500,
+          "line": 499,
           "column": 0
         },
         "end": {
-          "line": 503,
+          "line": 502,
           "column": 2
         }
       }
@@ -6540,22 +6648,22 @@
     ],
     "loc": {
       "start": {
-        "line": 505,
+        "line": 504,
         "column": 0
       },
       "end": {
-        "line": 517,
+        "line": 516,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 518,
+          "line": 517,
           "column": 0
         },
         "end": {
-          "line": 521,
+          "line": 520,
           "column": 2
         }
       }
@@ -6816,22 +6924,22 @@
     ],
     "loc": {
       "start": {
-        "line": 523,
+        "line": 522,
         "column": 0
       },
       "end": {
-        "line": 535,
+        "line": 534,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 536,
+          "line": 535,
           "column": 0
         },
         "end": {
-          "line": 539,
+          "line": 538,
           "column": 2
         }
       }
@@ -7061,22 +7169,22 @@
     ],
     "loc": {
       "start": {
-        "line": 541,
+        "line": 540,
         "column": 0
       },
       "end": {
-        "line": 549,
+        "line": 548,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 550,
+          "line": 549,
           "column": 0
         },
         "end": {
-          "line": 557,
+          "line": 556,
           "column": 2
         }
       }
@@ -7091,7 +7199,7 @@
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 550,
+        "lineNumber": 549,
         "default": "{}"
       },
       {
@@ -7386,22 +7494,22 @@
     ],
     "loc": {
       "start": {
-        "line": 559,
+        "line": 558,
         "column": 0
       },
       "end": {
-        "line": 568,
+        "line": 567,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 569,
+          "line": 568,
           "column": 0
         },
         "end": {
-          "line": 573,
+          "line": 572,
           "column": 2
         }
       }
@@ -7682,22 +7790,22 @@
     ],
     "loc": {
       "start": {
-        "line": 620,
+        "line": 619,
         "column": 0
       },
       "end": {
-        "line": 631,
+        "line": 630,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 632,
+          "line": 631,
           "column": 0
         },
         "end": {
-          "line": 637,
+          "line": 636,
           "column": 2
         }
       }
@@ -8039,22 +8147,22 @@
     ],
     "loc": {
       "start": {
-        "line": 639,
+        "line": 638,
         "column": 0
       },
       "end": {
-        "line": 650,
+        "line": 649,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 651,
+          "line": 650,
           "column": 0
         },
         "end": {
-          "line": 656,
+          "line": 655,
           "column": 2
         }
       }
@@ -8430,22 +8538,22 @@
     ],
     "loc": {
       "start": {
-        "line": 658,
+        "line": 657,
         "column": 0
       },
       "end": {
-        "line": 669,
+        "line": 668,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 670,
+          "line": 669,
           "column": 0
         },
         "end": {
-          "line": 675,
+          "line": 674,
           "column": 2
         }
       }
@@ -8787,22 +8895,22 @@
     ],
     "loc": {
       "start": {
-        "line": 677,
+        "line": 676,
         "column": 0
       },
       "end": {
-        "line": 688,
+        "line": 687,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 689,
+          "line": 688,
           "column": 0
         },
         "end": {
-          "line": 694,
+          "line": 693,
           "column": 2
         }
       }
@@ -9134,22 +9242,22 @@
     ],
     "loc": {
       "start": {
-        "line": 696,
+        "line": 695,
         "column": 0
       },
       "end": {
-        "line": 706,
+        "line": 705,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 707,
+          "line": 706,
           "column": 0
         },
         "end": {
-          "line": 718,
+          "line": 717,
           "column": 2
         }
       }
@@ -9430,22 +9538,22 @@
     ],
     "loc": {
       "start": {
-        "line": 720,
+        "line": 719,
         "column": 0
       },
       "end": {
-        "line": 732,
+        "line": 731,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 733,
+          "line": 732,
           "column": 0
         },
         "end": {
-          "line": 733,
+          "line": 732,
           "column": 37
         }
       }
@@ -9785,22 +9893,22 @@
     ],
     "loc": {
       "start": {
-        "line": 748,
+        "line": 747,
         "column": 0
       },
       "end": {
-        "line": 759,
+        "line": 758,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 760,
+          "line": 759,
           "column": 0
         },
         "end": {
-          "line": 760,
+          "line": 759,
           "column": 37
         }
       }
@@ -10144,22 +10252,22 @@
     ],
     "loc": {
       "start": {
-        "line": 776,
+        "line": 775,
         "column": 0
       },
       "end": {
-        "line": 789,
+        "line": 788,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 790,
+          "line": 789,
           "column": 0
         },
         "end": {
-          "line": 828,
+          "line": 827,
           "column": 2
         }
       }
@@ -10501,22 +10609,22 @@
     ],
     "loc": {
       "start": {
-        "line": 830,
+        "line": 829,
         "column": 0
       },
       "end": {
-        "line": 843,
+        "line": 842,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 844,
+          "line": 843,
           "column": 0
         },
         "end": {
-          "line": 858,
+          "line": 857,
           "column": 2
         }
       }
@@ -10531,7 +10639,7 @@
       {
         "title": "param",
         "name": "attrValuePairs",
-        "lineNumber": 844
+        "lineNumber": 843
       },
       {
         "title": "param",
@@ -10863,22 +10971,22 @@
     ],
     "loc": {
       "start": {
-        "line": 860,
+        "line": 859,
         "column": 0
       },
       "end": {
-        "line": 873,
+        "line": 872,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 874,
+          "line": 873,
           "column": 0
         },
         "end": {
-          "line": 889,
+          "line": 888,
           "column": 2
         }
       }
@@ -10893,7 +11001,7 @@
       {
         "title": "param",
         "name": "attrValuePairs",
-        "lineNumber": 874
+        "lineNumber": 873
       },
       {
         "title": "param",
@@ -11215,22 +11323,22 @@
     ],
     "loc": {
       "start": {
-        "line": 891,
+        "line": 890,
         "column": 0
       },
       "end": {
-        "line": 901,
+        "line": 900,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 902,
+          "line": 901,
           "column": 0
         },
         "end": {
-          "line": 906,
+          "line": 905,
           "column": 2
         }
       }
@@ -11501,22 +11609,22 @@
     ],
     "loc": {
       "start": {
-        "line": 908,
+        "line": 907,
         "column": 0
       },
       "end": {
-        "line": 917,
+        "line": 916,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 918,
+          "line": 917,
           "column": 0
         },
         "end": {
-          "line": 918,
+          "line": 917,
           "column": 35
         }
       }
@@ -11781,22 +11889,22 @@
     ],
     "loc": {
       "start": {
-        "line": 942,
+        "line": 941,
         "column": 0
       },
       "end": {
-        "line": 950,
+        "line": 949,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 951,
+          "line": 950,
           "column": 0
         },
         "end": {
-          "line": 957,
+          "line": 956,
           "column": 2
         }
       }
@@ -12060,22 +12168,22 @@
     ],
     "loc": {
       "start": {
-        "line": 959,
+        "line": 958,
         "column": 0
       },
       "end": {
-        "line": 967,
+        "line": 966,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 968,
+          "line": 967,
           "column": 0
         },
         "end": {
-          "line": 976,
+          "line": 975,
           "column": 2
         }
       }
@@ -12339,22 +12447,22 @@
     ],
     "loc": {
       "start": {
-        "line": 978,
+        "line": 977,
         "column": 0
       },
       "end": {
-        "line": 986,
+        "line": 985,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 987,
+          "line": 986,
           "column": 0
         },
         "end": {
-          "line": 995,
+          "line": 994,
           "column": 2
         }
       }
@@ -12618,22 +12726,22 @@
     ],
     "loc": {
       "start": {
-        "line": 997,
+        "line": 996,
         "column": 0
       },
       "end": {
-        "line": 1005,
+        "line": 1004,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1006,
+          "line": 1005,
           "column": 0
         },
         "end": {
-          "line": 1014,
+          "line": 1013,
           "column": 2
         }
       }
@@ -12897,22 +13005,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1016,
+        "line": 1015,
         "column": 0
       },
       "end": {
-        "line": 1024,
+        "line": 1023,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1025,
+          "line": 1024,
           "column": 0
         },
         "end": {
-          "line": 1035,
+          "line": 1034,
           "column": 2
         }
       }
@@ -13160,22 +13268,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1037,
+        "line": 1036,
         "column": 0
       },
       "end": {
-        "line": 1045,
+        "line": 1044,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1046,
+          "line": 1045,
           "column": 0
         },
         "end": {
-          "line": 1046,
+          "line": 1045,
           "column": 81
         }
       }
@@ -13451,22 +13559,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1048,
+        "line": 1047,
         "column": 0
       },
       "end": {
-        "line": 1056,
+        "line": 1055,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1057,
+          "line": 1056,
           "column": 0
         },
         "end": {
-          "line": 1057,
+          "line": 1056,
           "column": 83
         }
       }
@@ -13742,22 +13850,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1059,
+        "line": 1058,
         "column": 0
       },
       "end": {
-        "line": 1067,
+        "line": 1066,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1068,
+          "line": 1067,
           "column": 0
         },
         "end": {
-          "line": 1068,
+          "line": 1067,
           "column": 85
         }
       }
@@ -14033,22 +14141,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1070,
+        "line": 1069,
         "column": 0
       },
       "end": {
-        "line": 1078,
+        "line": 1077,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1079,
+          "line": 1078,
           "column": 0
         },
         "end": {
-          "line": 1079,
+          "line": 1078,
           "column": 95
         }
       }
@@ -14264,22 +14372,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 1081,
+        "line": 1080,
         "column": 0
       },
       "end": {
-        "line": 1083,
+        "line": 1082,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1084,
+          "line": 1083,
           "column": 0
         },
         "end": {
-          "line": 1088,
+          "line": 1087,
           "column": 2
         }
       }
@@ -14368,22 +14476,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 1090,
+        "line": 1089,
         "column": 0
       },
       "end": {
-        "line": 1092,
+        "line": 1091,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1093,
+          "line": 1092,
           "column": 0
         },
         "end": {
-          "line": 1097,
+          "line": 1096,
           "column": 2
         }
       }
@@ -14497,22 +14605,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1099,
+        "line": 1098,
         "column": 0
       },
       "end": {
-        "line": 1107,
+        "line": 1106,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1108,
+          "line": 1107,
           "column": 0
         },
         "end": {
-          "line": 1108,
+          "line": 1107,
           "column": 50
         }
       }
@@ -14752,22 +14860,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1110,
+        "line": 1109,
         "column": 0
       },
       "end": {
-        "line": 1118,
+        "line": 1117,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1119,
+          "line": 1118,
           "column": 0
         },
         "end": {
-          "line": 1119,
+          "line": 1118,
           "column": 49
         }
       }
@@ -15007,22 +15115,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1121,
+        "line": 1120,
         "column": 0
       },
       "end": {
-        "line": 1129,
+        "line": 1128,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1130,
+          "line": 1129,
           "column": 0
         },
         "end": {
-          "line": 1130,
+          "line": 1129,
           "column": 42
         }
       }
@@ -15195,22 +15303,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1132,
+        "line": 1131,
         "column": 0
       },
       "end": {
-        "line": 1140,
+        "line": 1139,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1141,
+          "line": 1140,
           "column": 0
         },
         "end": {
-          "line": 1141,
+          "line": 1140,
           "column": 27
         }
       }
@@ -15225,7 +15333,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1141
+        "lineNumber": 1140
       }
     ],
     "properties": [],
@@ -15388,22 +15496,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1143,
+        "line": 1142,
         "column": 0
       },
       "end": {
-        "line": 1151,
+        "line": 1150,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1152,
+          "line": 1151,
           "column": 0
         },
         "end": {
-          "line": 1152,
+          "line": 1151,
           "column": 29
         }
       }
@@ -15418,7 +15526,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1152
+        "lineNumber": 1151
       }
     ],
     "properties": [],
@@ -15572,22 +15680,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1154,
+        "line": 1153,
         "column": 0
       },
       "end": {
-        "line": 1162,
+        "line": 1161,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1163,
+          "line": 1162,
           "column": 0
         },
         "end": {
-          "line": 1163,
+          "line": 1162,
           "column": 33
         }
       }
@@ -15742,22 +15850,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1365,
+        "line": 1364,
         "column": 0
       },
       "end": {
-        "line": 1377,
+        "line": 1376,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1403,
+          "line": 1402,
           "column": 0
         },
         "end": {
-          "line": 1432,
+          "line": 1431,
           "column": 1
         }
       }
@@ -15970,22 +16078,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1379,
+        "line": 1378,
         "column": 0
       },
       "end": {
-        "line": 1392,
+        "line": 1391,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1403,
+          "line": 1402,
           "column": 0
         },
         "end": {
-          "line": 1432,
+          "line": 1431,
           "column": 1
         }
       }
@@ -16215,22 +16323,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1394,
+        "line": 1393,
         "column": 0
       },
       "end": {
-        "line": 1402,
+        "line": 1401,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1403,
+          "line": 1402,
           "column": 0
         },
         "end": {
-          "line": 1432,
+          "line": 1431,
           "column": 1
         }
       }
@@ -16271,26 +16379,26 @@
       ],
       "loc": {
         "start": {
-          "line": 1404,
+          "line": 1403,
           "column": 4
         },
         "end": {
-          "line": 1407,
+          "line": 1406,
           "column": 7
         }
       },
       "context": {
         "loc": {
           "start": {
-            "line": 1408,
+            "line": 1407,
             "column": 4
           },
           "end": {
-            "line": 1412,
+            "line": 1411,
             "column": 5
           }
         },
-        "sortKey": "undefined 00001408",
+        "sortKey": "undefined 00001407",
         "code": "{\n    /**\n     * @class\n     * @ignore\n     */\n    constructor(condition, value, desc) {\n        this.condition = condition;\n        this.value = value;\n        this.desc = desc;\n    }\n\n    async validNodes(nodeId) {\n        let matchingNode, minDiff = Infinity;\n        const results = await this.value;\n        for (const result of results) {\n            if(await this.condition(nodeId, result.result)){\n                const diff = await boundingBox.getPositionalDifference(dom,nodeId,result.elem);\n                if(diff < minDiff){\n                    minDiff = diff;\n                    matchingNode = {elem:result.elem, dist:diff};\n                }\n            }    \n        }\n        return matchingNode;\n    }\n\n    toString() {\n        return this.desc;\n    }\n}"
       },
       "augments": [],
@@ -17056,22 +17164,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1434,
+        "line": 1433,
         "column": 0
       },
       "end": {
-        "line": 1453,
+        "line": 1452,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1455,
+          "line": 1454,
           "column": 0
         },
         "end": {
-          "line": 1462,
+          "line": 1461,
           "column": 2
         }
       }

--- a/lib/api.json
+++ b/lib/api.json
@@ -89,22 +89,22 @@
     ],
     "loc": {
       "start": {
-        "line": 42,
+        "line": 44,
         "column": 0
       },
       "end": {
-        "line": 51,
+        "line": 53,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 0
         },
         "end": {
-          "line": 64,
+          "line": 66,
           "column": 2
         }
       }
@@ -348,22 +348,22 @@
     ],
     "loc": {
       "start": {
-        "line": 66,
+        "line": 68,
         "column": 0
       },
       "end": {
-        "line": 70,
+        "line": 72,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 71,
+          "line": 73,
           "column": 0
         },
         "end": {
-          "line": 78,
+          "line": 80,
           "column": 2
         }
       }
@@ -504,22 +504,22 @@
     ],
     "loc": {
       "start": {
-        "line": 80,
+        "line": 82,
         "column": 0
       },
       "end": {
-        "line": 84,
+        "line": 86,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 85,
+          "line": 87,
           "column": 0
         },
         "end": {
-          "line": 85,
+          "line": 87,
           "column": 37
         }
       }
@@ -665,22 +665,22 @@
     ],
     "loc": {
       "start": {
-        "line": 87,
+        "line": 89,
         "column": 0
       },
       "end": {
-        "line": 94,
+        "line": 96,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 95,
+          "line": 97,
           "column": 0
         },
         "end": {
-          "line": 103,
+          "line": 105,
           "column": 2
         }
       }
@@ -920,22 +920,22 @@
     ],
     "loc": {
       "start": {
-        "line": 105,
+        "line": 107,
         "column": 0
       },
       "end": {
-        "line": 115,
+        "line": 117,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 116,
+          "line": 118,
           "column": 0
         },
         "end": {
-          "line": 129,
+          "line": 131,
           "column": 2
         }
       }
@@ -1245,22 +1245,22 @@
     ],
     "loc": {
       "start": {
-        "line": 131,
+        "line": 133,
         "column": 0
       },
       "end": {
-        "line": 139,
+        "line": 141,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 140,
+          "line": 142,
           "column": 0
         },
         "end": {
-          "line": 144,
+          "line": 146,
           "column": 2
         }
       }
@@ -1275,7 +1275,7 @@
       {
         "title": "param",
         "name": "url",
-        "lineNumber": 140
+        "lineNumber": 142
       }
     ],
     "properties": [],
@@ -1447,22 +1447,22 @@
     ],
     "loc": {
       "start": {
-        "line": 146,
+        "line": 148,
         "column": 0
       },
       "end": {
-        "line": 150,
+        "line": 152,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 151,
+          "line": 153,
           "column": 0
         },
         "end": {
-          "line": 158,
+          "line": 160,
           "column": 2
         }
       }
@@ -1693,22 +1693,22 @@
     ],
     "loc": {
       "start": {
-        "line": 171,
+        "line": 173,
         "column": 0
       },
       "end": {
-        "line": 185,
+        "line": 187,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 186,
+          "line": 188,
           "column": 0
         },
         "end": {
-          "line": 186,
+          "line": 188,
           "column": 29
         }
       }
@@ -2470,22 +2470,22 @@
     ],
     "loc": {
       "start": {
-        "line": 221,
+        "line": 223,
         "column": 0
       },
       "end": {
-        "line": 232,
+        "line": 234,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 233,
+          "line": 235,
           "column": 0
         },
         "end": {
-          "line": 244,
+          "line": 246,
           "column": 2
         }
       }
@@ -2764,7 +2764,7 @@
       {
         "title": "param",
         "name": "args",
-        "lineNumber": 233,
+        "lineNumber": 235,
         "type": {
           "type": "RestType"
         }
@@ -2987,22 +2987,22 @@
     ],
     "loc": {
       "start": {
-        "line": 246,
+        "line": 248,
         "column": 0
       },
       "end": {
-        "line": 257,
+        "line": 259,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 258,
+          "line": 260,
           "column": 0
         },
         "end": {
-          "line": 269,
+          "line": 271,
           "column": 2
         }
       }
@@ -3281,7 +3281,7 @@
       {
         "title": "param",
         "name": "args",
-        "lineNumber": 258,
+        "lineNumber": 260,
         "type": {
           "type": "RestType"
         }
@@ -3480,22 +3480,22 @@
     ],
     "loc": {
       "start": {
-        "line": 271,
+        "line": 273,
         "column": 0
       },
       "end": {
-        "line": 280,
+        "line": 282,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 281,
+          "line": 283,
           "column": 0
         },
         "end": {
-          "line": 297,
+          "line": 299,
           "column": 2
         }
       }
@@ -3771,22 +3771,22 @@
     ],
     "loc": {
       "start": {
-        "line": 299,
+        "line": 301,
         "column": 0
       },
       "end": {
-        "line": 307,
+        "line": 309,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 308,
+          "line": 310,
           "column": 0
         },
         "end": {
-          "line": 312,
+          "line": 314,
           "column": 2
         }
       }
@@ -4098,22 +4098,22 @@
     ],
     "loc": {
       "start": {
-        "line": 314,
+        "line": 316,
         "column": 0
       },
       "end": {
-        "line": 327,
+        "line": 329,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 328,
+          "line": 330,
           "column": 0
         },
         "end": {
-          "line": 345,
+          "line": 347,
           "column": 2
         }
       }
@@ -4539,22 +4539,22 @@
     ],
     "loc": {
       "start": {
-        "line": 354,
+        "line": 356,
         "column": 0
       },
       "end": {
-        "line": 364,
+        "line": 366,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 365,
+          "line": 367,
           "column": 0
         },
         "end": {
-          "line": 381,
+          "line": 383,
           "column": 2
         }
       }
@@ -4916,22 +4916,22 @@
     ],
     "loc": {
       "start": {
-        "line": 383,
+        "line": 385,
         "column": 0
       },
       "end": {
-        "line": 395,
+        "line": 397,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 396,
+          "line": 398,
           "column": 0
         },
         "end": {
-          "line": 402,
+          "line": 404,
           "column": 2
         }
       }
@@ -5386,22 +5386,22 @@
     ],
     "loc": {
       "start": {
-        "line": 404,
+        "line": 406,
         "column": 0
       },
       "end": {
-        "line": 413,
+        "line": 415,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 414,
+          "line": 416,
           "column": 0
         },
         "end": {
-          "line": 423,
+          "line": 425,
           "column": 2
         }
       }
@@ -5677,22 +5677,22 @@
     ],
     "loc": {
       "start": {
-        "line": 425,
+        "line": 427,
         "column": 0
       },
       "end": {
-        "line": 434,
+        "line": 436,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 435,
+          "line": 437,
           "column": 0
         },
         "end": {
-          "line": 435,
+          "line": 437,
           "column": 35
         }
       }
@@ -5988,22 +5988,22 @@
     ],
     "loc": {
       "start": {
-        "line": 464,
+        "line": 466,
         "column": 0
       },
       "end": {
-        "line": 476,
+        "line": 478,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 477,
+          "line": 479,
           "column": 0
         },
         "end": {
-          "line": 480,
+          "line": 482,
           "column": 2
         }
       }
@@ -6264,22 +6264,22 @@
     ],
     "loc": {
       "start": {
-        "line": 482,
+        "line": 484,
         "column": 0
       },
       "end": {
-        "line": 494,
+        "line": 496,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 495,
+          "line": 497,
           "column": 0
         },
         "end": {
-          "line": 498,
+          "line": 500,
           "column": 2
         }
       }
@@ -6540,22 +6540,22 @@
     ],
     "loc": {
       "start": {
-        "line": 500,
+        "line": 502,
         "column": 0
       },
       "end": {
-        "line": 512,
+        "line": 514,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 513,
+          "line": 515,
           "column": 0
         },
         "end": {
-          "line": 516,
+          "line": 518,
           "column": 2
         }
       }
@@ -6816,22 +6816,22 @@
     ],
     "loc": {
       "start": {
-        "line": 518,
+        "line": 520,
         "column": 0
       },
       "end": {
-        "line": 530,
+        "line": 532,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 531,
+          "line": 533,
           "column": 0
         },
         "end": {
-          "line": 534,
+          "line": 536,
           "column": 2
         }
       }
@@ -7061,22 +7061,22 @@
     ],
     "loc": {
       "start": {
-        "line": 536,
+        "line": 538,
         "column": 0
       },
       "end": {
-        "line": 544,
+        "line": 546,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 545,
+          "line": 547,
           "column": 0
         },
         "end": {
-          "line": 552,
+          "line": 554,
           "column": 2
         }
       }
@@ -7091,7 +7091,7 @@
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 545,
+        "lineNumber": 547,
         "default": "{}"
       },
       {
@@ -7386,22 +7386,22 @@
     ],
     "loc": {
       "start": {
-        "line": 554,
+        "line": 556,
         "column": 0
       },
       "end": {
-        "line": 563,
+        "line": 565,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 564,
+          "line": 566,
           "column": 0
         },
         "end": {
-          "line": 568,
+          "line": 570,
           "column": 2
         }
       }
@@ -7682,22 +7682,22 @@
     ],
     "loc": {
       "start": {
-        "line": 615,
+        "line": 617,
         "column": 0
       },
       "end": {
-        "line": 626,
+        "line": 628,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 627,
+          "line": 629,
           "column": 0
         },
         "end": {
-          "line": 632,
+          "line": 634,
           "column": 2
         }
       }
@@ -8039,22 +8039,22 @@
     ],
     "loc": {
       "start": {
-        "line": 634,
+        "line": 636,
         "column": 0
       },
       "end": {
-        "line": 645,
+        "line": 647,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 646,
+          "line": 648,
           "column": 0
         },
         "end": {
-          "line": 651,
+          "line": 653,
           "column": 2
         }
       }
@@ -8430,22 +8430,22 @@
     ],
     "loc": {
       "start": {
-        "line": 653,
+        "line": 655,
         "column": 0
       },
       "end": {
-        "line": 664,
+        "line": 666,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 665,
+          "line": 667,
           "column": 0
         },
         "end": {
-          "line": 670,
+          "line": 672,
           "column": 2
         }
       }
@@ -8787,22 +8787,22 @@
     ],
     "loc": {
       "start": {
-        "line": 672,
+        "line": 674,
         "column": 0
       },
       "end": {
-        "line": 683,
+        "line": 685,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 684,
+          "line": 686,
           "column": 0
         },
         "end": {
-          "line": 689,
+          "line": 691,
           "column": 2
         }
       }
@@ -9134,22 +9134,22 @@
     ],
     "loc": {
       "start": {
-        "line": 691,
+        "line": 693,
         "column": 0
       },
       "end": {
-        "line": 701,
+        "line": 703,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 702,
+          "line": 704,
           "column": 0
         },
         "end": {
-          "line": 713,
+          "line": 715,
           "column": 2
         }
       }
@@ -9430,22 +9430,22 @@
     ],
     "loc": {
       "start": {
-        "line": 715,
+        "line": 717,
         "column": 0
       },
       "end": {
-        "line": 727,
+        "line": 729,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 728,
+          "line": 730,
           "column": 0
         },
         "end": {
-          "line": 728,
+          "line": 730,
           "column": 37
         }
       }
@@ -9785,22 +9785,22 @@
     ],
     "loc": {
       "start": {
-        "line": 743,
+        "line": 745,
         "column": 0
       },
       "end": {
-        "line": 754,
+        "line": 756,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 755,
+          "line": 757,
           "column": 0
         },
         "end": {
-          "line": 755,
+          "line": 757,
           "column": 37
         }
       }
@@ -10144,22 +10144,22 @@
     ],
     "loc": {
       "start": {
-        "line": 771,
+        "line": 773,
         "column": 0
       },
       "end": {
-        "line": 784,
+        "line": 786,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 785,
+          "line": 787,
           "column": 0
         },
         "end": {
-          "line": 823,
+          "line": 825,
           "column": 2
         }
       }
@@ -10501,22 +10501,22 @@
     ],
     "loc": {
       "start": {
-        "line": 825,
+        "line": 827,
         "column": 0
       },
       "end": {
-        "line": 838,
+        "line": 840,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 839,
+          "line": 841,
           "column": 0
         },
         "end": {
-          "line": 853,
+          "line": 855,
           "column": 2
         }
       }
@@ -10531,7 +10531,7 @@
       {
         "title": "param",
         "name": "attrValuePairs",
-        "lineNumber": 839
+        "lineNumber": 841
       },
       {
         "title": "param",
@@ -10863,22 +10863,22 @@
     ],
     "loc": {
       "start": {
-        "line": 855,
+        "line": 857,
         "column": 0
       },
       "end": {
-        "line": 868,
+        "line": 870,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 869,
+          "line": 871,
           "column": 0
         },
         "end": {
-          "line": 884,
+          "line": 886,
           "column": 2
         }
       }
@@ -10893,7 +10893,7 @@
       {
         "title": "param",
         "name": "attrValuePairs",
-        "lineNumber": 869
+        "lineNumber": 871
       },
       {
         "title": "param",
@@ -11215,22 +11215,22 @@
     ],
     "loc": {
       "start": {
-        "line": 886,
+        "line": 888,
         "column": 0
       },
       "end": {
-        "line": 896,
+        "line": 898,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 897,
+          "line": 899,
           "column": 0
         },
         "end": {
-          "line": 901,
+          "line": 903,
           "column": 2
         }
       }
@@ -11501,22 +11501,22 @@
     ],
     "loc": {
       "start": {
-        "line": 903,
+        "line": 905,
         "column": 0
       },
       "end": {
-        "line": 912,
+        "line": 914,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 913,
+          "line": 915,
           "column": 0
         },
         "end": {
-          "line": 913,
+          "line": 915,
           "column": 35
         }
       }
@@ -11781,22 +11781,22 @@
     ],
     "loc": {
       "start": {
-        "line": 937,
+        "line": 939,
         "column": 0
       },
       "end": {
-        "line": 945,
+        "line": 947,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 946,
+          "line": 948,
           "column": 0
         },
         "end": {
-          "line": 952,
+          "line": 954,
           "column": 2
         }
       }
@@ -12060,22 +12060,22 @@
     ],
     "loc": {
       "start": {
-        "line": 954,
+        "line": 956,
         "column": 0
       },
       "end": {
-        "line": 962,
+        "line": 964,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 963,
+          "line": 965,
           "column": 0
         },
         "end": {
-          "line": 971,
+          "line": 973,
           "column": 2
         }
       }
@@ -12339,22 +12339,22 @@
     ],
     "loc": {
       "start": {
-        "line": 973,
+        "line": 975,
         "column": 0
       },
       "end": {
-        "line": 981,
+        "line": 983,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 982,
+          "line": 984,
           "column": 0
         },
         "end": {
-          "line": 990,
+          "line": 992,
           "column": 2
         }
       }
@@ -12618,22 +12618,22 @@
     ],
     "loc": {
       "start": {
-        "line": 992,
+        "line": 994,
         "column": 0
       },
       "end": {
-        "line": 1000,
+        "line": 1002,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1001,
+          "line": 1003,
           "column": 0
         },
         "end": {
-          "line": 1009,
+          "line": 1011,
           "column": 2
         }
       }
@@ -12897,22 +12897,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1011,
+        "line": 1013,
         "column": 0
       },
       "end": {
-        "line": 1019,
+        "line": 1021,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1020,
+          "line": 1022,
           "column": 0
         },
         "end": {
-          "line": 1030,
+          "line": 1032,
           "column": 2
         }
       }
@@ -13160,22 +13160,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1032,
+        "line": 1034,
         "column": 0
       },
       "end": {
-        "line": 1040,
+        "line": 1042,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1041,
+          "line": 1043,
           "column": 0
         },
         "end": {
-          "line": 1041,
+          "line": 1043,
           "column": 81
         }
       }
@@ -13451,22 +13451,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1043,
+        "line": 1045,
         "column": 0
       },
       "end": {
-        "line": 1051,
+        "line": 1053,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1052,
+          "line": 1054,
           "column": 0
         },
         "end": {
-          "line": 1052,
+          "line": 1054,
           "column": 83
         }
       }
@@ -13742,22 +13742,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1054,
+        "line": 1056,
         "column": 0
       },
       "end": {
-        "line": 1062,
+        "line": 1064,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1063,
+          "line": 1065,
           "column": 0
         },
         "end": {
-          "line": 1063,
+          "line": 1065,
           "column": 85
         }
       }
@@ -14033,22 +14033,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1065,
+        "line": 1067,
         "column": 0
       },
       "end": {
-        "line": 1073,
+        "line": 1075,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1074,
+          "line": 1076,
           "column": 0
         },
         "end": {
-          "line": 1074,
+          "line": 1076,
           "column": 95
         }
       }
@@ -14264,22 +14264,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 1075,
+        "line": 1078,
         "column": 0
       },
       "end": {
-        "line": 1077,
+        "line": 1080,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1078,
+          "line": 1081,
           "column": 0
         },
         "end": {
-          "line": 1082,
+          "line": 1085,
           "column": 2
         }
       }
@@ -14368,22 +14368,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 1084,
+        "line": 1087,
         "column": 0
       },
       "end": {
-        "line": 1086,
+        "line": 1089,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1087,
+          "line": 1090,
           "column": 0
         },
         "end": {
-          "line": 1091,
+          "line": 1094,
           "column": 2
         }
       }
@@ -14497,23 +14497,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1076,
+        "line": 1096,
         "column": 0
       },
       "end": {
-        "line": 1084,
+        "line": 1104,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1085,
+          "line": 1105,
           "column": 0
         },
         "end": {
-          "line": 1085,
-
+          "line": 1105,
           "column": 50
         }
       }
@@ -14753,22 +14752,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1087,
+        "line": 1107,
         "column": 0
       },
       "end": {
-        "line": 1095,
+        "line": 1115,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1096,
+          "line": 1116,
           "column": 0
         },
         "end": {
-          "line": 1096,
+          "line": 1116,
           "column": 49
         }
       }
@@ -15008,22 +15007,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1098,
+        "line": 1118,
         "column": 0
       },
       "end": {
-        "line": 1106,
+        "line": 1126,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1107,
+          "line": 1127,
           "column": 0
         },
         "end": {
-          "line": 1107,
+          "line": 1127,
           "column": 42
         }
       }
@@ -15196,22 +15195,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1109,
+        "line": 1129,
         "column": 0
       },
       "end": {
-        "line": 1117,
+        "line": 1137,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1118,
+          "line": 1138,
           "column": 0
         },
         "end": {
-          "line": 1118,
+          "line": 1138,
           "column": 27
         }
       }
@@ -15226,7 +15225,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1118
+        "lineNumber": 1138
       }
     ],
     "properties": [],
@@ -15389,22 +15388,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1120,
+        "line": 1140,
         "column": 0
       },
       "end": {
-        "line": 1128,
+        "line": 1148,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1129,
+          "line": 1149,
           "column": 0
         },
         "end": {
-          "line": 1129,
+          "line": 1149,
           "column": 29
         }
       }
@@ -15419,7 +15418,7 @@
       {
         "title": "param",
         "name": "e",
-        "lineNumber": 1129
+        "lineNumber": 1149
       }
     ],
     "properties": [],
@@ -15573,22 +15572,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1131,
+        "line": 1151,
         "column": 0
       },
       "end": {
-        "line": 1139,
+        "line": 1159,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1140,
+          "line": 1160,
           "column": 0
         },
         "end": {
-          "line": 1140,
+          "line": 1160,
           "column": 33
         }
       }
@@ -15743,22 +15742,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1342,
+        "line": 1362,
         "column": 0
       },
       "end": {
-        "line": 1354,
+        "line": 1374,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1380,
+          "line": 1400,
           "column": 0
         },
         "end": {
-          "line": 1409,
+          "line": 1429,
           "column": 1
         }
       }
@@ -15971,22 +15970,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1356,
+        "line": 1376,
         "column": 0
       },
       "end": {
-        "line": 1369,
+        "line": 1389,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1380,
+          "line": 1400,
           "column": 0
         },
         "end": {
-          "line": 1409,
+          "line": 1429,
           "column": 1
         }
       }
@@ -16216,22 +16215,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1371,
+        "line": 1391,
         "column": 0
       },
       "end": {
-        "line": 1379,
+        "line": 1399,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1380,
+          "line": 1400,
           "column": 0
         },
         "end": {
-          "line": 1409,
+          "line": 1429,
           "column": 1
         }
       }
@@ -16272,26 +16271,26 @@
       ],
       "loc": {
         "start": {
-          "line": 1381,
+          "line": 1401,
           "column": 4
         },
         "end": {
-          "line": 1384,
+          "line": 1404,
           "column": 7
         }
       },
       "context": {
         "loc": {
           "start": {
-            "line": 1385,
+            "line": 1405,
             "column": 4
           },
           "end": {
-            "line": 1389,
+            "line": 1409,
             "column": 5
           }
         },
-        "sortKey": "undefined 00001385",
+        "sortKey": "undefined 00001405",
         "code": "{\n    /**\n     * @class\n     * @ignore\n     */\n    constructor(condition, value, desc) {\n        this.condition = condition;\n        this.value = value;\n        this.desc = desc;\n    }\n\n    async validNodes(nodeId) {\n        let matchingNode, minDiff = Infinity;\n        const results = await this.value;\n        for (const result of results) {\n            if(await this.condition(nodeId, result.result)){\n                const diff = await boundingBox.getPositionalDifference(dom,nodeId,result.elem);\n                if(diff < minDiff){\n                    minDiff = diff;\n                    matchingNode = {elem:result.elem, dist:diff};\n                }\n            }    \n        }\n        return matchingNode;\n    }\n\n    toString() {\n        return this.desc;\n    }\n}"
       },
       "augments": [],
@@ -17057,22 +17056,22 @@
     ],
     "loc": {
       "start": {
-        "line": 1411,
+        "line": 1431,
         "column": 0
       },
       "end": {
-        "line": 1430,
+        "line": 1450,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1432,
+          "line": 1452,
           "column": 0
         },
         "end": {
-          "line": 1439,
+          "line": 1459,
           "column": 2
         }
       }

--- a/lib/api.json
+++ b/lib/api.json
@@ -282,7 +282,7 @@
           "children": [
             {
               "type": "text",
-              "value": "Allows to switch between tabs using URL.",
+              "value": "Allows to switch between tabs using URL or page title.",
               "position": {
                 "start": {
                   "line": 1,
@@ -291,8 +291,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 41,
-                  "offset": 40
+                  "column": 55,
+                  "offset": 54
                 },
                 "indent": []
               }
@@ -306,8 +306,8 @@
             },
             "end": {
               "line": 1,
-              "column": 41,
-              "offset": 40
+              "column": 55,
+              "offset": 54
             },
             "indent": []
           }
@@ -321,15 +321,15 @@
         },
         "end": {
           "line": 1,
-          "column": 41,
-          "offset": 40
+          "column": 55,
+          "offset": 54
         }
       }
     },
     "tags": [
       {
         "title": "param",
-        "description": "URL to the target to switch.",
+        "description": "URL/Page title of the tab to switch.",
         "lineNumber": 3,
         "type": {
           "type": "NameExpression",
@@ -393,7 +393,7 @@
               "children": [
                 {
                   "type": "text",
-                  "value": "URL to the target to switch.",
+                  "value": "URL/Page title of the tab to switch.",
                   "position": {
                     "start": {
                       "line": 1,
@@ -402,8 +402,8 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 29,
-                      "offset": 28
+                      "column": 37,
+                      "offset": 36
                     },
                     "indent": []
                   }
@@ -417,8 +417,8 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 29,
-                  "offset": 28
+                  "column": 37,
+                  "offset": 36
                 },
                 "indent": []
               }
@@ -432,8 +432,8 @@
             },
             "end": {
               "line": 1,
-              "column": 29,
-              "offset": 28
+              "column": 37,
+              "offset": 36
             }
           }
         },

--- a/lib/pageHandler.js
+++ b/lib/pageHandler.js
@@ -1,9 +1,10 @@
 let page,xhrEvent;
 let framePromises = {};
 
-const setPage = (p,event,domContentCallback) => {
+const setPage = async (p,event,domContentCallback) => {
     page = p;
     xhrEvent = event;
+    await page.bringToFront();
     page.domContentEventFired(domContentCallback);
     page.addScriptToEvaluateOnNewDocument({source:'localStorage.clear()'});
     page.frameStartedLoading(p => {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -32,7 +32,7 @@ const connect_to_cri = async (target) => {
                 await Promise.all([network.enable(), page.enable(), dom.enable()]);
                 await networkHandler.setNetwork(network,xhrEvent);
                 await targetHandler.setTarget(criTarget,target,connect_to_cri);
-                pageHandler.setPage(page,xhrEvent,async function () {
+                await pageHandler.setPage(page,xhrEvent,async function () {
                     rootId = null;
                     const { root: { nodeId } } = await dom.getDocument();
                     rootId = nodeId;

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -13,7 +13,7 @@ const ChromiumRevision = require(path.join(helper.projectRoot(), 'package.json')
 const EventEmiter = require('events').EventEmitter;
 const xhrEvent = new EventEmiter();
 const default_timeout = 2000;
-let chromeProcess, page, network, runtime, input, client, dom, browser, criTarget;
+let chromeProcess, page, network, runtime, input, client, dom, criTarget;
 let rootId = null;
 
 const connect_to_cri = async (target) => {
@@ -22,7 +22,6 @@ const connect_to_cri = async (target) => {
             if(!target) target = await cri.New();
             await cri({target},async (c) => {
                 client = c;
-                browser = c.Browser;
                 page = c.Page;
                 network = c.Network;
                 runtime = c.Runtime;
@@ -69,17 +68,17 @@ module.exports.openBrowser = async (options = { headless: true }) => {
 };
 
 /**
- * Gives the browser version packaged with Taiko.
- *
- * @returns {Promise<string>}
+ * Allows to switch between targets using URL.
+ * 
+ * @param {string} targetUrl - URL to the target to switch.
+ * @returns {Promise<Object>} - Object with the description of the action performed.
  */
-module.exports.getBrowserVersion = async () => {
-    if (!browser) {
-        await module.exports.openBrowser({ headless: true });
-    }
-    var version = await browser.getVersion();
-    await module.exports.closeBrowser();
-    return version.product;
+module.exports.switchToTarget = async (targetUrl) => {
+    const target = targetHandler.getCriTarget(targetUrl);
+    await connect_to_cri(target);
+    const { root: { nodeId } } = await dom.getDocument();
+    rootId = nodeId;
+    return {description:`Switched to target with url "${targetUrl}"`};
 };
 
 /**
@@ -1453,7 +1452,7 @@ class RelativeSearchElement {
  */
 
 module.exports.metadata = {
-    'Browser actions': ['openBrowser', 'closeBrowser', 'getBrowserVersion', 'client'],
+    'Browser actions': ['openBrowser', 'closeBrowser', 'client','switchToTarget'],
     'Page actions': ['goto', 'reload', 'title', 'click', 'doubleClick', 'rightClick', 'hover', 'focus', 'write', 'attach', 'press', 'highlight', 'scrollTo', 'scrollRight', 'scrollLeft', 'scrollUp', 'scrollDown', 'screenshot'],
     'Selectors': ['$', 'image', 'link', 'listItem', 'button', 'inputField', 'fileField', 'textField', 'comboBox', 'checkBox', 'radioButton', 'text', 'contains'],
     'Proximity selectors': ['toLeftOf', 'toRightOf', 'above', 'below', 'near'],

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -6,13 +6,14 @@ const boundingBox = require('./boundingBox');
 const keyPress = require('./keyPress');
 const networkHandler = require('./networkHandler');
 const pageHandler = require('./pageHandler');
+const targetHandler = require('./targetHandler');
 const fs = require('fs');
 const path = require('path');
 const ChromiumRevision = require(path.join(helper.projectRoot(), 'package.json')).taiko.chromium_revision;
 const EventEmiter = require('events').EventEmitter;
 const xhrEvent = new EventEmiter();
 const default_timeout = 2000;
-let chromeProcess, page, network, runtime, input, client, dom, browser;
+let chromeProcess, page, network, runtime, input, client, dom, browser, criTarget;
 let rootId = null;
 
 const connect_to_cri = async (target) => {
@@ -27,8 +28,10 @@ const connect_to_cri = async (target) => {
                 runtime = c.Runtime;
                 input = c.Input;
                 dom = c.DOM;
+                criTarget = c.Target;
                 await Promise.all([network.enable(), page.enable(), dom.enable()]);
                 await networkHandler.setNetwork(network,xhrEvent);
+                await targetHandler.setTarget(criTarget,target,connect_to_cri);
                 pageHandler.setPage(page,xhrEvent,async function () {
                     rootId = null;
                     const { root: { nodeId } } = await dom.getDocument();

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -30,7 +30,7 @@ const connect_to_cri = async (target) => {
                 criTarget = c.Target;
                 await Promise.all([network.enable(), page.enable(), dom.enable()]);
                 await networkHandler.setNetwork(network,xhrEvent);
-                await targetHandler.setTarget(criTarget,target,connect_to_cri);
+                await targetHandler.setTarget(criTarget,connect_to_cri);
                 await pageHandler.setPage(page,xhrEvent,async function () {
                     rootId = null;
                     const { root: { nodeId } } = await dom.getDocument();
@@ -68,17 +68,17 @@ module.exports.openBrowser = async (options = { headless: true }) => {
 };
 
 /**
- * Allows to switch between tabs using URL.
+ * Allows to switch between tabs using URL or page title.
  * 
- * @param {string} targetUrl - URL to the target to switch.
+ * @param {string} targetUrl - URL/Page title of the tab to switch.
  * @returns {Promise<Object>} - Object with the description of the action performed.
  */
 module.exports.switchTo = async (targetUrl) => {
-    const target = targetHandler.getCriTarget(targetUrl);
+    const target = await targetHandler.getCriTarget(targetUrl);
     await connect_to_cri(target);
     const { root: { nodeId } } = await dom.getDocument();
     rootId = nodeId;
-    return {description:`Switched to target with url "${targetUrl}"`};
+    return {description:`Switched to tab with url "${targetUrl}"`};
 };
 
 /**

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -15,27 +15,29 @@ const default_timeout = 2000;
 let chromeProcess, page, network, runtime, input, client, dom, browser;
 let rootId = null;
 
-const connect_to_cri = async () => {
-    return new Promise(function connect(resolve) {
-        cri(async (c) => {
-            client = c;
-            browser = c.Browser;
-            page = c.Page;
-            network = c.Network;
-            runtime = c.Runtime;
-            input = c.Input;
-            dom = c.DOM;
-            await Promise.all([network.enable(), page.enable(), dom.enable()]);
-            await networkHandler.setNetwork(network,xhrEvent);
-            pageHandler.setPage(page,xhrEvent,async function () {
-                rootId = null;
-                const { root: { nodeId } } = await dom.getDocument();
-                rootId = nodeId;
+const connect_to_cri = async (target) => {
+    return new Promise(async function connect(resolve) {
+        try{
+            if(!target) target = await cri.New();
+            await cri({target},async (c) => {
+                client = c;
+                browser = c.Browser;
+                page = c.Page;
+                network = c.Network;
+                runtime = c.Runtime;
+                input = c.Input;
+                dom = c.DOM;
+                await Promise.all([network.enable(), page.enable(), dom.enable()]);
+                await networkHandler.setNetwork(network,xhrEvent);
+                pageHandler.setPage(page,xhrEvent,async function () {
+                    rootId = null;
+                    const { root: { nodeId } } = await dom.getDocument();
+                    rootId = nodeId;
+                });
+                resolve();
             });
-            resolve();
-        }).on('error', () => {
-            setTimeout(() => { connect(resolve); }, 1000);
-        });
+        }
+        catch(e){setTimeout(() => { connect(resolve); }, 1000);}
     });
 };
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -68,12 +68,12 @@ module.exports.openBrowser = async (options = { headless: true }) => {
 };
 
 /**
- * Allows to switch between targets using URL.
+ * Allows to switch between tabs using URL.
  * 
  * @param {string} targetUrl - URL to the target to switch.
  * @returns {Promise<Object>} - Object with the description of the action performed.
  */
-module.exports.switchToTarget = async (targetUrl) => {
+module.exports.switchTo = async (targetUrl) => {
     const target = targetHandler.getCriTarget(targetUrl);
     await connect_to_cri(target);
     const { root: { nodeId } } = await dom.getDocument();
@@ -1452,7 +1452,7 @@ class RelativeSearchElement {
  */
 
 module.exports.metadata = {
-    'Browser actions': ['openBrowser', 'closeBrowser', 'client','switchToTarget'],
+    'Browser actions': ['openBrowser', 'closeBrowser', 'client','switchTo'],
     'Page actions': ['goto', 'reload', 'title', 'click', 'doubleClick', 'rightClick', 'hover', 'focus', 'write', 'attach', 'press', 'highlight', 'scrollTo', 'scrollRight', 'scrollLeft', 'scrollUp', 'scrollDown', 'screenshot'],
     'Selectors': ['$', 'image', 'link', 'listItem', 'button', 'inputField', 'fileField', 'textField', 'comboBox', 'checkBox', 'radioButton', 'text', 'contains'],
     'Proximity selectors': ['toLeftOf', 'toRightOf', 'above', 'below', 'near'],

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -1,14 +1,21 @@
 const targets = new Map();
 let criTarget;
 
-const setTarget = async (target,connect_to_cri) => {
-    criTarget = target;
+const setTarget = async (ctarget,target,connect_to_cri) => {
+    criTarget = ctarget;
     if(!targets.has(target.id))targets.set(target.id,target);
 
     await criTarget.setDiscoverTargets({discover:true});
 
     criTarget.targetCreated(async (target) => {
-        await connect_to_cri(target);
+        let cri_target = { description: '',
+            devtoolsFrontendUrl: '/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/'+target.targetInfo.targetId,
+            id: '1A4C42AB8E25AC00E985ACE981540306',
+            title: '',
+            type: 'page',
+            url: '',
+            webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/page/'+ target.targetInfo.targetId};
+        await connect_to_cri(cri_target);
     });
 
     criTarget.targetInfoChanged((target)=>{

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -6,7 +6,7 @@ const setTarget = async (ctarget,connect_to_cri) => {
     criTarget = ctarget;
     await criTarget.setDiscoverTargets({discover:true});
     criTarget.targetCreated(async (target) => {
-        await connect_to_cri(constructCriTarget(target.targetInfo));
+        if(target.targetInfo.type === 'page') await connect_to_cri(constructCriTarget(target.targetInfo));
     });
 };
 

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -1,4 +1,6 @@
 const targets = new Map();
+const default_host = '127.0.0.1';
+const default_port = '9222';
 let criTarget;
 
 const setTarget = async (ctarget,target,connect_to_cri) => {
@@ -16,15 +18,15 @@ const setTarget = async (ctarget,target,connect_to_cri) => {
     });
 };
 
-const constructCriTarget = (target) => {
+const constructCriTarget = (target,host=default_host,port=default_port) => {
     return { 
         description: '',
-        devtoolsFrontendUrl: '/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/'+target.targetId,
+        devtoolsFrontendUrl: `/devtools/inspector.html?ws=${host}:${port}/devtools/page/${target.targetId}`,
         id: target.targetId,
         title: '',
         type: 'page',
         url: '',
-        webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/page/'+ target.targetId
+        webSocketDebuggerUrl: `ws://${host}:${port}/devtools/page/${target.targetId}`
     };
 };
 
@@ -33,7 +35,7 @@ const getUrlList = () => {
     let count = 0;
     targets.forEach((value)=>{
         count ++;
-        urlList += `\n${count}: ${value.url}`;
+        urlList += `\n${count}: ${value.title}`;
     });
     return urlList;
 };
@@ -41,7 +43,7 @@ const getUrlList = () => {
 const getCriTarget = (targetURL) => {
     let target;
     targets.forEach((value,key) => {
-        if(value.url === targetURL) target = targets.get(key);
+        if(value.title === targetURL) target = targets.get(key);
     });
     if(!target) throw new Error('No target with given URL found.\nURL list' + getUrlList());
     return constructCriTarget(target);

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -1,20 +1,12 @@
-const targets = new Map();
 const default_host = '127.0.0.1';
 const default_port = '9222';
 let criTarget;
 
-const setTarget = async (ctarget,target,connect_to_cri) => {
+const setTarget = async (ctarget,connect_to_cri) => {
     criTarget = ctarget;
-    if(!targets.has(target.id))targets.set(target.id,target);
-
     await criTarget.setDiscoverTargets({discover:true});
-
     criTarget.targetCreated(async (target) => {
         await connect_to_cri(constructCriTarget(target.targetInfo));
-    });
-
-    criTarget.targetInfoChanged((target)=>{
-        targets.set(target.targetInfo.targetId, target.targetInfo);
     });
 };
 
@@ -30,23 +22,14 @@ const constructCriTarget = (target,host=default_host,port=default_port) => {
     };
 };
 
-const getUrlList = () => {
-    let urlList = '';
-    let count = 0;
-    targets.forEach((value)=>{
-        count ++;
-        urlList += `\n${count}: ${value.title}`;
-    });
-    return urlList;
-};
-
-const getCriTarget = (targetURL) => {
-    let target;
-    targets.forEach((value,key) => {
-        if(value.title === targetURL) target = targets.get(key);
-    });
-    if(!target) throw new Error('No target with given URL found.\nURL list' + getUrlList());
-    return constructCriTarget(target);
+const getCriTarget = async (targetURL) => {
+    let targetToSwitch;
+    const targets = (await criTarget.getTargets()).targetInfos; 
+    for(const target of targets){
+        if(target.title === targetURL || target.url === targetURL) targetToSwitch = target;
+    }
+    if(!targetToSwitch) throw new Error('No target with given URL/Title found.');
+    return constructCriTarget(targetToSwitch);
 };
 
 module.exports = {getCriTarget,setTarget};

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -1,0 +1,8 @@
+const targets = new Map();
+
+
+const getTargets = () => {
+    return targets;
+};
+
+module.exports = {getTargets};

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -1,8 +1,20 @@
 const targets = new Map();
+let criTarget;
+
+const setTarget = (target,connect_to_cri) => {
+    criTarget = target;
+    if(!targets.has(target.id))targets.set(target.id,target);
+    criTarget.targetCreated(async (target) => {
+        await connect_to_cri(target);
+    });
+    criTarget.targetInfoChanged((target)=>{
+        targets[target.targetInfo.targetID] = target.targetInfo;
+    });
+};
 
 
 const getTargets = () => {
     return targets;
 };
 
-module.exports = {getTargets};
+module.exports = {getTargets,setTarget};

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -8,24 +8,43 @@ const setTarget = async (ctarget,target,connect_to_cri) => {
     await criTarget.setDiscoverTargets({discover:true});
 
     criTarget.targetCreated(async (target) => {
-        let cri_target = { description: '',
-            devtoolsFrontendUrl: '/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/'+target.targetInfo.targetId,
-            id: '1A4C42AB8E25AC00E985ACE981540306',
-            title: '',
-            type: 'page',
-            url: '',
-            webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/page/'+ target.targetInfo.targetId};
-        await connect_to_cri(cri_target);
+        await connect_to_cri(constructCriTarget(target.targetInfo));
     });
 
     criTarget.targetInfoChanged((target)=>{
-        targets[target.targetInfo.targetID] = target.targetInfo;
+        targets.set(target.targetInfo.targetId, target.targetInfo);
     });
 };
 
-
-const getTargets = () => {
-    return targets;
+const constructCriTarget = (target) => {
+    return { 
+        description: '',
+        devtoolsFrontendUrl: '/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/'+target.targetId,
+        id: target.targetId,
+        title: '',
+        type: 'page',
+        url: '',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:9222/devtools/page/'+ target.targetId
+    };
 };
 
-module.exports = {getTargets,setTarget};
+const getUrlList = () => {
+    let urlList = '';
+    let count = 0;
+    targets.forEach((value)=>{
+        count ++;
+        urlList += `\n${count}: ${value.url}`;
+    });
+    return urlList;
+};
+
+const getCriTarget = (targetURL) => {
+    let target;
+    targets.forEach((value,key) => {
+        if(value.url === targetURL) target = targets.get(key);
+    });
+    if(!target) throw new Error('No target with given URL found.\nURL list' + getUrlList());
+    return constructCriTarget(target);
+};
+
+module.exports = {getCriTarget,setTarget};

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -1,12 +1,16 @@
 const targets = new Map();
 let criTarget;
 
-const setTarget = (target,connect_to_cri) => {
+const setTarget = async (target,connect_to_cri) => {
     criTarget = target;
     if(!targets.has(target.id))targets.set(target.id,target);
+
+    await criTarget.setDiscoverTargets({discover:true});
+
     criTarget.targetCreated(async (target) => {
         await connect_to_cri(target);
     });
+
     criTarget.targetInfoChanged((target)=>{
         targets[target.targetInfo.targetID] = target.targetInfo;
     });


### PR DESCRIPTION
- Automatically switches control to new target opened
- Allows to switch between tabs using url or page title

Below scripts demos on accessing elements in newly opened page, switching tab and accessing elements there.

```
(async () => {
    try {
        await openBrowser();
        await goto('https://gauge.org');
        await click(link(toLeftOf('Plugins')));
        await highlight(link("Features"));
        await switchTo('Open Source Test Automation Framework | Gauge'); 
        await click("Plugins");
    } catch (e) {
        console.error(e);
    } finally {
        closeBrowser();
    }
})();
```