### PR TITLE
Browser local storage and cookies

### DIFF
--- a/lib/networkHandler.js
+++ b/lib/networkHandler.js
@@ -7,8 +7,6 @@ let network, xhrEvent;
 const setNetwork = async (n, event) => {
     network = n;
     xhrEvent = event;
-    await network.clearBrowserCache();
-    await network.clearBrowserCookies();
     network.requestWillBeSent(emitXHREvent);
     network.responseReceived(resolveXHREvent);
     registerInterceptHandler();

--- a/lib/pageHandler.js
+++ b/lib/pageHandler.js
@@ -5,7 +5,6 @@ const setPage = async (pg, event, domContentCallback) => {
     xhrEvent = event;
     await page.bringToFront();
     page.domContentEventFired(domContentCallback);
-    page.addScriptToEvaluateOnNewDocument({ source: 'localStorage.clear()' });
     page.frameStartedLoading(p => {
         xhrEvent.emit('frameStartedLoading', p);
     });

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -97,12 +97,12 @@ module.exports.openBrowser = async (options = { headless: true }) => {
     const chromeExecutable = browserFetcher.getExecutablePath();
     options = setBrowserOptions(options);
     let args = [`--remote-debugging-port=${options.port}`,'--use-mock-keychain'];
+    if (options.args) args = args.concat(options.args);
     if (!args.some(arg => arg.startsWith('--user-data-dir'))) {
         temporaryUserDataDir = await mkdtempAsync(CHROME_PROFILE_PATH);
         args.push(`--user-data-dir=${temporaryUserDataDir}`);
     }
     if (options.headless) args = args.concat(['--headless', '--window-size=1440,900']);
-    if (options.args) args = args.concat(options.args);
     chromeProcess = childProcess.spawn(chromeExecutable, args);
     const endpoint = await browserFetcher.waitForWSEndpoint(chromeProcess, default_timeout);
     currentHost = endpoint.host;


### PR DESCRIPTION
- No need to clear browser local storage as taiko always creates a unique [--user-data-dir](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/user_data_dir.md).
- Persist cookies and cache throughout a single run. It will help the user to share the session across tab.
