### PR TITLE
Changed exists() to return a boolean value

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -192,8 +192,8 @@ function addFunctionToRepl(target, repl, isPlugin = false) {
                     let wrraper = async (interval, timeout) => {
                         let v = await existsFunc(interval, timeout);
                         if (v)
-                            return { description: 'Exists' };
-                        return { description: 'Does not Exist' };
+                            return true;
+                        return false;
                     };
                     res.exists = wrraper;
                 }


### PR DESCRIPTION
According to the documentation [here](https://taiko.gauge.org/#elementwrapper), exists() is supposed to have been returning a boolean value since 0.4.0, but currently it is returning a JSON object.

It looks like it was changed to return a boolean back in [this commit](https://github.com/getgauge/taiko/commit/49be4d4ea776ea343d23c0abbc6595920f130b58), but since then there's apparently been some reorganization. The call in taiko.js has been moved to helper.js, and the call in repl.js, which was still returning a non-boolean value and I believe was previously returning to taiko.js, is now returning directly to the user.

As far as I can tell, the JSON object is not needed and can simply be changed to a boolean value. Please do correct me if I'm missing something or there's a better way to go about this.