### PR TITLE
Incorporate commander.js to handle taiko command line args and flags.

### DIFF
--- a/bin/runFile.js
+++ b/bin/runFile.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const util = require('util');
+const taiko = require('../lib/taiko');
+const { removeQuotes, symbols } = require('../lib/util');
+module.exports = (file, observe, observeTime) => {
+    const realFuncs = {};
+    for (let func in taiko) {
+        realFuncs[func] = taiko[func];
+        if (realFuncs[func].constructor.name === 'AsyncFunction')
+            global[func] = async function () {
+                let res, args = arguments;
+                if (func === 'openBrowser') {
+                    if (args['0']) {
+                        args['0'].headless = !observe;
+                        args[0].observe = observe;
+                        args['0'].observeTime = observeTime;
+                    }
+                    else
+                        args = [{ headless: !observe, observe: observe, observeTime: observeTime }];
+                }
+                res = await realFuncs[func].apply(this, args);
+                if (res.description) {
+                    res.description = symbols.pass + res.description;
+                    console.log(removeQuotes(util.inspect(res.description, { colors: true }), res.description));
+                }
+                return res;
+            };
+        else
+            global[func] = function () {
+                return realFuncs[func].apply(this, arguments);
+            };
+        require.cache[path.join(__dirname, 'taiko.js')].exports[func] = global[func];
+    }
+    const oldNodeModulesPaths = module.constructor._nodeModulePaths;
+    module.constructor._nodeModulePaths = function () {
+        const ret = oldNodeModulesPaths.apply(this, arguments);
+        ret.push(__dirname);
+        return ret;
+    };
+    require(path.resolve(file).slice(0, -3));
+};

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -104,5 +104,10 @@ program
             repl_mode = true;
             repl.initiaize();
         }
-    })
-    .parse(process.argv);
+    });
+program.unknownOption = (option) => {
+    console.error('error: unknown option `%s', option);
+    program.outputHelp();
+    process.exit(1);
+};
+program.parse(process.argv);

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -73,14 +73,14 @@ function setupEmulateDevice(device) {
         process.env['TAIKO_EMULATE_DEVICE'] = device;
     else {
         console.log(`Invalid value ${device} for --emulate-device`);
-        console.log(`Available devices ${Object.keys(devices).join(', ')}`);
+        console.log(`Available devices: ${Object.keys(devices).join(', ')}`);
         process.exit(1);
     }
 }
 program
     .version(printVersion(), '-v, --version')
-    .usage(`<file> [options]
-       taiko [options]`)
+    .usage(`[options]
+       taiko <file> [options]`)
     .option(
         '-o, --observe [observeTime]',
         'enables headful mode and runs script with 3000ms delay by default\n\t\t\t\toptionally takes observeTime in millisecond eg: --observe 5000',
@@ -90,7 +90,7 @@ program
         '--slow-mod [observeTime]',
         'similar to --observe option'
     )
-    .option('--emulate-device <device>', 'Allows to simulate device viewport. Visit https://github.com/getgauge/taiko/blob/master/lib/device.js for all the available options', setupEmulateDevice)
+    .option('--emulate-device <device>', 'Allows to simulate device viewport. Visit https://github.com/getgauge/taiko/blob/master/lib/device.js for all the available devices', setupEmulateDevice)
     .action(function () {
         if (!isTaikoRunner(program.rawArgs[1])) {
             module.exports = taiko;

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-const { runFile } = require('./runFile');
+const runFile = require('./runFile');
 const fs = require('fs');
 const program = require('commander');
 const taiko = require('../lib/taiko');

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -78,14 +78,6 @@ function setupEmulateDevice(device) {
     }
 }
 
-function calcObserveDelay(shouldObserve, observeTime) {
-    if( shouldObserve ) {
-        return observeTime || 3000;
-    }else {
-        return observeTime || 0;
-    }
-}
-
 program
     .version(printVersion(), '-v, --version')
     .usage(`[options]
@@ -111,8 +103,7 @@ program
             const fileName = program.args[0];
             validate(fileName);
             const observe = Boolean(program.observe || program.slowMod );
-            let observeTime = calcObserveDelay(observe, program.waitTime);
-            runFile(fileName, observe, observeTime);
+            runFile(fileName, observe, program.waitTime);
         } else {
             repl_mode = true;
             repl.initiaize();

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -55,9 +55,6 @@ program
         `enables headful mode and runs script with 3000ms delay by default.
         \t\t\tpass --wait-time option to override the default 3000ms\n`
     )
-    .option(
-        '--slow-mod', 'similar to --observe option\n'
-    )
     .option('-w, --wait-time <time in ms>', 'runs script with provided delay\n', parseInt)
     .option(
         '--emulate-device <device>',

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -5,6 +5,7 @@ const childProcess = require('child_process');
 const BrowserFetcher = require('./browserFetcher');
 const removeFolder = require('rimraf');
 const { helper, waitFor, isString, isFunction } = require('./helper');
+const { calcObserveDelay } = require('./util');
 const removeFolderAsync = helper.promisify(removeFolder);
 const inputHandler = require('./inputHandler');
 const domHandler = require('./domHandler');
@@ -78,7 +79,7 @@ const setBrowserOptions = (options) => {
     headful = !options.headless;
     ignoreSSLErrors = options.ignoreCertificateErrors;
     observe = options.observe || false;
-    observeTime = options.observeTime || 3000;
+    observeTime = calcObserveDelay(observe, options.observeTime);
     return options;
 };
 
@@ -2367,7 +2368,7 @@ for(const func in module.exports){
     realFuncs[func] = module.exports[func];
     if (realFuncs[func].constructor.name === 'AsyncFunction')
         module.exports[func] = async function(){
-            if(observe){await waitFor(observeTime);}
+            if(observeTime){await waitFor(observeTime);}
             return await realFuncs[func].apply(this, arguments);
         };
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,3 +25,11 @@ module.exports.isTaikoRunner = (path) => {
             return true;
     }
 };
+
+module.exports.calcObserveDelay = (shouldObserve, observeTime) => {
+    if( shouldObserve ) {
+        return observeTime || 3000;
+    }else {
+        return observeTime || 0;
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1913,8 +1913,7 @@
 		"commander": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-			"dev": true
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
 		},
 		"component-emitter": {
 			"version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
 		"proxy-from-env": "^1.0.0",
 		"recast": "^0.17.2",
 		"repl.history": "^0.1.4",
-		"rimraf": "^2.6.1"
+		"rimraf": "^2.6.1",
+		"commander": "^2.19.0"
 	},
 	"devDependencies": {
 		"documentation": "^9.1.1",


### PR DESCRIPTION
```
Usage: taiko [options]
       taiko <file> [options]

Options:
  -v, --version                 output the version number
  -o, --observe                 enables headful mode and runs script with 3000ms delay by default.
          			pass --wait-time option to override the default 3000ms

  --slow-mod                    similar to --observe option

  -w, --wait-time <time in ms>  runs script with provided delay

  --emulate-device <device>     Allows to simulate device viewport. Visit https://github.com/getgauge/taiko/blob/master/lib/device.js for all the available devices

  -h, --help                    output usage information

```