### PR TITLE
Fix click api to click on the innermost element which matches the selector.

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1332,7 +1332,9 @@ function match(text, ...args) {
     const get = async (e = '*') => {
         let elements = await $$xpath('//' + e + `[@value=${xpath(text)}]`);
         if (!elements || !elements.length) {
-            elements = await $$xpath('//' + e + `[translate(normalize-space(.),'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')=${xpath(text.toLowerCase())}]`);
+            const xpathToText = xpath(text.toLowerCase());
+            const xpathToTranslateInnerText = 'translate(normalize-space(.),"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz")';
+            elements = await $$xpath('//' + e + `[not(descendant::*[contains(${xpathToTranslateInnerText}, ${xpathToText})]) and ${xpathToTranslateInnerText}=${xpathToText}]`);
         }
         return await handleRelativeSearch(elements, args);
     };


### PR DESCRIPTION
Ignore all the elements which are merely a wrapper for the element matching the provided selector or text.