### PR TITLE
Support for Coffeescript and other languages

### DIFF
--- a/bin/runFile.js
+++ b/bin/runFile.js
@@ -48,5 +48,5 @@ module.exports = async (file, observe, observeTime, continueRepl) => {
         ret.push(__dirname);
         return ret;
     };
-    require(path.resolve(file).slice(0, -3));
+    require(path.resolve(file));
 };

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -29,6 +29,10 @@ process.on('unhandledRejection', exitOnUnhandledFailures);
 process.on('uncaughtException', exitOnUnhandledFailures);
 
 function validate(file) {
+    if (!file.endsWith('.js')) {
+        console.log('Invalid file extension. Only javascript files are accepted.');
+        process.exit(1);
+    }
     if (!fs.existsSync(file)) {
         console.log('File does not exist.');
         process.exit(1);

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -28,6 +28,13 @@ async function exitOnUnhandledFailures(e) {
 process.on('unhandledRejection', exitOnUnhandledFailures);
 process.on('uncaughtException', exitOnUnhandledFailures);
 
+function validate(file) {
+    if (!fs.existsSync(file)) {
+        console.log('File does not exist.');
+        process.exit(1);
+    }
+}
+
 function setupEmulateDevice(device) {
     if (devices.hasOwnProperty(device))
         process.env['TAIKO_EMULATE_DEVICE'] = device;
@@ -100,6 +107,7 @@ if (isTaikoRunner(process.argv[1])) {
         .action(function () {
             if (program.args.length) {
                 const fileName = program.args[0];
+                validate(fileName);
                 const observe = Boolean(program.observe || program.slowMod);
                 if (program.load) {
                     runFile(fileName, true, program.waitTime, (fileName) => {

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -28,13 +28,6 @@ async function exitOnUnhandledFailures(e) {
 process.on('unhandledRejection', exitOnUnhandledFailures);
 process.on('uncaughtException', exitOnUnhandledFailures);
 
-function validate(file) {
-    if (!fs.existsSync(file)) {
-        console.log('File does not exist.');
-        process.exit(1);
-    }
-}
-
 function setupEmulateDevice(device) {
     if (devices.hasOwnProperty(device))
         process.env['TAIKO_EMULATE_DEVICE'] = device;
@@ -107,7 +100,6 @@ if (isTaikoRunner(process.argv[1])) {
         .action(function () {
             if (program.args.length) {
                 const fileName = program.args[0];
-                validate(fileName);
                 const observe = Boolean(program.observe || program.slowMod);
                 if (program.load) {
                     runFile(fileName, true, program.waitTime, (fileName) => {

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -29,7 +29,7 @@ process.on('unhandledRejection', exitOnUnhandledFailures);
 process.on('uncaughtException', exitOnUnhandledFailures);
 
 function validate(file) {
-    if (!file.endsWith('.js')) {
+    if (!['.js', '.coffee'].some(extension => file.endsWith(extension))) {
         console.log('Invalid file extension. Only javascript files are accepted.');
         process.exit(1);
     }

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -29,10 +29,6 @@ process.on('unhandledRejection', exitOnUnhandledFailures);
 process.on('uncaughtException', exitOnUnhandledFailures);
 
 function validate(file) {
-    if (!file.endsWith('.js')) {
-        console.log('Invalid file extension. Only javascript files are accepted.');
-        process.exit(1);
-    }
     if (!fs.existsSync(file)) {
         console.log('File does not exist.');
         process.exit(1);


### PR DESCRIPTION
This is a follow up on #490 . Made these changes and got taiko to run my functional tests in Coffeescript.

Just added the `.coffee` extension along with `.js` while checking the extension of the file. Though I reckon that Typescript would require `.ts` and many more languages to come in the future would possibly have their own. Perhaps it might be useful to not do such a check at all.

Also, removed the slicing of the filename string since it was cutting off the last three characters of the filename making `xyz.coffee` into `xyz.cof`. I'm guessing this was done to make a filename like `index.js` into just `index`. From what I've seen `index.js` should also work fine in most cases as well :)

Making these changes has worked out well for me. Haven't yet tried making things work together with Gauge yet, but I have my fingers crossed that any problems wouldn't arise.

Cheers! 🎉 