### PR TITLE
Fixed incorrect parameters to runFile

### DIFF
--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -92,7 +92,7 @@ if (isTaikoRunner(process.argv[1])) {
                 validate(fileName);
                 const observe = Boolean(program.observe || program.slowMod);
                 if (program.load) {
-                    runFile(fileName, true, program.waitTime, fileName => {
+                    runFile(taiko, fileName, true, program.waitTime, fileName => {
                         return new Promise(resolve => {
                             repl_mode = true;
                             repl.initialize(taiko, fileName).then(r => {


### PR DESCRIPTION
The --load option was not working due to the fact that the parameters used are incorrect. Updated parameters passed to runFile to match signature.