### PR TITLE
Avoid single-letter variables in REPL output

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Taiko’s REPL keeps a history of all successful commands. Once you finish a flo
             await goto("google.com");
             await write("taiko test automation");
             await click("Google Search");
-        } catch (e) {
-                console.error(e);
+        } catch (error) {
+                console.error(error);
         } finally {
                 closeBrowser();
         }

--- a/docs/layout/partials/header.html
+++ b/docs/layout/partials/header.html
@@ -97,8 +97,8 @@ click(<span class="hljs-string">"Google Search"</span>)</code></pre>
     await goto(<span class="hljs-string">"google.com"</span>);
     await write(<span class="hljs-string">"taiko test automation"</span>);
     await click(<span class="hljs-string">"Google Search"</span>);
-  } catch (e) {
-      console.error(e);
+  } catch (error) {
+      console.error(error);
   } finally {
     closeBrowser();
   }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -115,8 +115,8 @@ function code() {
     return importTaiko + `(async () => {
     try {
 ${ text}
-    } catch (e) {
-        console.error(e);
+    } catch (error) {
+        console.error(error);
     } finally {
         await closeBrowser();
     }


### PR DESCRIPTION
Single letter variables tend to be confusing and make the code less
readable. Let's use the full word `error` instead of `e` for clarity.