### PR TITLE
Use the right annotation for tableCell documentation

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2202,7 +2202,7 @@ function fileField(attrValuePairs, _options = {}, ...args) {
 }
 
 /**
- * This {@tableCell selector} lets you identify a table cell
+ * This {@link selector} lets you identify a table cell
  * on a web page with row and column and row values as options and locating table using proximity selectors,
  * or table labels.
  *


### PR DESCRIPTION
This fixes the display of documentation while running the
.api command in the REPL.

Without this fix the tableCell api is not added to api.json
while generating documentation.