### PR TITLE
Wrap console log && support --no-log

### DIFF
--- a/bin/runFile.js
+++ b/bin/runFile.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const util = require('util');
 const recorder = require('../recorder');
+const { safeLog } = require('../lib/util');
 
 const { removeQuotes, symbols } = require('../lib/util');
 module.exports = async (taiko, file, observe, observeTime, continueRepl) => {
@@ -33,7 +34,7 @@ module.exports = async (taiko, file, observe, observeTime, continueRepl) => {
             global[func]  = taiko[func];
         if (continueRepl) {
             recorder.repl = async () => {
-                console.log(removeQuotes(util.inspect('Starting REPL..', { colors: true }), 'Starting REPL..'));
+                safeLog(removeQuotes(util.inspect('Starting REPL..', { colors: true }), 'Starting REPL..'));
                 await continueRepl(file);
             };
         }
@@ -43,7 +44,7 @@ module.exports = async (taiko, file, observe, observeTime, continueRepl) => {
     eventEmitter.on('success', (desc) => {
         desc = symbols.pass + desc;
         desc = removeQuotes(util.inspect(desc, { colors: true }), desc);
-        console.log(desc);
+        safeLog(desc);
     });
     const oldNodeModulesPaths = module.constructor._nodeModulePaths;
     module.constructor._nodeModulePaths = function () {

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -66,6 +66,10 @@ function setEmulatedNetwork(networkType) {
     process.env.TAIKO_EMULATE_NETWORK = networkType;
 }
 
+function setDisableLogout() {
+    process.env.TAIKO_DISABLE_LOGOUT = 'true';
+}
+
 function seekingForHelp(args) {
     return args.includes('-h') || args.includes('--help');
 }
@@ -127,6 +131,11 @@ if (isCLICommand() && isTaikoRunner(processArgv[1])) {
         .option(
             '--plugin <plugin1,plugin2...>',
             'Load the taiko plugin.', setPluginNameInEnv
+        )
+        .option(
+            '--no-log',
+            'Disable log output of taiko',
+            setDisableLogout
         )
         .action(function (_, fileName, cmd) {
             taiko = require('../lib/taiko');

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -4,7 +4,7 @@ const runFile = require('./runFile');
 const fs = require('fs');
 const Command = require('commander').Command;
 const repl = require('../lib/repl/repl');
-const { isTaikoRunner } = require('../lib/util');
+const { isTaikoRunner, safeLog } = require('../lib/util');
 const devices = require('../lib/data/devices').default;
 const NETWORK_TYPES = Object.keys(require('../lib/data/networkConditions'));
 const { getExecutablePlugins } = require('../lib/plugins');
@@ -33,11 +33,11 @@ process.on('uncaughtException', exitOnUnhandledFailures);
 
 function validate(file) {
     if (!file.endsWith('.js')) {
-        console.log('Invalid file extension. Only javascript files are accepted.');
+        safeLog('Invalid file extension. Only javascript files are accepted.');
         process.exit(1);
     }
     if (!fs.existsSync(file)) {
-        console.log('File does not exist.');
+        safeLog('File does not exist.');
         process.exit(1);
     }
 }
@@ -46,8 +46,8 @@ function setupEmulateDevice(device) {
     if (Object.prototype.hasOwnProperty.call(devices, device))
         process.env['TAIKO_EMULATE_DEVICE'] = device;
     else {
-        console.log(`Invalid value ${device} for --emulate-device`);
-        console.log(`Available devices: ${Object.keys(devices).join(', ')}`);
+        safeLog(`Invalid value ${device} for --emulate-device`);
+        safeLog(`Available devices: ${Object.keys(devices).join(', ')}`);
         process.exit(1);
     }
 }
@@ -59,8 +59,8 @@ function setPluginNameInEnv(pluginName) {
 
 function setEmulatedNetwork(networkType) {
     if (!NETWORK_TYPES.includes(networkType)) {
-        console.log(`Invalid value ${networkType} for --emulate-network`);
-        console.log(`Available options: ${NETWORK_TYPES.join(', ')}`);
+        safeLog(`Invalid value ${networkType} for --emulate-network`);
+        safeLog(`Available options: ${NETWORK_TYPES.join(', ')}`);
         process.exit(1);
     }
     process.env.TAIKO_EMULATE_NETWORK = networkType;

--- a/lib/repl/repl.js
+++ b/lib/repl/repl.js
@@ -4,6 +4,7 @@ const util = require('util');
 const { aEval } = require('./awaitEval');
 const { initSearch } = require('./repl-search');
 const { removeQuotes, symbols } = require('../util');
+const { safeLog } = require('../../lib/util');
 const funcs = {};
 let commands = [];
 const stringColor = util.inspect.styles.string;
@@ -23,7 +24,7 @@ module.exports.initialize = async (taiko, previousSessionFile) => {
         process.nextTick(() => {
             desc = symbols.pass + desc;
             desc = removeQuotes(util.inspect(desc, { colors: true }), desc);
-            console.log(desc);
+            safeLog(desc);
             repl.setPrompt('> ');
             repl.prompt();
         });
@@ -53,14 +54,14 @@ function initCommands(taiko, repl, previousSessionFile) {
     repl.defineCommand('trace', {
         help: 'Show last error stack trace',
         action() {
-            console.log(lastStack ? lastStack : util.inspect(undefined, { colors: true }));
+            safeLog(lastStack ? lastStack : util.inspect(undefined, { colors: true }));
             this.displayPrompt();
         }
     });
     repl.defineCommand('code', {
         help: 'Prints or saves the code for all evaluated commands in this REPL session',
         action(file) {
-            if (!file) console.log(code());
+            if (!file) safeLog(code());
             else writeCode(file, previousSessionFile);
             this.displayPrompt();
         }
@@ -68,7 +69,7 @@ function initCommands(taiko, repl, previousSessionFile) {
     repl.defineCommand('step', {
         help: 'Generate gauge steps from recorded script. (openBrowser and closeBrowser are not recorded as part of step)',
         action(file) {
-            if (!file) console.log(step());
+            if (!file) safeLog(step());
             else writeStep(file);
             this.displayPrompt();
         }
@@ -76,14 +77,14 @@ function initCommands(taiko, repl, previousSessionFile) {
     repl.defineCommand('version', {
         help: 'Prints version info',
         action() {
-            console.log(`${version} (${browserVersion})`);
+            safeLog(`${version} (${browserVersion})`);
             this.displayPrompt();
         }
     });
     repl.defineCommand('api', {
         help: 'Prints api info',
         action(name) {
-            if (!doc) console.log('API usage not available.');
+            if (!doc) safeLog('API usage not available.');
             else if (name) displayUsageFor(name);
             else displayUsage(taiko);
             this.displayPrompt();
@@ -158,17 +159,17 @@ function writeCode(file, previousSessionFile) {
             fs.writeFileSync(file, code());
         }
         if (previousSessionFile) {
-            console.log(`Recorded session to ${file}.`);
+            safeLog(`Recorded session to ${file}.`);
             if (path.resolve(file) === path.resolve(previousSessionFile)) {
-                console.log(`Please update contents of ${previousSessionFile} before running it with taiko.`);
+                safeLog(`Please update contents of ${previousSessionFile} before running it with taiko.`);
             } else {
-                console.log(`The previous session was recorded in ${previousSessionFile}.`);
-                console.log(`Please merge contents of ${previousSessionFile} and ${file} before running it with taiko.`);
+                safeLog(`The previous session was recorded in ${previousSessionFile}.`);
+                safeLog(`Please merge contents of ${previousSessionFile} and ${file} before running it with taiko.`);
             }
         }
     } catch (error) {
-        console.log(`Failed to write to ${file}.`);
-        console.log(error.stacktrace);
+        safeLog(`Failed to write to ${file}.`);
+        safeLog(error.stacktrace);
     }
 }
 
@@ -214,35 +215,35 @@ function addFunctionToRepl(target, repl) {
 }
 
 function displayTaiko() {
-    console.log(`\nVersion: ${version} (Chromium:${browserVersion})`);
-    console.log('Type .api for help and .exit to quit\n');
+    safeLog(`\nVersion: ${version} (Chromium:${browserVersion})`);
+    safeLog('Type .api for help and .exit to quit\n');
 }
 
 function displayUsageFor(name) {
     const e = doc.find(e => e.name === name);
     if (!e) {
-        console.log(`Function ${name} doesn't exist.`);
+        safeLog(`Function ${name} doesn't exist.`);
         return;
     }
-    console.log();
-    console.log(desc(e.description));
+    safeLog();
+    safeLog(desc(e.description));
     if (e.examples.length > 0) {
-        console.log();
-        console.log(e.examples.length > 1 ? 'Examples:' : 'Example:');
-        console.log(e.examples
+        safeLog();
+        safeLog(e.examples.length > 1 ? 'Examples:' : 'Example:');
+        safeLog(e.examples
             .map(e => e.description.split('\n').map(e => '\t' + e).join('\n'))
             .join('\n'));
-        console.log();
+        safeLog();
     }
 }
 
 function displayUsage(taiko) {
     taiko.metadata.Helpers = taiko.metadata.Helpers.filter(item => item !== 'repl');
     for (let k in taiko.metadata)
-        console.log(`
+        safeLog(`
 ${removeQuotes(util.inspect(k, { colors: true }), k)}
     ${taiko.metadata[k].join(', ')}`);
-    console.log(`
+    safeLog(`
 Run \`.api <name>\` for more info on a specific function. For Example: \`.api click\`.
 Complete documentation is available at http://taiko.gauge.org.
 `);

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -23,7 +23,18 @@ const descEvent = new EventEmitter();
 let chromeProcess, temporaryUserDataDir, page, network, runtime, input, _client, dom, overlay, criTarget, 
     currentPort, currentHost, security, device, eventHandlerProxy, clientProxy, localProtocol = false;
 
+const safeLog = console.log;
+
+console.log = (...args) => {
+    if (typeof process.env.TAIKO_DISABLE_LOGOUT === 'string' && process.env.TAIKO_DISABLE_LOGOUT == 'true') {
+        return;
+    }
+    safeLog.apply(this, args);
+};
+
 module.exports.emitter = descEvent;
+
+module.exports.safeLog = safeLog;
 
 const connect_to_cri = async (target) => {
     if (process.env.LOCAL_PROTOCOL) {
@@ -2720,6 +2731,6 @@ module.exports.metadata = {
     'Selectors': ['$', 'image', 'link', 'listItem', 'button', 'inputField', 'fileField', 'textBox', 'textField', 'comboBox', 'dropDown', 'checkBox', 'radioButton', 'text'],
     'Proximity selectors': ['toLeftOf', 'toRightOf', 'above', 'below', 'near'],
     'Events': ['alert', 'prompt', 'confirm', 'beforeunload'],
-    'Helpers': ['evaluate', 'intervalSecs', 'timeoutSecs', 'to', 'into', 'accept', 'dismiss', 'setConfig', 'waitFor', 'repl'],
+    'Helpers': ['evaluate', 'intervalSecs', 'timeoutSecs', 'to', 'into', 'accept', 'dismiss', 'setConfig', 'waitFor', 'repl', 'safeLog'],
     'Extensions': ['loadPlugin']
 };

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2,7 +2,7 @@ const cri = require('chrome-remote-interface');
 const childProcess = require('child_process');
 const { helper, wait, isString, isFunction, getIfExists, waitUntil,
     exists, xpath, waitForNavigation, timeouts, assertType } = require('./helper');
-const { createJsDialogEventName } = require('./util');
+const { createJsDialogEventName, safeLog } = require('./util');
 const inputHandler = require('./handlers/inputHandler');
 const domHandler = require('./handlers/domHandler');
 const networkHandler = require('./handlers/networkHandler');
@@ -23,18 +23,7 @@ const descEvent = new EventEmitter();
 let chromeProcess, temporaryUserDataDir, page, network, runtime, input, _client, dom, overlay, criTarget, 
     currentPort, currentHost, security, device, eventHandlerProxy, clientProxy, localProtocol = false;
 
-const safeLog = console.log;
-
-console.log = (...args) => {
-    if (typeof process.env.TAIKO_DISABLE_LOGOUT === 'string' && process.env.TAIKO_DISABLE_LOGOUT == 'true') {
-        return;
-    }
-    safeLog.apply(this, args);
-};
-
 module.exports.emitter = descEvent;
-
-module.exports.safeLog = safeLog;
 
 const connect_to_cri = async (target) => {
     if (process.env.LOCAL_PROTOCOL) {
@@ -91,7 +80,7 @@ async function reconnect() {
         await dom.getDocument();
         eventHandler.emit('reconnected');
     } catch (e) {
-        console.log(e);
+        safeLog(e);
     }
 }
 
@@ -2731,6 +2720,6 @@ module.exports.metadata = {
     'Selectors': ['$', 'image', 'link', 'listItem', 'button', 'inputField', 'fileField', 'textBox', 'textField', 'comboBox', 'dropDown', 'checkBox', 'radioButton', 'text'],
     'Proximity selectors': ['toLeftOf', 'toRightOf', 'above', 'below', 'near'],
     'Events': ['alert', 'prompt', 'confirm', 'beforeunload'],
-    'Helpers': ['evaluate', 'intervalSecs', 'timeoutSecs', 'to', 'into', 'accept', 'dismiss', 'setConfig', 'waitFor', 'repl', 'safeLog'],
+    'Helpers': ['evaluate', 'intervalSecs', 'timeoutSecs', 'to', 'into', 'accept', 'dismiss', 'setConfig', 'waitFor', 'repl'],
     'Extensions': ['loadPlugin']
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -36,3 +36,10 @@ module.exports.trimCharLeft = (baseString,char) =>{
     const splitedString = baseString.split(char);
     return splitedString[splitedString.length - 1];
 };
+
+module.exports.safeLog = (args) => {
+    if (typeof process.env.TAIKO_DISABLE_LOGOUT === 'string' && process.env.TAIKO_DISABLE_LOGOUT == 'true') {
+        return;
+    }
+    console.log.apply(this, args);
+};


### PR DESCRIPTION
Fix issue #690 

Provide an option --no-log to disable all log from taiko itself, but still, allow user's script to use console.log

```sh
# will disable logs from within taiko itself
$ taiko user.js --no-log
```
