### PR TITLE
Extending intercept api to accept json as response body

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -76,6 +76,7 @@ const isFunction = (functionToCheck) => {
 };
 
 const isString = obj => typeof obj === 'string' || obj instanceof String;
+const isObject = obj => typeof obj === 'object' || obj instanceof Object;
 
 function waitFor(time) {
     var promise = new Promise(resolve => setTimeout(() => {
@@ -89,5 +90,6 @@ module.exports = {
     assert,
     isFunction,
     isString,
+    isObject,
     waitFor
 };

--- a/lib/networkHandler.js
+++ b/lib/networkHandler.js
@@ -1,4 +1,4 @@
-const { isFunction, isString } = require('./helper');
+const { isFunction, isString, isObject} = require('./helper');
 const requestPromises = {};
 const interceptors = [];
 let network, xhrEvent;
@@ -50,7 +50,8 @@ const handleInterceptor = p => {
 };
 
 const mockResponse = (response, options) => {
-    const responseBody = Buffer.from(response.body);
+    let responseBodyJson = isObject(response.body) ? JSON.stringify(response.body) : response.body;
+    const responseBody = Buffer.from(responseBodyJson);
 
     const responseHeaders = {};
     if (response.headers) {


### PR DESCRIPTION
Now users can use intercept as following.

`intercept( "example.com",  { body: {  cart:['product1 details', 'product2 details' ] } } );`