### PR TITLE
Added check for --window-size argument before adding default value for it when openBrowser is called in headless mode.

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -265,7 +265,10 @@ module.exports.openBrowser = async (
       args.push(`--user-data-dir=${temporaryUserDataDir}`);
     }
     if (options.headless) {
-      args = args.concat(['--headless', '--window-size=1440,900']);
+      args.push('--headless');
+      if (!args.some(arg => arg.startsWith('--window-size'))) {
+        args.push('--window-size=1440,900');
+      }
     }
     chromeProcess = await childProcess.spawn(chromeExecutable, args);
     if (options.dumpio) {


### PR DESCRIPTION
I had an issue similar to [#140](https://github.com/getgauge/taiko/issues/140) wherein the screen size of browser that is opened was too small for the application that I am working on.

This [commit](https://github.com/getgauge/taiko/commit/ee4c6652f8323321c24138f103d4eb86339e72a4) supposedly fixed the issue but here the --window-size argument has a default set to --window-size=1440,900 without checking if there is any --window-size argument passed or not.

In the pull request I have added a check to see if the --window-size argument is passed or not before falling back to default '--window-size=1440,900' when openBrowser is called in headless mode.
  