### PR TITLE
Chromium download can be skipped when specified in .npmrc

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -81,6 +81,14 @@ function main() {
     return;
   }
 
+  if (
+    process.env.NPM_CONFIG_TAIKO_SKIP_CHROMIUM_DOWNLOAD ||
+    process.env.npm_config_taiko_skip_chromium_download
+  ) {
+    console.log('Skipping Chromium Download as given in npm config.');
+    return;
+  }
+
   // Do nothing if the revision is already downloaded.
   if (revisionInfo.local) {
     console.log('Skipping Chromium Download as the revision is already found.');


### PR DESCRIPTION
Can already be done via an env var but there is no convenient way to skip on every install.

It's useful in constrained environments where one needs to use a specific version of Chromium.