### PR TITLE
Throw error when supplied targetUrl to switchTo is empty #1057

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -418,6 +418,11 @@ module.exports.switchTo = async arg => {
         'The "targetUrl" argument must be of type string or regex. Received type ' + typeof arg,
       );
     }
+    if (arg == '') {
+      throw new Error(
+        'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
+      );
+    }
     if (Object.prototype.toString.call(arg).includes('RegExp')) {
       arg = new RegExp(arg);
     }

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -420,7 +420,7 @@ module.exports.switchTo = async arg => {
     }
     if (arg.trim() == '') {
       throw new Error(
-        'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
+        'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex'
       );
     }
     if (Object.prototype.toString.call(arg).includes('RegExp')) {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -418,7 +418,7 @@ module.exports.switchTo = async arg => {
         'The "targetUrl" argument must be of type string or regex. Received type ' + typeof arg,
       );
     }
-    if (arg == '') {
+    if (arg.trim() == '') {
       throw new Error(
         'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
       );

--- a/test/unit-tests/switchTo.test.js
+++ b/test/unit-tests/switchTo.test.js
@@ -13,4 +13,10 @@ describe('switchTo', () => {
   it('should throw error if no url specified', async () => {
     await expect(taiko.switchTo()).to.eventually.rejectedWith(TypeError);
   });
+
+  it('should throw error if url is empty', async () => {
+    await expect(taiko.switchTo('')).to.eventually.rejectedWith(
+      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
+    );
+  });
 });

--- a/test/unit-tests/switchTo.test.js
+++ b/test/unit-tests/switchTo.test.js
@@ -22,7 +22,7 @@ describe('switchTo', () => {
 
   it('should throw error if url is only spaces', async () => {
     await expect(taiko.switchTo('  ')).to.eventually.rejectedWith(
-      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
+      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex'
     );
   });
 });

--- a/test/unit-tests/switchTo.test.js
+++ b/test/unit-tests/switchTo.test.js
@@ -16,7 +16,7 @@ describe('switchTo', () => {
 
   it('should throw error if url is empty', async () => {
     await expect(taiko.switchTo('')).to.eventually.rejectedWith(
-      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
+      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex'
     );
   });
 

--- a/test/unit-tests/switchTo.test.js
+++ b/test/unit-tests/switchTo.test.js
@@ -19,4 +19,10 @@ describe('switchTo', () => {
       'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
     );
   });
+
+  it('should throw error if url is only spaces', async () => {
+    await expect(taiko.switchTo('  ')).to.eventually.rejectedWith(
+      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex.',
+    );
+  });
 });


### PR DESCRIPTION
Raise an error with suggestion when an empty string is passed to the `switchTo` api.

```
> switchTo("")                                                                                                                               
 ✘ Error: Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex, run `.trace` for more info.       
```

Fixes #1057 