### PR TITLE
#277 optimize wait

### DIFF
--- a/lib/domHandler.js
+++ b/lib/domHandler.js
@@ -16,10 +16,21 @@
 /**
  * This module consists of functions imported from Puppeteer(https://github.com/GoogleChrome/puppeteer)
  */
-let dom;
+let dom, eventHandler;
 
-const setDOM = (DOM) => {
+const setDOM = (DOM, event) => {
     dom = DOM;
+    eventHandler = event;
+    dom.childNodeRemoved(p => {
+        eventHandler.emit('childNodeRemoved', p);
+    });
+    dom.childNodeCountUpdated(p => {
+        eventHandler.emit('childNodeCountUpdated', p);
+    });
+    dom.setChildNodes(p => {
+        eventHandler.emit('setChildNodes',p);
+    });
+
 }; 
 
 async function boundingBoxCenter(e) {

--- a/lib/domHandler.js
+++ b/lib/domHandler.js
@@ -16,21 +16,10 @@
 /**
  * This module consists of functions imported from Puppeteer(https://github.com/GoogleChrome/puppeteer)
  */
-let dom, eventHandler;
+let dom;
 
-const setDOM = (DOM, event) => {
+const setDOM = (DOM) => {
     dom = DOM;
-    eventHandler = event;
-    dom.childNodeRemoved(p => {
-        eventHandler.emit('childNodeRemoved', p);
-    });
-    dom.childNodeCountUpdated(p => {
-        eventHandler.emit('childNodeCountUpdated', p);
-    });
-    dom.setChildNodes(p => {
-        eventHandler.emit('setChildNodes',p);
-    });
-
 }; 
 
 async function boundingBoxCenter(e) {

--- a/lib/networkHandler.js
+++ b/lib/networkHandler.js
@@ -23,7 +23,7 @@ const registerInterceptHandler = ( ) => {
 };
 
 const emitXHREvent = p => {
-    if (p.hasUserGesture) {
+    if (p.hasUserGesture && !(requestPromises && requestPromises[p.requestId])) {
         let resolve;
         xhrEvent.emit('xhrEvent', new Promise((r) => { resolve = r; }));
         requestPromises[p.requestId] = resolve;

--- a/lib/networkHandler.js
+++ b/lib/networkHandler.js
@@ -8,7 +8,8 @@ const setNetwork = async (n, event) => {
     network = n;
     xhrEvent = event;
     network.requestWillBeSent(emitXHREvent);
-    network.responseReceived(resolveXHREvent);
+    network.loadingFinished(resolveXHREvent);
+    network.loadingFailed(resolveXHREvent);
     registerInterceptHandler();
 };
 

--- a/lib/networkHandler.js
+++ b/lib/networkHandler.js
@@ -23,7 +23,7 @@ const registerInterceptHandler = ( ) => {
 };
 
 const emitXHREvent = p => {
-    if (p.hasUserGesture && !(requestPromises && requestPromises[p.requestId])) {
+    if (!(requestPromises && requestPromises[p.requestId])) {
         let resolve;
         xhrEvent.emit('xhrEvent', new Promise((r) => { resolve = r; }));
         requestPromises[p.requestId] = resolve;

--- a/lib/pageHandler.js
+++ b/lib/pageHandler.js
@@ -1,10 +1,13 @@
-let page, xhrEvent, framePromises = {};
+let page, xhrEvent, framePromises = {}, frameNavigationPromise = {};
 
 const setPage = async (pg, event, domContentCallback) => {
     page = pg;
     xhrEvent = event;
     await page.bringToFront();
     page.domContentEventFired(domContentCallback);
+    page.frameScheduledNavigation(emitFrameNavigationEvent);
+    page.frameClearedScheduledNavigation(resolveFrameNavigationEvent);
+    page.frameNavigated(resolveFrameNavigationEvent);
     page.frameStartedLoading(emitFrameEvent);
     page.frameStoppedLoading(resolveFrameEvent);
     page.loadEventFired(p => {
@@ -14,6 +17,22 @@ const setPage = async (pg, event, domContentCallback) => {
     page.lifecycleEvent((p)=>{
         xhrEvent.emit(p.name, p);
     });
+};
+
+const emitFrameNavigationEvent = p => {
+    if (!(frameNavigationPromise && frameNavigationPromise[p.frameId])) {
+        let resolve;
+        xhrEvent.emit('frameNavigationEvent', new Promise((r) => { resolve = r; }));
+        frameNavigationPromise[p.frameId] = resolve;
+    }
+};
+
+const resolveFrameNavigationEvent = p => {
+    const frameId = p.frameId ? p.frameId : p.frame.frameId ;
+    if (frameNavigationPromise && frameNavigationPromise[frameId]) {
+        frameNavigationPromise[frameId]();
+        delete frameNavigationPromise[frameId];
+    }
 };
 
 const emitFrameEvent = p => {

--- a/lib/pageHandler.js
+++ b/lib/pageHandler.js
@@ -1,13 +1,10 @@
-let page, xhrEvent, framePromises = {}, frameNavigationPromise = {};
+let page, xhrEvent, framePromises = {};
 
 const setPage = async (pg, event, domContentCallback) => {
     page = pg;
     xhrEvent = event;
     await page.bringToFront();
     page.domContentEventFired(domContentCallback);
-    page.frameScheduledNavigation(emitFrameNavigationEvent);
-    page.frameClearedScheduledNavigation(resolveFrameNavigationEvent);
-    page.frameNavigated(resolveFrameNavigationEvent);
     page.frameStartedLoading(emitFrameEvent);
     page.frameStoppedLoading(resolveFrameEvent);
     page.loadEventFired(p => {
@@ -17,22 +14,6 @@ const setPage = async (pg, event, domContentCallback) => {
     page.lifecycleEvent((p)=>{
         xhrEvent.emit(p.name, p);
     });
-};
-
-const emitFrameNavigationEvent = p => {
-    if (!(frameNavigationPromise && frameNavigationPromise[p.frameId])) {
-        let resolve;
-        xhrEvent.emit('frameNavigationEvent', new Promise((r) => { resolve = r; }));
-        frameNavigationPromise[p.frameId] = resolve;
-    }
-};
-
-const resolveFrameNavigationEvent = p => {
-    const frameId = p.frameId ? p.frameId : p.frame.frameId ;
-    if (frameNavigationPromise && frameNavigationPromise[frameId]) {
-        frameNavigationPromise[frameId]();
-        delete frameNavigationPromise[frameId];
-    }
 };
 
 const emitFrameEvent = p => {

--- a/lib/pageHandler.js
+++ b/lib/pageHandler.js
@@ -8,6 +8,9 @@ const setPage = async (pg, event, domContentCallback) => {
     page.frameStartedLoading(p => {
         xhrEvent.emit('frameStartedLoading', p);
     });
+    page.frameStoppedLoading(p => {
+        xhrEvent.emit('frameStoppedLoading', p);
+    });
     page.loadEventFired(p => {
         xhrEvent.emit('loadEventFired', p);
     });

--- a/lib/pageHandler.js
+++ b/lib/pageHandler.js
@@ -1,16 +1,12 @@
-let page, xhrEvent;
+let page, xhrEvent, framePromises = {};
 
 const setPage = async (pg, event, domContentCallback) => {
     page = pg;
     xhrEvent = event;
     await page.bringToFront();
     page.domContentEventFired(domContentCallback);
-    page.frameStartedLoading(p => {
-        xhrEvent.emit('frameStartedLoading', p);
-    });
-    page.frameStoppedLoading(p => {
-        xhrEvent.emit('frameStoppedLoading', p);
-    });
+    page.frameStartedLoading(emitFrameEvent);
+    page.frameStoppedLoading(resolveFrameEvent);
     page.loadEventFired(p => {
         xhrEvent.emit('loadEventFired', p);
     });
@@ -18,6 +14,21 @@ const setPage = async (pg, event, domContentCallback) => {
     page.lifecycleEvent((p)=>{
         xhrEvent.emit(p.name, p);
     });
+};
+
+const emitFrameEvent = p => {
+    if (!(framePromises && framePromises[p.frameId])) {
+        let resolve;
+        xhrEvent.emit('frameEvent', new Promise((r) => { resolve = r; }));
+        framePromises[p.frameId] = resolve;
+    }
+};
+
+const resolveFrameEvent = p => {
+    if (framePromises && framePromises[p.frameId]) {
+        framePromises[p.frameId]();
+        delete framePromises[p.frameId];
+    }
 };
 
 module.exports = { setPage };

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -17,7 +17,7 @@ const path = require('path');
 const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'taiko_dev_profile-');
 const EventEmiter = require('events').EventEmitter;
 const xhrEvent = new EventEmiter();
-const default_timeout = 15000;
+const default_timeout = 30000;
 let chromeProcess, temporaryUserDataDir, page, network, runtime, input, client, dom, emulation, overlay, criTarget, currentPort, currentHost,
     headful, security, ignoreSSLErrors, observe, observeTime;
 
@@ -195,10 +195,16 @@ module.exports.setViewPort = async (options) => {
  */
 module.exports.openTab = async (targetUrl, options = { timeout: 30000 }) => {
     if (!/^https?:\/\//i.test(targetUrl) && !/^file/i.test(targetUrl)) targetUrl = 'http://' + targetUrl;
-    const targetPromise = new Promise((resolve) => {
-        xhrEvent.addListener('targetNavigated', resolve);
-    });
-    const promises = [targetPromise];
+    const promises = [
+        new Promise((resolve) => {
+            xhrEvent.addListener('targetNavigated', resolve);
+        }),
+        new Promise((resolve) => {	
+            xhrEvent.addListener('networkIdle', resolve);	
+        }),
+        new Promise((resolve) => {	
+            xhrEvent.addListener('loadEventFired', resolve);	
+        })];
     await criTarget.createTarget({ url: targetUrl });
     await waitForNavigation(options.timeout, promises).catch(handleTimeout(options.timeout));
     xhrEvent.removeAllListeners();
@@ -1635,9 +1641,6 @@ module.exports.dismiss = async () => {
 
 const doActionAwaitingNavigation = async (options, action) => {
     let promises = [];
-    const targetPromise = new Promise((resolve) => {
-        xhrEvent.addListener('targetNavigated', resolve);
-    });
     const paintPromise = new Promise((resolve) => {
         xhrEvent.addListener('firstMeaningfulPaint', resolve);
     });
@@ -1648,8 +1651,15 @@ const doActionAwaitingNavigation = async (options, action) => {
     xhrEvent.addListener('frameNavigationEvent', func);
     xhrEvent.addListener('firstPaint', () => promises.push(paintPromise));
     xhrEvent.once('targetCreated', () => { 
-        promises = [];
-        promises.push(targetPromise);
+        promises = [new Promise((resolve) => {
+            xhrEvent.addListener('targetNavigated', resolve);
+        }),
+        new Promise((resolve) => {	
+            xhrEvent.addListener('networkIdle', resolve);	
+        }),
+        new Promise((resolve) => {	
+            xhrEvent.addListener('loadEventFired', resolve);	
+        })];
     });
     
     await action();

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1645,7 +1645,6 @@ const doActionAwaitingNavigation = async (options, action) => {
    
     xhrEvent.addListener('xhrEvent', func);
     xhrEvent.addListener('frameEvent', func);
-    xhrEvent.addListener('frameNavigationEvent', func);
     xhrEvent.addListener('firstPaint', () => promises.push(paintPromise));
     xhrEvent.once('targetCreated', () => { 
         promises = [];

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1704,6 +1704,7 @@ const doActionAwaitingNavigation = async (options, action) => {
    
     xhrEvent.addListener('xhrEvent', func);
     xhrEvent.addListener('frameEvent', func);
+    xhrEvent.addListener('frameNavigationEvent', func);
     xhrEvent.addListener('firstPaint', () => promises.push(paintPromise));
     xhrEvent.once('targetCreated', () => { 
         promises = [];

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -204,7 +204,11 @@ module.exports.openTab = async (targetUrl, options = { timeout: 30000 }) => {
         }),
         new Promise((resolve) => {	
             xhrEvent.addListener('loadEventFired', resolve);	
-        })];
+        }),
+        new Promise((resolve) => {
+            xhrEvent.addListener('firstMeaningfulPaint', resolve);
+        })
+    ];
     await criTarget.createTarget({ url: targetUrl });
     await waitForNavigation(options.timeout, promises).catch(handleTimeout(options.timeout));
     xhrEvent.removeAllListeners();
@@ -252,9 +256,10 @@ module.exports.closeTab = async (targetUrl) => {
 module.exports.goto = async (url, options = { timeout: 30000 }) => {
     validate();
     if (!/^https?:\/\//i.test(url) && !/^file/i.test(url)) url = 'http://' + url;
-    const promises = [page.loadEventFired(), 
-        page.frameStoppedLoading(), 
-        page.domContentEventFired(),
+    const promises = [
+        new Promise((resolve) => {
+            xhrEvent.addListener('loadEventFired', resolve);
+        }),
         new Promise((resolve) => {
             xhrEvent.addListener('networkIdle', resolve);
         }),
@@ -264,6 +269,8 @@ module.exports.goto = async (url, options = { timeout: 30000 }) => {
     ];
     let func = addPromiseToWait(promises);
     xhrEvent.addListener('xhrEvent', func);
+    xhrEvent.addListener('frameEvent', func);
+    xhrEvent.addListener('frameNavigationEvent', func);
     if (options.headers) await network.setExtraHTTPHeaders({ headers: options.headers });
     const res = await page.navigate({ url: url });
     if (res.errorText) throw new Error(`Navigation to url ${url} failed.\n REASON: ${res.errorText}`);
@@ -1651,15 +1658,20 @@ const doActionAwaitingNavigation = async (options, action) => {
     xhrEvent.addListener('frameNavigationEvent', func);
     xhrEvent.addListener('firstPaint', () => promises.push(paintPromise));
     xhrEvent.once('targetCreated', () => { 
-        promises = [new Promise((resolve) => {
-            xhrEvent.addListener('targetNavigated', resolve);
-        }),
-        new Promise((resolve) => {	
-            xhrEvent.addListener('networkIdle', resolve);	
-        }),
-        new Promise((resolve) => {	
-            xhrEvent.addListener('loadEventFired', resolve);	
-        })];
+        promises = [
+            new Promise((resolve) => {
+                xhrEvent.addListener('targetNavigated', resolve);
+            }),
+            new Promise((resolve) => {	
+                xhrEvent.addListener('networkIdle', resolve);	
+            }),
+            new Promise((resolve) => {	
+                xhrEvent.addListener('loadEventFired', resolve);	
+            }),
+            new Promise((resolve) => {
+                xhrEvent.addListener('firstMeaningfulPaint', resolve);
+            })
+        ];
     });
     
     await action();

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1700,13 +1700,10 @@ const doActionAwaitingNavigation = async (options, action) => {
     const paintPromise = new Promise((resolve) => {
         xhrEvent.addListener('firstMeaningfulPaint', resolve);
     });
-    const framePromise = new Promise((resolve) => {
-        xhrEvent.addListener('frameStoppedLoading', resolve);
-    });
     let func = addPromiseToWait(promises);
    
     xhrEvent.addListener('xhrEvent', func);
-    xhrEvent.addListener('frameStartedLoading', () => promises.push(framePromise));
+    xhrEvent.addListener('frameEvent', func);
     xhrEvent.addListener('firstPaint', () => promises.push(paintPromise));
     xhrEvent.once('targetCreated', () => { 
         promises = [];

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1645,6 +1645,7 @@ const doActionAwaitingNavigation = async (options, action) => {
    
     xhrEvent.addListener('xhrEvent', func);
     xhrEvent.addListener('frameEvent', func);
+    xhrEvent.addListener('frameNavigationEvent', func);
     xhrEvent.addListener('firstPaint', () => promises.push(paintPromise));
     xhrEvent.once('targetCreated', () => { 
         promises = [];

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1693,7 +1693,7 @@ const setRootId = () => {
 };
 
 const doActionAwaitingNavigation = async (options, action) => {
-    const promises = [];
+    let promises = [];
     const targetPromise = new Promise((resolve) => {
         xhrEvent.addListener('targetNavigated', resolve);
     });
@@ -1706,10 +1706,13 @@ const doActionAwaitingNavigation = async (options, action) => {
     let func = addPromiseToWait(promises);
    
     xhrEvent.addListener('xhrEvent', func);
-    xhrEvent.once('frameStartedLoading', () => promises.push(framePromise));
-    xhrEvent.once('targetCreated', () => promises.push(targetPromise));
-    xhrEvent.once('firstPaint', () => promises.push(paintPromise));
-   
+    xhrEvent.addListener('frameStartedLoading', () => promises.push(framePromise));
+    xhrEvent.addListener('firstPaint', () => promises.push(paintPromise));
+    xhrEvent.once('targetCreated', () => { 
+        promises = [];
+        promises.push(targetPromise);
+    });
+    
     await action();
     await waitForPromises(promises, options.waitForStart);
     if (options.awaitNavigation) {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -16,7 +16,7 @@ const path = require('path');
 const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'taiko_dev_profile-');
 const EventEmiter = require('events').EventEmitter;
 const xhrEvent = new EventEmiter();
-const default_timeout = 15000;
+const default_timeout = 30000;
 let chromeProcess, temporaryUserDataDir, page, network, runtime, input, client, dom, emulation, overlay, criTarget, currentPort, currentHost, rootId = null,
     headful, security, ignoreSSLErrors, observe, observeTime;
 
@@ -121,6 +121,7 @@ module.exports.openBrowser = async (options = { headless: true }) => {
  */
 module.exports.closeBrowser = async () => {
     validate();
+    xhrEvent.removeAllListeners();
     await _closeBrowser();
     networkHandler.resetInterceptors();
     return { description: 'Browser closed' };
@@ -128,6 +129,7 @@ module.exports.closeBrowser = async () => {
 
 const _closeBrowser = async () => {
     if (client) {
+        await client.removeAllListeners();
         await page.close();
         await client.close();
         client = null;
@@ -1698,18 +1700,20 @@ const doActionAwaitingNavigation = async (options, action) => {
     const paintPromise = new Promise((resolve) => {
         xhrEvent.addListener('firstMeaningfulPaint', resolve);
     });
+    const framePromise = new Promise((resolve) => {
+        xhrEvent.addListener('frameStoppedLoading', resolve);
+    });
     let func = addPromiseToWait(promises);
    
     xhrEvent.addListener('xhrEvent', func);
-    xhrEvent.once('frameStartedLoading', () => promises.push(page.frameStoppedLoading()));
+    xhrEvent.once('frameStartedLoading', () => promises.push(framePromise));
     xhrEvent.once('targetCreated', () => promises.push(targetPromise));
     xhrEvent.once('firstPaint', () => promises.push(paintPromise));
    
     await action();
     await waitForPromises(promises, options.waitForStart);
     if (options.awaitNavigation) {
-        //TODO:Handle frame load without loadEventFired
-        await waitForNavigation(options.timeout, promises).catch(() => { });
+        await waitForNavigation(options.timeout, promises).catch(handleTimeout(options.timeout));
     }
     xhrEvent.removeAllListeners();
 };

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -42,7 +42,7 @@ const connect_to_cri = async (target) => {
                 await Promise.all([network.enable(), page.enable(), dom.enable(), overlay.enable(), security.enable()]);
                 await networkHandler.setNetwork(network, xhrEvent);
                 await inputHandler.setInput(input);
-                await domHandler.setDOM(dom);
+                await domHandler.setDOM(dom, xhrEvent);
                 await targetHandler.setTarget(criTarget, xhrEvent, connect_to_cri, currentHost, currentPort);
                 await pageHandler.setPage(page, xhrEvent, async function () {
                     if (!client) return;
@@ -256,6 +256,8 @@ module.exports.goto = async (url, options = { timeout: 30000 }) => {
             xhrEvent.addListener('firstMeaningfulPaint', resolve);
         })
     ];
+    let func = addPromiseToWait(promises);
+    xhrEvent.addListener('xhrEvent', func);
     if (options.headers) await network.setExtraHTTPHeaders({ headers: options.headers });
     const res = await page.navigate({ url: url });
     if (res.errorText) throw new Error(`Navigation to url ${url} failed.\n REASON: ${res.errorText}`);
@@ -1690,29 +1692,23 @@ const setRootId = () => {
 
 const doActionAwaitingNavigation = async (options, action) => {
     const promises = [];
-    const loadEventPromise = new Promise((resolve) => {
-        xhrEvent.addListener('loadEventFired', resolve);
-    });
     const targetPromise = new Promise((resolve) => {
         xhrEvent.addListener('targetNavigated', resolve);
     });
     const paintPromise = new Promise((resolve) => {
         xhrEvent.addListener('firstMeaningfulPaint', resolve);
     });
-    const networkIdlePromise = new Promise((resolve) => {
-        xhrEvent.addListener('networkIdle', resolve);
+    const domNodeChangePromise = new Promise((resolve) => {
+        xhrEvent.addListener('childNodeCountUpdated', resolve);
     });
-
     let func = addPromiseToWait(promises);
-    const loadListener = () => {
-        promises.push(loadEventPromise);
-        promises.push(page.frameStoppedLoading());
-    };
+   
     xhrEvent.addListener('xhrEvent', func);
-    xhrEvent.once('xhrEvent',()=>promises.push(networkIdlePromise));
-    xhrEvent.once('frameStartedLoading', loadListener);
+    xhrEvent.once('frameStartedLoading', () => promises.push(page.frameStoppedLoading()));
     xhrEvent.once('targetCreated', () => promises.push(targetPromise));
     xhrEvent.once('firstPaint', () => promises.push(paintPromise));
+    xhrEvent.once('childNodeRemoved', () => promises.push(domNodeChangePromise));
+    xhrEvent.once('setChildNodes', () => promises.push(domNodeChangePromise));
     await action();
     await waitForPromises(promises, options.waitForStart);
     if (options.awaitNavigation) {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -42,7 +42,7 @@ const connect_to_cri = async (target) => {
                 await Promise.all([network.enable(), page.enable(), dom.enable(), overlay.enable(), security.enable()]);
                 await networkHandler.setNetwork(network, xhrEvent);
                 await inputHandler.setInput(input);
-                await domHandler.setDOM(dom, xhrEvent);
+                await domHandler.setDOM(dom);
                 await targetHandler.setTarget(criTarget, xhrEvent, connect_to_cri, currentHost, currentPort);
                 await pageHandler.setPage(page, xhrEvent, async function () {
                     if (!client) return;
@@ -1698,17 +1698,13 @@ const doActionAwaitingNavigation = async (options, action) => {
     const paintPromise = new Promise((resolve) => {
         xhrEvent.addListener('firstMeaningfulPaint', resolve);
     });
-    const domNodeChangePromise = new Promise((resolve) => {
-        xhrEvent.addListener('childNodeCountUpdated', resolve);
-    });
     let func = addPromiseToWait(promises);
    
     xhrEvent.addListener('xhrEvent', func);
     xhrEvent.once('frameStartedLoading', () => promises.push(page.frameStoppedLoading()));
     xhrEvent.once('targetCreated', () => promises.push(targetPromise));
     xhrEvent.once('firstPaint', () => promises.push(paintPromise));
-    xhrEvent.once('childNodeRemoved', () => promises.push(domNodeChangePromise));
-    xhrEvent.once('setChildNodes', () => promises.push(domNodeChangePromise));
+   
     await action();
     await waitForPromises(promises, options.waitForStart);
     if (options.awaitNavigation) {

--- a/lib/targetHandler.js
+++ b/lib/targetHandler.js
@@ -9,18 +9,7 @@ const setTarget = async (ctarget, handler, connect_to_cri, currentHost, currentP
     criTarget.targetCreated(async (target) => {
         if (target.targetInfo.type === 'page') {
             eventHandler.emit('targetCreated');
-            await connect_to_cri(constructCriTarget(target.targetInfo));
-            const loadEventPromise = new Promise((resolve) => {
-                eventHandler.addListener('loadEventFired', resolve);
-            });
-            const networkIdlePromise = new Promise((resolve) => {
-                eventHandler.addListener('networkIdle', resolve);
-            });
-            const paintPromise = new Promise((resolve) => {
-                eventHandler.addListener('firstMeaningfulPaint', resolve);
-            });
-            await Promise.all([loadEventPromise,networkIdlePromise,paintPromise])
-                .then(()=>{eventHandler.emit('targetNavigated');});
+            await connect_to_cri(constructCriTarget(target.targetInfo)).then(()=>eventHandler.emit('targetNavigated'));
         }
     });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "taiko",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	],
 	"taiko": {
 		"chromium_revision": "615489",
-		"chromium_version": "72.0.3606.0"
+		"chromium_version": "73.0.3638.0"
 	},
 	"author": "getgauge",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"headless-browser"
 	],
 	"taiko": {
-		"chromium_revision": "606647",
+		"chromium_revision": "615489",
 		"chromium_version": "72.0.3606.0"
 	},
 	"author": "getgauge",


### PR DESCRIPTION
- fix network calls wait, resolve on loading finished or load failed and add promise only once for a request
- fix new target wait by clearing old promises and add wait for firstMeaningfulPaint and load events
- wait for all frame loads and frame navigation
- handle navigation timeout on any action
- update default timeout for any action navigation to 30sec as same as goto
- update chromium
- clean up listeners on closeBrowser  