### PR TITLE
Adds `trim()` to the REPL's `.code` function lookup

### DIFF
--- a/lib/repl/repl.js
+++ b/lib/repl/repl.js
@@ -376,4 +376,4 @@ const params = p => {
     .join('');
 };
 
-const isTaikoFunc = keyword => keyword.split('(')[0] in funcs;
+const isTaikoFunc = keyword => keyword.split('(')[0].trim() in funcs;


### PR DESCRIPTION
https://github.com/getgauge/taiko/issues/1016

Adds a `.trim()` to the `isTaikoFunc()`'s split token, so that if the user's style includes spaces between functions and the opening parenthesis, eg: `goto (foo)` (note the space), the lookup resulting from `.code` will still recognize Taiko functions as such and add `await`.