### PR TITLE
Handling hidden elements

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1581,7 +1581,7 @@ const prepareParameters = (attrValuePairs, options, ...args) => {
         values.selector = { label: attrValuePairs, args: args };
     }
     values.options = options || {};
-    if(options.selectHiddenElement && hasProximitySelectors(values))
+    if(values.options.selectHiddenElement && hasProximitySelectors(values))
         console.warn('WARNING: Proximity of hidden element are not available hence proximity selector will be ignored');
     return values;
 };

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2700,12 +2700,19 @@ const handleTimeout = (timeout, listenerCallbackMap) => {
     };
 };
 
-const highlightElemOnAction = async (elem) => {
+const highlightElemOnAction = async (nodeId) => {
     if (highlightOnAction.toLowerCase() === 'true') {
-        const result = await domHandler.getBoxModel(elem);
-        await overlay.highlightQuad({ quad: result.model.border, outlineColor: { r: 255, g: 0, b: 0 } });
-        await waitFor(1000);
-        await overlay.hideHighlight();
+        try {
+            let result = await domHandler.getBoxModel(nodeId);
+            await overlay.highlightQuad({ quad: result.model.border, outlineColor: { r: 255, g: 0, b: 0 } });
+            await waitFor(1000);
+            await overlay.hideHighlight();
+        } catch(err) {
+            if((await filterVisibleNodes([nodeId], evaluate)).length < 1 )
+                console.warn('WARNING: Taiko cannot highlight hidden elements.');
+            else
+                throw err;
+        }
     }
 };
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1581,6 +1581,8 @@ const prepareParameters = (attrValuePairs, options, ...args) => {
         values.selector = { label: attrValuePairs, args: args };
     }
     values.options = options || {};
+    if(options.selectHiddenElement && values.selector.args.length > 0)
+        throw new Error('Taiko does not support proximity selectors with the hidden element.');
     return values;
 };
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1581,8 +1581,8 @@ const prepareParameters = (attrValuePairs, options, ...args) => {
         values.selector = { label: attrValuePairs, args: args };
     }
     values.options = options || {};
-    if(options.selectHiddenElement && values.selector.args.length > 0)
-        throw new Error('Taiko does not support proximity selectors with the hidden element.');
+    if(options.selectHiddenElement && hasProximitySelectors(values))
+        console.warn('WARNING: Proximity of hidden element are not available hence proximity selector will be ignored');
     return values;
 };
 
@@ -1778,6 +1778,10 @@ module.exports.inputField = (attrValuePairs, ...args) => {
  * @returns {ElementWrapper}
  */
 module.exports.fileField = fileField;
+
+function hasProximitySelectors(values) {
+    return values.selector.args.length > 0;
+}
 
 function fileField(attrValuePairs, _options = {}, ...args) {
     validate();


### PR DESCRIPTION
Show warning when a proximity selector is used with `selectHiddenElement` option.
Show when Taiko default highlight on action tries to highlight a hidden element.
