### PR TITLE
Fix the quotation mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ This launches the Taiko prompt. You can now use Taiko’s API as commands in thi
 
 You can now automate this Chrome browser instance with commands, for example, make the browser search google for something.
 
-    > goto(“google.com”)
-    > write(“taiko test automation”)
-    > click(“Google Search”)
+    > goto("google.com")
+    > write("taiko test automation")
+    > click("Google Search")
 
-These commands make the browser go to google’s home page, type the text “taiko test automation” and click on the “Google Search” button. You can see the browser performing these actions as you type and press enter for each command.
+These commands make the browser go to google’s home page, type the text "taiko test automation" and click on the "Google Search" button. You can see the browser performing these actions as you type and press enter for each command.
 
 Taiko’s REPL keeps a history of all successful commands. Once you finish a flow of execution, you can generate a test script using the special command .code 
 
@@ -124,28 +124,28 @@ To see more details of an API along with examples use
 
 Taiko’s API treats the browser as a black box. With Taiko we can write scripts by looking at a web page and without inspecting it’s source code For example on `google.com` the command
 
-    > click(“Google Search”)
+    > click("Google Search")
 
 clicks on any element with the text `Google Search` (a button on the page at https://google.com). Taiko’s API mimics user interactions with the browser. For example if you want to write into an element that’s currently in focus use 
 
-    > write(“something”)
+    > write("something")
 
 Or if you want to write into a specific text field 
 
-    > write(“something”, into(textField({placeholder: “Username”})))
+    > write("something", into(textField({placeholder: "Username"})))
 
 With Taiko’s API we can avoid using ids/css/xpath selectors to create reliable tests that don’t break with changes in the web page’s structure.
 
 You can also use Taiko’s proximity selectors to visually locate elements. For example
 
-    > click(checkbox(near(“Username”)))
+    > click(checkbox(near("Username")))
 
 Will click the checkbox that is nearest to any element with the text `Username`. 
 
 Taiko’s also supports XPath and CSS selectors
 
-    > click($(“#button_id”)) // Using CSS selectors
-    > click($(“//input[name=`button_name`]”)) // Xpath selectors
+    > click($("#button_id")) // Using CSS selectors
+    > click($("//input[name=`button_name`]")) // Xpath selectors
 
 ## Handle XHR and dynamic content
 
@@ -159,15 +159,15 @@ Setting up test infrastructure and test data is hard. Taiko makes this easy with
 
 Or redirect an XHR request on the page to a test instance
 
-    > intercept(“https://fetchdata.com”, “http://fetchtestdata.com”)
+    > intercept("https://fetchdata.com", "http://fetchtestdata.com")
 
 Or stub an XHR request to return custom data
 
-    > intercept(“https://fetchdata.com”, {“test”: data})
+    > intercept("https://fetchdata.com", {"test": data})
  
 Or even modify data sent by XHR requests
 
-    > intercept(“https://fetchdata.com”, (request) => {request.continue({“custom”: “data”})})
+    > intercept("https://fetchdata.com", (request) => {request.continue({"custom": "data"})})
 
 This simplifies our test setups as we don’t have to set up mock servers, or replace url’s in tests to point to test instances.
 

--- a/docs/layout/partials/header.html
+++ b/docs/layout/partials/header.html
@@ -68,15 +68,15 @@ Type .api for help and .exit to quit
       To automate this Chrome browser instance, you can use other commands from the Taiko API. Here's another example to get the browser to search google for something. 
     </p>
     <div class="code-section">
-      <pre class="hljs"><code>goto(<span class="hljs-string">“google.com”</span>)
-write(<span class="hljs-string">“taiko test automation”</span>)
-click(<span class="hljs-string">“Google Search”</span>)</code></pre>
+      <pre class="hljs"><code>goto(<span class="hljs-string">"google.com"</span>)
+write(<span class="hljs-string">"taiko test automation"</span>)
+click(<span class="hljs-string">"Google Search"</span>)</code></pre>
     </div>
     <p>These commands get the browser to 
       <ul class="desc-list">
         <li>go to Google’s home page, </li>
-        <li>type the text “taiko test automation” and then </li>
-        <li>click on the “Google Search” button.</li>
+        <li>type the text "taiko test automation" and then </li>
+        <li>click on the "Google Search" button.</li>
       </ul>
     </p>
     <p>You can see the browser performing these actions as you type and press enter for each command.
@@ -162,35 +162,35 @@ openBrowser({args:<span class="hljs-string">['--window-size=1440,900']</span>}) 
         <p>For example on google.com, this command will click on any element with the text 'Google Search' (a button on the page).
     </p>
     <div class="code-section">
-      <pre class="hljs"><code>click(<span class="hljs-string">“Google Search”</span>)</code></pre>
+      <pre class="hljs"><code>click(<span class="hljs-string">"Google Search"</span>)</code></pre>
   </div>
     <p>
       Taiko’s API mimics user interactions with the browser. For example if you want to write into an element that’s currently in focus, use 
     </p>
     <div class="code-section">
-      <pre class="hljs"><code>write(<span class="hljs-string">“something”</span>)</code></pre>
+      <pre class="hljs"><code>write(<span class="hljs-string">"something"</span>)</code></pre>
     </div>
     <p>
       Or if you want to write into a specific text field 
     </p>
     <div class="code-section">
-      <pre class="hljs"><code>write(<span class="hljs-string">“something”</span>, into(textField({placeholder: <span class="hljs-string">“Username”</span>})))</code></pre>
+      <pre class="hljs"><code>write(<span class="hljs-string">"something"</span>, into(textField({placeholder: <span class="hljs-string">"Username"</span>})))</code></pre>
   </div>
     <p>
         With Taiko’s API you can avoid using ids/css/xpath selectors to create reliable tests that don’t break with changes in the web page’s structure.
     </p>
     <p>You can also use Taiko’s proximity selectors to visually locate elements. For example, this command will click the checkbox that is nearest to any element with the text 'Username'.</p>
     <div class="code-section">
-      <pre class="hljs"><code>click(checkbox(near(<span class="hljs-string">“Username”</span>)))</code></pre>
+      <pre class="hljs"><code>click(checkbox(near(<span class="hljs-string">"Username"</span>)))</code></pre>
   </div>
     <p>
       Taiko’s also supports XPath and CSS selectors.
     </p>
     <div class="code-section">
-      <pre class="hljs"><code>click($(“#button_id”)) // Using CSS selectors</code></pre>
+      <pre class="hljs"><code>click($("#button_id")) // Using CSS selectors</code></pre>
     </div>
     <div class="code-section">
-      <pre class="hljs"><code>click($(<span class="hljs-string">“//input[name=`button_name`]”</span>)) <span class="comment-code">// Xpath selectors</span></code></pre>
+      <pre class="hljs"><code>click($(<span class="hljs-string">"//input[name=`button_name`]"</span>)) <span class="comment-code">// Xpath selectors</span></code></pre>
     </div>
   </div>
   <div class="sub-section">
@@ -215,20 +215,20 @@ openBrowser({args:<span class="hljs-string">['--window-size=1440,900']</span>}) 
     <p>or redirecting an XHR request on the page to a test instance
     </p>
     <div class="code-section">
-      <pre class="hljs"><code>intercept(<span class="hljs-string">“https://fetchdata.com”</span>, <span class="hljs-string">“http://fetchtestdata.com”</span>)</code></pre>
+      <pre class="hljs"><code>intercept(<span class="hljs-string">"https://fetchdata.com"</span>, <span class="hljs-string">"http://fetchtestdata.com"</span>)</code></pre>
     </div>
     <p>
     stubbing an XHR request to return custom data
     </p>
     <div class="code-section">
-      <pre class="hljs"><code>intercept(<span class="hljs-string">“https://fetchdata.com”</span>, {<span class="hljs-string">“test”: data </span>})</code></pre>
+      <pre class="hljs"><code>intercept(<span class="hljs-string">"https://fetchdata.com"</span>, {<span class="hljs-string">"test": data </span>})</code></pre>
     </div>
     <p>
      modify data sent by the XHR request
     </p>
     <div class="code-section">
-      <pre class="hljs"> <code>intercept(<span class="hljs-string">“https://fetchdata.com”</span>, (request) =>  
-  {request.continue({<span class="hljs-string">“custom”: “data”</span>})}))</code></pre>
+      <pre class="hljs"> <code>intercept(<span class="hljs-string">"https://fetchdata.com"</span>, (request) =>  
+  {request.continue({<span class="hljs-string">"custom": "data"</span>})}))</code></pre>
     </div>
     <p>This simplifies test setups as Taiko doesn’t have to set up mock servers, or replace URLs in tests to point to test instances.
     </p>


### PR DESCRIPTION
Fix the quotation mark. In case anyone who wants to copy command from the Webpage or README will execute the command failed.