### PR TITLE
Added support for plugins to extend taiko via subcommands

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,4 +1,7 @@
 const fs = require('fs');
+const childProcess = require('child_process');
+const path = require('path');
+
 const getPlugins = () => {
     const taikoPlugin = process.env.TAIKO_PLUGIN;
     if (taikoPlugin) {
@@ -6,7 +9,7 @@ const getPlugins = () => {
             .split(/\s*,\s*/)
             .map(plugin => plugin.match(/^taiko-.*/) ? plugin : `taiko-${plugin}`);
     }
-    if(!fs.existsSync('./package.json')) return [];
+    if (!fs.existsSync('./package.json')) return [];
     let data = fs.readFileSync('./package.json', 'utf-8');
     let packageJson = JSON.parse(data);
     let taikoPluginNames = Object.keys(packageJson.dependencies || {})
@@ -15,6 +18,52 @@ const getPlugins = () => {
     return taikoPluginNames;
 };
 
-module.exports = {
-    getPlugins
+
+const getExecutablePlugins = () => {
+    let pluginsGlobalPath = childProcess.spawnSync('npm', ['root', '-g']).stdout.toString().trim();
+    let pluginsLocalPath = childProcess.spawnSync('npm', ['root']).stdout.toString().trim();
+    let globalPlugins = getPluginsInstalledOn(pluginsGlobalPath);
+    let localPlugins = getPluginsInstalledOn(pluginsLocalPath);
+    let globalExecutablePlugin = filterExecutablePlugin(globalPlugins, pluginsGlobalPath);
+    let localExecutablePlugin = filterExecutablePlugin(localPlugins, pluginsLocalPath);
+
+    return Object.keys(globalExecutablePlugin)
+        .reduce((localPlugins, globalPlugin) => {
+            if (!localPlugins.hasOwnProperty(globalPlugin))
+                localPlugins[globalPlugin] = globalExecutablePlugin[globalPlugin];
+            return localPlugins;
+        }, localExecutablePlugin);
 };
+
+function getPluginsInstalledOn(pluginsPath) {
+    return fs.readdirSync(pluginsPath, { withFileTypes: true })
+        .filter(npmModule => {
+            if (npmModule.isSymbolicLink()) {
+                let fsStaat = fs.statSync(path.resolve(pluginsPath, fs.readlinkSync(path.resolve(pluginsPath, npmModule.name))));
+                return fsStaat.isDirectory() && npmModule.name.match(/^taiko-.*/);
+            }
+            return npmModule.isDirectory() && npmModule.name.match(/^taiko-.*/);
+        })
+        .map(plugin => plugin.name);
+}
+
+function filterExecutablePlugin(plugins, pluginsPath) {
+    return plugins
+        .filter(npmModule => {
+            let packageJson = getPackageJsonForPlugin(pluginsPath, npmModule);
+            return packageJson.capability && packageJson.capability.includes('subcommands');
+        })
+        .reduce((plugins, plugin) => {
+            plugins[plugin.replace(/^taiko-/, '')] = path.join(pluginsPath, plugin);
+            return plugins;
+        }, {});
+}
+
+function getPackageJsonForPlugin(pluginsPath, plugin) {
+    return require(path.resolve(pluginsPath, plugin, 'package.json'));
+}
+module.exports = {
+    getPlugins,
+    getExecutablePlugins
+};
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"lint": "eslint bin/*.js lib/*.js test/*/*.js",
 		"doc": "node docs/generateDocSearch.js && documentation build lib/taiko.js -f md --shallow -o docs/index.md --markdown-toc=false && node docs/setup.js",
 		"test:api": "node test/unit-tests/taiko-test.js",
-		"examples": "npm install --prefix examples && npm test --prefix examples",
+		"examples": "npm install --prefix examples && cd examples && npm test ; cd --",
 		"test:unit": "npm run lint && mocha test/unit-tests/ --timeout 30000",
 		"test": "npm run test:api && npm run test:unit && npm run examples",
 		"test-functional": "cd test/functional-tests && npm install && npm test",

--- a/test/unit-tests/plugins.test.js
+++ b/test/unit-tests/plugins.test.js
@@ -2,70 +2,70 @@ const expect = require('chai').expect;
 const rewire = require('rewire');
 const PLUGINS = rewire('../../lib/plugins');
 
-function mockReadFileSyncWith (content) {
-    var fsMock = {
-        readFileSync: function ( ) {
-            return content;
-        },
-        existsSync: function ( ) {
-            return true;
-        }
-    };
-    PLUGINS.__set__('fs', fsMock);
-}
-
-describe('GetPlugins', () => {
-    describe('With ENV variable', () => {
-        afterEach(() => {
-            delete process.env.TAIKO_PLUGIN;
-        });
-        it('should give plugin name from ENV variable', () => {
-            process.env.TAIKO_PLUGIN = 'some-plugin';
-            expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-some-plugin']);
-        });
-
-        it('should give plugin names from ENV variable', () => {
-            process.env.TAIKO_PLUGIN = 'plugin-1 ,plugin-2, plugin-3';
-            expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-plugin-1', 'taiko-plugin-2', 'taiko-plugin-3']);
-        });
-    });
-
-    describe('Get plugins from package.json', () => {
-
-        it('should give empty array if there is no package.json', () => {
+describe('Plugins', () => {
+    describe('GetPlugins', () => {
+        function mockReadFileSyncWith(content) {
             var fsMock = {
-                existsSync: function ( ) {
-                    return false;
+                readFileSync: function () {
+                    return content;
+                },
+                existsSync: function () {
+                    return true;
                 }
             };
             PLUGINS.__set__('fs', fsMock);
-            expect(PLUGINS.getPlugins()).to.deep.equal([]);
+        }
+        describe('With ENV variable', () => {
+            afterEach(() => {
+                delete process.env.TAIKO_PLUGIN;
+            });
+            it('should give plugin name from ENV variable', () => {
+                process.env.TAIKO_PLUGIN = 'some-plugin';
+                expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-some-plugin']);
+            });
+
+            it('should give plugin names from ENV variable', () => {
+                process.env.TAIKO_PLUGIN = 'plugin-1 ,plugin-2, plugin-3';
+                expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-plugin-1', 'taiko-plugin-2', 'taiko-plugin-3']);
+            });
         });
 
-        it('should give plugin name from dependencies', () => {
-            mockReadFileSyncWith(`{
+        describe('Get plugins from package.json', () => {
+
+            it('should give empty array if there is no package.json', () => {
+                var fsMock = {
+                    existsSync: function () {
+                        return false;
+                    }
+                };
+                PLUGINS.__set__('fs', fsMock);
+                expect(PLUGINS.getPlugins()).to.deep.equal([]);
+            });
+
+            it('should give plugin name from dependencies', () => {
+                mockReadFileSyncWith(`{
                 "dependencies": {
                     "taiko-dep-plugin-1": "v2.4.5",
                     "taiko-dep-plugin-2": "v1.4.5",
                     "some-other-module" : "v1.0.1"
                 }
             }`);
-            expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-dep-plugin-1', 'taiko-dep-plugin-2']);
-        });
+                expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-dep-plugin-1', 'taiko-dep-plugin-2']);
+            });
 
-        it('should give plugin name from devDependencies', () => {
-            mockReadFileSyncWith(`{
+            it('should give plugin name from devDependencies', () => {
+                mockReadFileSyncWith(`{
                 "devDependencies": {
                     "taiko-devDep-plugin-1": "v2.4.5",
                     "taiko-devDep-plugin-2": "v1.4.5",
                     "some-other-module" : "v1.0.1"
                 }
             }`);
-            expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-devDep-plugin-1', 'taiko-devDep-plugin-2']);
-        });
+                expect(PLUGINS.getPlugins()).to.deep.equal(['taiko-devDep-plugin-1', 'taiko-devDep-plugin-2']);
+            });
 
-        it('should give plugin name from both devDependencies and dependencies', () => {
-            mockReadFileSyncWith(`{
+            it('should give plugin name from both devDependencies and dependencies', () => {
+                mockReadFileSyncWith(`{
                 "dependencies": {
                     "taiko-dep-plugin-1": "v2.4.5",
                     "taiko-dep-plugin-2": "v1.4.5",
@@ -77,8 +77,74 @@ describe('GetPlugins', () => {
                     "some-other-module" : "v1.0.1"
                 }
             }`);
-            const expectedPluginNames = ['taiko-dep-plugin-1', 'taiko-dep-plugin-2', 'taiko-devDep-plugin-1', 'taiko-devDep-plugin-2'];
-            expect(PLUGINS.getPlugins()).to.deep.equal(expectedPluginNames);
+                const expectedPluginNames = ['taiko-dep-plugin-1', 'taiko-dep-plugin-2', 'taiko-devDep-plugin-1', 'taiko-devDep-plugin-2'];
+                expect(PLUGINS.getPlugins()).to.deep.equal(expectedPluginNames);
+            });
+        });
+    });
+
+    describe('GetExecutablePlugin', () => {
+        function createFakeFsDirentObj(name, isDir, isSymLink) {
+            return {
+                name: name,
+                isSymbolicLink: () => isSymLink,
+                isDirectory: () => isDir
+            };
+        }
+        it('should give all globally installed executable taiko-plugin and there path', () => {
+            var fsMock = {
+                readdirSync: function (path) {
+                    if (path === '/tmp/global/taiko-plugin-path')
+                        return [
+                            createFakeFsDirentObj('taiko-global-plugin1', true, false),
+                            createFakeFsDirentObj('taiko-plugin2', true, false),
+                            createFakeFsDirentObj('taiko-plugin3', false, false),
+                            createFakeFsDirentObj('tmpdir', true, false),
+                            createFakeFsDirentObj('taiko-global-plugin4', false, true),
+                            createFakeFsDirentObj('taiko-dup-plugin1', true, false)
+                        ];
+                    return [
+                        createFakeFsDirentObj('taiko-plugin1', true, false),
+                        createFakeFsDirentObj('taiko-plugin2', true, false),
+                        createFakeFsDirentObj('taiko-plugin3', false, false),
+                        createFakeFsDirentObj('tmpdir', true, false),
+                        createFakeFsDirentObj('taiko-plugin4', false, true),
+                        createFakeFsDirentObj('taiko-dup-plugin1', true, false)
+                    ];
+                },
+                statSync: function () {
+                    return { isDirectory: () => true };
+                },
+                readlinkSync: () => {
+                    return '/tmp/taiko-plugin-simlinked-path';
+                }
+            };
+            PLUGINS.__set__('childProcess', {
+                spawnSync: (...args) => {
+                    if (args[1][1] === '-g')
+                        return { stdout: '/tmp/global/taiko-plugin-path' };
+                    return { stdout: '/tmp/local/taiko-plugin-path' };
+                }
+            });
+            PLUGINS.__set__('fs', fsMock);
+            PLUGINS.__set__('getPackageJsonForPlugin', (pluginPath, plugin) => {
+                if (['taiko-global-plugin1', 'taiko-global-plugin4', 'taiko-plugin1', 'taiko-plugin4', 'taiko-dup-plugin1'].includes(plugin)) {
+                    return { capability: ['subcommands'] };
+                } else if (plugin === 'taiko-plugin2') {
+                    return { capability: [] };
+                } else {
+                    return {};
+                }
+            });
+
+            const expected = {
+                'global-plugin1': '/tmp/global/taiko-plugin-path/taiko-global-plugin1',
+                'global-plugin4': '/tmp/global/taiko-plugin-path/taiko-global-plugin4',
+                'plugin1': '/tmp/local/taiko-plugin-path/taiko-plugin1',
+                'plugin4': '/tmp/local/taiko-plugin-path/taiko-plugin4',
+                'dup-plugin1': '/tmp/local/taiko-plugin-path/taiko-dup-plugin1'
+            };
+            expect(PLUGINS.getExecutablePlugins()).to.be.deep.equal(expected);
         });
     });
 });


### PR DESCRIPTION
**Taiko** plugins can extend **Taiko** via subcommands
`taiko <taiko-pluginname> <options>`

**Example:** 

 [taiko-diagnostics](https://github.com/saikrishna321/taiko-diagnostics/) can extend Taiko via subcommands as `taiko diagnostics <options>`

In order to be able to extend Taiko via subcommands, plugins have to implement a few things.

- Add a **capability** section in **package.json**

      { 
           ...,
          capability: ["subcommands"],
          ...
      }

- Add `exec` API.

Taiko will invoke plugin's `exec` API with all the options passed to Taiko subcommand.
