### PR TITLE
#321 handle textnode

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -614,13 +614,20 @@ const setOptions = (options, x, y) => {
 const checkIfElementAtPointOrChild = async (e) => {
 
     function isElementAtPointOrChild() {
-        const value = this.getBoundingClientRect();
+        let value, elem = this;
+        if(elem.nodeType === Node.TEXT_NODE){
+            let range = document.createRange();
+            range.selectNodeContents(elem);
+            value = range.getClientRects()[0];
+            console.log(value);
+            elem = elem.parentElement;
+        } else value = elem.getBoundingClientRect();
         const y = (value.top + value.bottom) / 2;
         const x = (value.left + value.right) / 2;
         const node = document.elementFromPoint(x, y);
-        return this.contains(node) ||
+        return elem.contains(node) ||
             (window.getComputedStyle(node).getPropertyValue('opacity') < 0.1) ||
-            (window.getComputedStyle(this).getPropertyValue('opacity') < 0.1);
+            (window.getComputedStyle(elem).getPropertyValue('opacity') < 0.1);
     }
 
     const res = await runtimeHandler.runtimeCallFunctionOn(isElementAtPointOrChild, null, { nodeId: e });
@@ -638,7 +645,12 @@ const getChildNodes = async (element) => {
 
 const checkIfChildOfOtherMatches = async (elem, elements) => {
     function getElementFromPoint() {
-        let value = this.getBoundingClientRect();
+        let value, elem = this;
+        if(elem.nodeType === Node.TEXT_NODE){
+            let range = document.createRange();
+            range.selectNodeContents(elem);
+            value = range.getClientRects();
+        } else value = elem.getBoundingClientRect();
         const y = (value.top + value.bottom) / 2;
         const x = (value.left + value.right) / 2;
         return document.elementFromPoint(x, y);

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1871,18 +1871,30 @@ function match(text, ...args) {
         let textToTranslate = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + nbspChar;
         let translateTo = 'abcdefghijklmnopqrstuvwxyz' + ' ';
         let xpathText = `translate(normalize-space(${xpath(text)}), "${textToTranslate}", "${translateTo}")`;
-        if(e === '*') elements = await $$xpath(`//text()[translate(normalize-space(string()), "${textToTranslate}", "${translateTo}")=${xpathText}]`);
-        if((e === '*') && (!elements || !elements.length)) elements = await $$xpath(`//text()[contains(translate(normalize-space(string()), "${textToTranslate}", "${translateTo}")=${xpathText})]`);
-        if (!elements || !elements.length) elements = await $$xpath('//' + e + `[translate(normalize-space(@value), "${textToTranslate}", "${translateTo}")=${xpathText} or translate(normalize-space(@type), "${textToTranslate}", "${translateTo}")=${xpathText}]`);
-        if (!elements || !elements.length) {
-            const xpathToText = xpath(text.toLowerCase());
-            const xpathToTranslateInnerText = `translate(normalize-space(.), "${textToTranslate}", "${translateTo}")`;
-            elements = await $$xpath('//' + e + `[not(descendant::*[${xpathToTranslateInnerText}=${xpathToText}]) and ${xpathToTranslateInnerText}=${xpathToText}]`);
-        }
-        if (!elements || !elements.length) elements = await $$xpath('//' + e + `[not(descendant::*[contains(translate(normalize-space(.), '${textToTranslate}', '${translateTo}'), ${xpath(text.toLowerCase())})]) and contains(translate(normalize-space(.), '${textToTranslate}', '${translateTo}'), ${xpath(text.toLowerCase())})]`);
+        if( e === '*') elements = await matchTextNode( textToTranslate, translateTo, xpathText);
+        if (!elements || !elements.length) elements = await matchValueOrType( e, textToTranslate, translateTo, xpathText);
+        if (!elements || !elements.length) elements = await matchTextAcrossElements(e, textToTranslate, translateTo, xpathText);
         return await handleRelativeSearch(elements, args);
     };
     return { get: getIfExists(get), exists: exists(getIfExists(get)), description: `Element matching text "${text}"`, text: selectorText(get) };
+}
+
+async function  matchTextNode(textToTranslate,translateTo,xpathText){
+    const elements = await $$xpath(`//text()[translate(normalize-space(string()), "${textToTranslate}", "${translateTo}")=${xpathText}]`);
+    if((!elements || !elements.length)) return await $$xpath(`//text()[contains(translate(normalize-space(string()), "${textToTranslate}", "${translateTo}")=${xpathText})]`);
+    return elements;
+}
+
+async function matchValueOrType(e, textToTranslate, translateTo, xpathText){
+    return (await $$xpath('//' + e + `[translate(normalize-space(@value), "${textToTranslate}", "${translateTo}")=${xpathText} or translate(normalize-space(@type), "${textToTranslate}", "${translateTo}")=${xpathText}]`));
+}
+
+async function matchTextAcrossElements(e, textToTranslate, translateTo, xpathText){
+    const xpathToTranslateInnerText = `translate(normalize-space(.), "${textToTranslate}", "${translateTo}")`;
+    const elements = await $$xpath('//' + e + `[not(descendant::*[${xpathToTranslateInnerText}=${xpathText}]) and ${xpathToTranslateInnerText}=${xpathText}]`);
+    if (!elements || !elements.length) 
+        return await $$xpath('//' + e + `[not(descendant::*[contains(translate(normalize-space(.), '${textToTranslate}', '${translateTo}'), ${xpathText})]) and contains(translate(normalize-space(.), '${textToTranslate}', '${translateTo}'), ${xpathText})]`);
+    return elements;
 }
 
 /**

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2299,7 +2299,8 @@ const filter_visible_nodes = async (nodeIds) => {
     let visible_nodes = [];
 
     function isHidden() {
-        return this.offsetParent === null || this.offsetParent === undefined;
+        if(this.nodeType === Node.TEXT_NODE) return this.parentElement.offsetHeight <= 0 && this.parentElement.offsetWidth <= 0; 
+        return this.offsetHeight <= 0 && this.offsetWidth <= 0;
     }
 
     for (const nodeId of nodeIds) {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -619,7 +619,6 @@ const checkIfElementAtPointOrChild = async (e) => {
             let range = document.createRange();
             range.selectNodeContents(elem);
             value = range.getClientRects()[0];
-            console.log(value);
             elem = elem.parentElement;
         } else value = elem.getBoundingClientRect();
         const y = (value.top + value.bottom) / 2;
@@ -1872,7 +1871,8 @@ function match(text, ...args) {
         let textToTranslate = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + nbspChar;
         let translateTo = 'abcdefghijklmnopqrstuvwxyz' + ' ';
         let xpathText = `translate(normalize-space(${xpath(text)}), "${textToTranslate}", "${translateTo}")`;
-        if(e === '*') elements = await $$xpath(`//text()[contains(translate(normalize-space(string()), "${textToTranslate}", "${translateTo}"),${xpathText})]`);
+        if(e === '*') elements = await $$xpath(`//text()[translate(normalize-space(string()), "${textToTranslate}", "${translateTo}")=${xpathText}]`);
+        if((e === '*') && (!elements || !elements.length)) elements = await $$xpath(`//text()[contains(translate(normalize-space(string()), "${textToTranslate}", "${translateTo}")=${xpathText})]`);
         if (!elements || !elements.length) elements = await $$xpath('//' + e + `[translate(normalize-space(@value), "${textToTranslate}", "${translateTo}")=${xpathText} or translate(normalize-space(@type), "${textToTranslate}", "${translateTo}")=${xpathText}]`);
         if (!elements || !elements.length) {
             const xpathToText = xpath(text.toLowerCase());

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1898,7 +1898,7 @@ module.exports.toLeftOf = selector => {
     validate();
     return new RelativeSearchElement(async (e, v) => {
         const rect = await domHandler.getBoundingClientRect(e);
-        return rect.left < v;
+        return rect.right <= v;
     }, rectangle(selector, r => r.left), isString(selector) ? `To Left of ${selector}` : `To Left of ${selector.description}`);
 };
 
@@ -1917,7 +1917,7 @@ module.exports.toRightOf = selector => {
     const desc = isString(selector) ? `To Right of ${selector}` : `To Right of ${selector.description}`;
     return new RelativeSearchElement(async (e, v) => {
         const rect = await domHandler.getBoundingClientRect(e);
-        return rect.right > v;
+        return rect.left >= v;
     }, value, desc);
 };
 
@@ -1936,7 +1936,7 @@ module.exports.above = selector => {
     const value = rectangle(selector, r => r.top);
     return new RelativeSearchElement(async (e, v) => {
         const rect = await domHandler.getBoundingClientRect(e);
-        return rect.top < v;
+        return rect.bottom <= v;
     }, value, desc);
 };
 
@@ -1955,7 +1955,7 @@ module.exports.below = selector => {
     const value = rectangle(selector, r => r.bottom);
     return new RelativeSearchElement(async (e, v) => {
         const rect = await domHandler.getBoundingClientRect(e);
-        return rect.bottom > v;
+        return rect.top >= v;
     }, value, desc);
 };
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1855,11 +1855,13 @@ function match(text, ...args) {
     validate();
     assertType(text);
     const get = async (e = '*') => {
+        let elements;
         let nbspChar = String.fromCharCode(160);
         let textToTranslate = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' + nbspChar;
         let translateTo = 'abcdefghijklmnopqrstuvwxyz' + ' ';
         let xpathText = `translate(normalize-space(${xpath(text)}), "${textToTranslate}", "${translateTo}")`;
-        let elements = await $$xpath('//' + e + `[translate(normalize-space(@value), "${textToTranslate}", "${translateTo}")=${xpathText} or translate(normalize-space(@type), "${textToTranslate}", "${translateTo}")=${xpathText}]`);
+        if(e === '*') elements = await $$xpath(`//text()[contains(translate(normalize-space(string()), "${textToTranslate}", "${translateTo}"),${xpathText})]`);
+        if (!elements || !elements.length) elements = await $$xpath('//' + e + `[translate(normalize-space(@value), "${textToTranslate}", "${translateTo}")=${xpathText} or translate(normalize-space(@type), "${textToTranslate}", "${translateTo}")=${xpathText}]`);
         if (!elements || !elements.length) {
             const xpathToText = xpath(text.toLowerCase());
             const xpathToTranslateInnerText = `translate(normalize-space(.), "${textToTranslate}", "${translateTo}")`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3854,7 +3854,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3875,12 +3876,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3895,17 +3898,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4022,7 +4028,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4034,6 +4041,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4048,6 +4056,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4055,12 +4064,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4079,6 +4090,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4159,7 +4171,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4171,6 +4184,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4256,7 +4270,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4292,6 +4307,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4311,6 +4327,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4354,12 +4371,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -6154,7 +6173,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "3.0.0",
-					"resolved": "https://artifactory.origindigital-dac.com.au/artifactory/api/npm/npm-all/pify/-/pify-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				}
@@ -7389,7 +7408,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "3.0.0",
-					"resolved": "https://artifactory.origindigital-dac.com.au/artifactory/api/npm/npm-all/pify/-/pify-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				}

--- a/test/functional-tests/specs/ElementsAPI.spec
+++ b/test/functional-tests/specs/ElementsAPI.spec
@@ -33,7 +33,7 @@ File field
 Text Box
 ----------
 
-* Focus on Text Box "Username"
+* Focus on Text Box to right of "Username"
 * Write "Gopher" into Text Box "Username"
 * An existing Text Box "Username" value should give exists true
 * Get value "Gopher" of Text Box "Username"

--- a/test/functional-tests/specs/ElementsAPIIFrame.spec
+++ b/test/functional-tests/specs/ElementsAPIIFrame.spec
@@ -33,7 +33,7 @@ Attach file
 Text Box
 ----------
 
-* Focus on Text Box "Username"
+* Focus on Text Box to right of "Username"
 * Write "Gopher" into Text Box "Username"
 * An existing Text Box "Username" value should give exists true
 * Get value "Gopher" of Text Box "Username"

--- a/test/functional-tests/specs/browserActions.spec
+++ b/test/functional-tests/specs/browserActions.spec
@@ -26,7 +26,7 @@
 * Intercept Google Analytics
 * Navigate to "google.com"
 * Open Tab "https://www.thoughtworks.com/contact-us" with timeout "20000"
-* Click link below 
+* Click link near 
 
    |Type|Selector                         |
    |----|---------------------------------|

--- a/test/functional-tests/specs/positionalSelectors.spec
+++ b/test/functional-tests/specs/positionalSelectors.spec
@@ -1,6 +1,6 @@
 # Positional Selectors
 * Navigate to relative path "./specs/data/HTMLElements.html"
-* Focus on Text Box "Username"
+* Focus on Text Box to right of "Username"
 
 ## Into
 * Write "Gopher" into Text Box "Username"

--- a/test/functional-tests/specs/positionalSelectorsIFrame.spec
+++ b/test/functional-tests/specs/positionalSelectorsIFrame.spec
@@ -1,6 +1,6 @@
 # Positional Selectors in IFrame
 * Navigate to relative path "./specs/data/IFrameElements.html"
-* Focus on Text Box "Username"
+* Focus on Text Box to right of "Username"
 
 ## Into
 * Write "Gopher" into Text Box "Username"

--- a/test/functional-tests/tests/click.js
+++ b/test/functional-tests/tests/click.js
@@ -11,7 +11,8 @@ const {
   toLeftOf,
   button,
   rightClick,
-  doubleClick
+  doubleClick,
+  near
 } = require('../../../lib/taiko');
 
 step('Click link <userlink> below <table>', async function(userlink, table) {
@@ -43,8 +44,8 @@ step('Click link to left of <table>', async function(table) {
   await click(link(toLeftOf(_selectors.getElement(table))));
 });
 
-step('Click link below <table>', async function(table) {
-  await click(link(below(_selectors.getElement(table))), { timeout: 60000 });
+step('Click link near <table>', async function(table) {
+  await click(link(near(_selectors.getElement(table))), { timeout: 60000 });
 });
 
 step('Click button <selector>', async function(selector) {

--- a/test/functional-tests/tests/htmlElementAPI.js
+++ b/test/functional-tests/tests/htmlElementAPI.js
@@ -27,7 +27,8 @@ const {
   into,
   dismiss,
   accept,
-  intercept
+  intercept,
+  toRightOf
 } = require('../../../lib/taiko');
 
 beforeScenario(
@@ -124,8 +125,8 @@ step(
   }
 );
 
-step('Focus on Text Box <textBoxName>', async textBoxName => {
-  await focus(textBoxName);
+step("Focus on Text Box to right of <textBoxName>", async (textBoxName) => {
+  await focus(textBox(toRightOf(textBoxName)));
 });
 
 step(

--- a/test/unit-tests/radioButton.test.js
+++ b/test/unit-tests/radioButton.test.js
@@ -4,25 +4,21 @@ let { createHtml, removeFile, openBrowserArgs } = require('./test-util');
 describe('radio button', () => {
     describe('with inline text', () => {
         let filePath;
-        beforeAll(() => {
+        beforeAll(async () => {
             let innerHtml = '<form>' +
                 '<input type="radio" name="color" value="red" checked>Red</input>' +
                 '<input type="radio" name="color" value="yellow">Yellow</input>' +
                 '<input type="radio" name="color" value="green">Green</input>' +
                 '</form>';
-            filePath = createHtml(innerHtml);
-        });
-
-        beforeEach(async () => {
+            filePath = createHtml(innerHtml, 'radioButton');
             await openBrowser(openBrowserArgs);
             await goto(filePath);
-        }, 10000);
+        }, 30000);
 
-        afterAll(() => {
+        afterAll(async () => {
+            await closeBrowser();
             removeFile(filePath);
-        });
-
-        afterEach(async() => await closeBrowser());
+        }, 30000);
 
         test('test exists()', async () => {
             await expect(radioButton('Yellow').exists()).resolves.toBeTruthy();
@@ -42,13 +38,14 @@ describe('radio button', () => {
         });
 
         test('test isSelected()', async () => {
+            await radioButton('Red').select();
             await expect(radioButton('Red').isSelected()).resolves.toBeTruthy();
         });
     });
 
     describe('wrapped in label', () => {
         let filePath;
-        beforeAll(() => {
+        beforeAll(async () => {
             let innerHtml = '<form>' +
                 '<label>' +
                 '<input name="color" type="radio" value="red" checked />' +
@@ -63,19 +60,15 @@ describe('radio button', () => {
                 '<span>Green</span>' +
                 '</label>' +
                 '</form>';
-            filePath = createHtml(innerHtml);
-        });
-
-        beforeEach(async () => {
+            filePath = createHtml(innerHtml, 'radioButton');
             await openBrowser(openBrowserArgs);
             await goto(filePath);
-        }, 10000);
+        }, 30000);
 
-        afterAll(() => {
+        afterAll(async () => {
+            await closeBrowser();
             removeFile(filePath);
-        });
-
-        afterEach(async() => await closeBrowser());
+        }, 30000);
 
         test('test exists()', async () => {
             await expect(radioButton('Green').exists()).resolves.toBeTruthy();
@@ -85,7 +78,7 @@ describe('radio button', () => {
 
     describe('using label for', () => {
         let filePath;
-        beforeAll(() => {
+        beforeAll(async () => {
             let innerHtml = '<form>' +
                 '<p>' +
                 '<input id="c1" name="color" type="radio" value="red" checked />' +
@@ -99,19 +92,15 @@ describe('radio button', () => {
                 '<label for="c3"><input id="c3" name="color" type="radio" value="green" />Green</label>' +
                 '</p>' +
                 '</form>';
-            filePath = createHtml(innerHtml);
-        });
-
-        beforeEach(async () => {
+            filePath = createHtml(innerHtml, 'radioButton');
             await openBrowser(openBrowserArgs);
             await goto(filePath);
-        }, 10000);
+        }, 30000);
 
-        afterAll(() => {
+        afterAll(async () => {
+            await closeBrowser();
             removeFile(filePath);
-        });
-
-        afterEach(async() => await closeBrowser());
+        }, 30000);
 
         test('test exists()', async () => {
             await expect(radioButton('Red').exists()).resolves.toBeTruthy();

--- a/test/unit-tests/test-util.js
+++ b/test/unit-tests/test-util.js
@@ -1,8 +1,8 @@
 let path = require('path');
 let { writeFileSync, unlinkSync } = require('fs');
 
-module.exports.createHtml = (innerHtml) => {
-    let htmlFilePath = path.join(process.cwd(), 'test', 'unit-tests', 'data', 'test.html');
+module.exports.createHtml = (innerHtml, testName) => {
+    let htmlFilePath = path.join(process.cwd(), 'test', 'unit-tests', 'data', testName+'.html');
     let content = `<!DOCTYPE html>
         <html>
         <body>

--- a/test/unit-tests/textMatch.test.js
+++ b/test/unit-tests/textMatch.test.js
@@ -2,22 +2,31 @@ let { openBrowser, goto, closeBrowser, text, inputField, toRightOf } = require('
 let { createHtml, removeFile, openBrowserArgs } = require('./test-util');
 
 describe('text match', () => {
-    describe('text node', () => {
-        let filePath;
-        beforeAll(async () => {
-            let innerHtml = '<div>' +
+
+    let filePath;
+    beforeAll(async () => {
+        let innerHtml = '<div>' +
+                '<div name="text_node">' +
                 'User name: <input type="text" name="uname">' +
+                '</div>' +
+                '<div name="value_or_type_of_field_as_text">' +
+                '<input type="button" value="click me">' +
+                '<input type="submit">' +
+                '</div>' +
+                '<div name="text_across_element">' +
+                '<div>Text <span>Across</span> Element</div>' +
                 '</div>';
-            filePath = createHtml(innerHtml, 'text');
-            await openBrowser(openBrowserArgs);
-            await goto(filePath);
-        }, 30000);
+        filePath = createHtml(innerHtml, 'textMatch');
+        await openBrowser(openBrowserArgs);
+        await goto(filePath);
+    }, 30000);
 
-        afterAll(async () => {
-            await closeBrowser();
-            removeFile(filePath);
-        }, 30000);
-
+    afterAll(async () => {
+        await closeBrowser();
+        removeFile(filePath);
+    }, 30000);
+        
+    describe('text node', () => {
         test('test exact match exists()', async () => {
             await expect(text('User name:').exists()).resolves.toBeTruthy();
             await expect(text('user name:').exists()).resolves.toBeTruthy();
@@ -29,6 +38,26 @@ describe('text match', () => {
 
         test('test proximity selector', async () => {
             await expect(inputField(toRightOf('User name:')).exists()).resolves.toBeTruthy();
+        });
+    });
+
+    describe('value or type of field as text', () => {
+        test('test value as text exists()', async () => {
+            await expect(text('click me').exists()).resolves.toBeTruthy();
+        });
+
+        test('test type as text exists()', async() =>{
+            await expect(text('submit').exists()).resolves.toBeTruthy();
+        });
+    });
+
+    describe('text across element', () => {
+        test('test exact match exists()', async () => {
+            await expect(text('Text Across Element').exists()).resolves.toBeTruthy();
+        });
+
+        test('test partial match exists()', async () => {
+            await expect(text('Text').exists()).resolves.toBeTruthy();
         });
     });
 });

--- a/test/unit-tests/textMatch.test.js
+++ b/test/unit-tests/textMatch.test.js
@@ -1,0 +1,34 @@
+let { openBrowser, goto, closeBrowser, text, inputField, toRightOf } = require('../../lib/taiko');
+let { createHtml, removeFile, openBrowserArgs } = require('./test-util');
+
+describe('text match', () => {
+    describe('text node', () => {
+        let filePath;
+        beforeAll(async () => {
+            let innerHtml = '<div>' +
+                'User name: <input type="text" name="uname">' +
+                '</div>';
+            filePath = createHtml(innerHtml, 'text');
+            await openBrowser(openBrowserArgs);
+            await goto(filePath);
+        }, 30000);
+
+        afterAll(async () => {
+            await closeBrowser();
+            removeFile(filePath);
+        }, 30000);
+
+        test('test exact match exists()', async () => {
+            await expect(text('User name:').exists()).resolves.toBeTruthy();
+            await expect(text('user name:').exists()).resolves.toBeTruthy();
+        });
+
+        test('test partial match exists()', async () => {
+            await expect(text('User').exists()).resolves.toBeTruthy();
+        });
+
+        test('test proximity selector', async () => {
+            await expect(inputField(toRightOf('User name:')).exists()).resolves.toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
#321
- get text nodes using xpath when searching texts in `match()`
- update `isHidden()` method to use parentElement for text nodes and use offsetHeight and offsetWidth instead of offsetParent
- update click verifying if element is covered to use range for finding position of text nodes
- modify proximity selector logic for left, right, top and bottom as they were fetching overlapping elements too
- fix functional tests
- add integration test for text match

should also fix #335 and #186 