### PR TITLE
text() should string when single value is found

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -3432,7 +3432,7 @@ const selectorText = get => {
         })).value,
       );
     }
-    return texts;
+    return texts.length > 1 ? texts : texts[0];
   };
 };
 

--- a/test/functional-tests/tests/assert.js
+++ b/test/functional-tests/tests/assert.js
@@ -17,7 +17,7 @@ step('Assert Exists <table>', async function(table) {
 });
 
 step('assert text should be empty into <table>', async function(table) {
-  assert.equal((await _selectors.getElement(table).text())[0], '');
+  assert.equal((await _selectors.getElement(table).text()), '');
 });
 
 step('Assert text is not empty <table>', async function(table) {

--- a/test/unit-tests/$.test.js
+++ b/test/unit-tests/$.test.js
@@ -23,6 +23,14 @@ describe(test_name, () => {
             <p id="foo">taiko</p>
             <p>demo</p>
         </div>
+        <div class="test">
+            <p id="multileId">taiko</p>
+             <p>demo</p>
+        </div>
+          <div class="test">
+           <p id="multileId">taiko</p>
+          <p>demo</p>
+        </div>
             `;
     filePath = createHtml(innerHtml, test_name);
     await openBrowser(openBrowserArgs);
@@ -43,6 +51,16 @@ describe(test_name, () => {
     it('should find text with selectors', async () => {
       expect(await $('#foo').exists()).to.be.true;
       expect(await $('.test').exists()).to.be.true;
+    });
+    it('should return array of text with multiple elements', async () => {
+      expect(await $('#multileId').exists()).to.be.true;
+      expect(await $('#multileId').text()).to.be.an('array');
+      expect(await $('#multileId').text()).to.have.lengthOf(2);
+    });
+    it('should return text with single element', async () => {
+      expect(await $('#foo').exists()).to.be.true;
+      expect(await $('#foo').text()).to.be.a('string');
+      expect(await $('#foo').text()).to.not.be.an('array');
     });
     it('should find text with proximity selector', async () => {
       expect(

--- a/test/unit-tests/clear.test.js
+++ b/test/unit-tests/clear.test.js
@@ -98,11 +98,11 @@ multiple lines.</textarea>
     it('should be trigged after clearing textbox', async () => {
       await reload();
       await write('No man land', into(textBox('Country')));
-      expect((await $('#info-borad').text())[0]).to.equal(
+      expect((await $('#info-borad').text())).to.equal(
         'No man land',
       );
       await clear(textBox('Country'));
-      expect((await $('#info-borad').text())[0]).to.equal('');
+      expect((await $('#info-borad').text())).to.equal('');
     });
   });
 });


### PR DESCRIPTION
Current:

```
$('#foo').text() returns array even when single text is found
```

Fix:

```
$('#foo').text() returns 'string'  when single text is found
$('#foo').text() retuns 'array' when multiple text is found
```
