### PR TITLE
Remove duplicate runtime enable to fix switchTo

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -60,7 +60,6 @@ let chromeProcess,
   temporaryUserDataDir,
   page,
   network,
-  runtime,
   input,
   _client,
   dom,
@@ -103,7 +102,6 @@ const initCRIProperties = c => {
   clientProxy = getEventProxy(_client);
   page = c.Page;
   network = c.Network;
-  runtime = c.Runtime;
   input = c.Input;
   dom = c.DOM;
   overlay = c.Overlay;
@@ -121,7 +119,6 @@ const initCRI = async (target, n, options = {}) => {
     if (!options.window) {
       initCRIProperties(c);
       await Promise.all([
-        runtime.enable(),
         network.enable(),
         page.enable(),
         dom.enable(),
@@ -420,7 +417,7 @@ module.exports.switchTo = async arg => {
     }
     if (arg.trim() == '') {
       throw new Error(
-        'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex'
+        'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex',
       );
     }
     if (Object.prototype.toString.call(arg).includes('RegExp')) {

--- a/test/functional-tests/specs/browserActions.spec
+++ b/test/functional-tests/specs/browserActions.spec
@@ -3,8 +3,6 @@
 
 ## Switch To
 
-tags: knownIssue
-
 * Navigate to "http://localhost:3001/"
 * Click "Multiple Windows"
 * Assert page navigated to "/windows"

--- a/test/unit-tests/switchTo.test.js
+++ b/test/unit-tests/switchTo.test.js
@@ -16,13 +16,13 @@ describe('switchTo', () => {
 
   it('should throw error if url is empty', async () => {
     await expect(taiko.switchTo('')).to.eventually.rejectedWith(
-      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex'
+      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex',
     );
   });
 
   it('should throw error if url is only spaces', async () => {
     await expect(taiko.switchTo('  ')).to.eventually.rejectedWith(
-      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex'
+      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex',
     );
   });
 });


### PR DESCRIPTION
- since runtime domain is enabled in the runtimeHandler to listen for all executionContexts it need not be enabled again

Fixes #1063 
Fixes #939 