### PR TITLE
Fix waiting for loadEventFired

### DIFF
--- a/lib/doActionAwaitingNavigation.js
+++ b/lib/doActionAwaitingNavigation.js
@@ -1,6 +1,7 @@
-const { timeouts, wait } = require('./helper');
+const { timeouts, wait, waitUntil } = require('./helper');
 const networkHandler = require('./handlers/networkHandler');
 const pageHandler = require('./handlers/pageHandler');
+const runtimeHandler = require('./handlers/runtimeHandler');
 const { defaultConfig } = require('./config');
 const { eventHandler } = require('./eventBus');
 const { logEvent } = require('./logger');
@@ -24,14 +25,6 @@ const doActionAwaitingNavigation = async (options, action) => {
       );
     });
   } else {
-    if (options.isPageNavigationAction) {
-      promises.push(
-        new Promise(resolve => {
-          eventHandler.addListener('loadEventFired', resolve);
-          listenerCallbackMap['loadEventFired'] = resolve;
-        }),
-      );
-    }
     let func = addPromiseToWait(promises);
     listenerCallbackMap['xhrEvent'] = func;
     listenerCallbackMap['frameEvent'] = func;
@@ -44,10 +37,6 @@ const doActionAwaitingNavigation = async (options, action) => {
         new Promise(resolve => {
           eventHandler.addListener('targetNavigated', resolve);
           listenerCallbackMap['targetNavigated'] = resolve;
-        }),
-        new Promise(resolve => {
-          eventHandler.addListener('loadEventFired', resolve);
-          listenerCallbackMap['loadEventFired'] = resolve;
         }),
       ];
     };
@@ -114,12 +103,26 @@ const waitForPromises = (promises, waitForStart) => {
 const waitForNavigation = (timeout, promises = []) => {
   return new Promise((resolve, reject) => {
     Promise.all(promises)
-      .then(resolve)
+      .then(() => {
+        waitUntil(
+          async () => {
+            return (
+              (await runtimeHandler.runtimeEvaluate('document.readyState')).result.value ===
+              'complete'
+            );
+          },
+          defaultConfig.retryInterval,
+          defaultConfig.retryTimeout,
+        )
+          .then(resolve)
+          .catch(reject);
+      })
       .catch(reject);
     const timeoutId = setTimeout(() => reject('Timedout'), timeout);
     timeouts.push(timeoutId);
   });
 };
+
 module.exports = {
   doActionAwaitingNavigation,
 };

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -568,7 +568,6 @@ module.exports.openTab = async (
 ) => {
   validate();
   options = setNavigationOptions(options);
-  options.isPageNavigationAction = true;
   targetUrl = targetUrl ? targetUrl : 'about:blank';
 
   if (!/^https?:\/\//i.test(targetUrl) && !/^file/i.test(targetUrl)) {
@@ -629,7 +628,6 @@ module.exports.openWindow = async (url, options = {}) => {
   const targetId = await browserContext.createBrowserContext(url, options);
   await connect_to_cri(targetId);
   options = setNavigationOptions(options);
-  options.isPageNavigationAction = true;
   await doActionAwaitingNavigation(options, async () => {
     await pageHandler.handleNavigation(url);
   });
@@ -881,7 +879,6 @@ module.exports.goto = async (
     await network.setExtraHTTPHeaders({ headers: options.headers });
   }
   options = setNavigationOptions(options);
-  options.isPageNavigationAction = true;
   await doActionAwaitingNavigation(options, async () => {
     await pageHandler.handleNavigation(url);
   });
@@ -916,7 +913,6 @@ module.exports.reload = async (
   }
   validate();
   options = setNavigationOptions(options);
-  options.isPageNavigationAction = true;
   await doActionAwaitingNavigation(options, async () => {
     const value = options.ignoreCache || false;
     await page.reload({ ignoreCache: value });

--- a/test/unit-tests/goto.test.js
+++ b/test/unit-tests/goto.test.js
@@ -72,7 +72,6 @@ describe(test_name, () => {
       navigationTimeout: 30000,
       waitForNavigation: true,
       waitForStart: 100,
-      isPageNavigationAction: true,
     };
     await taiko.goto('example.com');
     expect(actualOptions).to.deep.equal(expectedOptions);

--- a/test/unit-tests/openTab.test.js
+++ b/test/unit-tests/openTab.test.js
@@ -52,7 +52,6 @@ describe('openTab', () => {
       navigationTimeout: 30000,
       waitForNavigation: true,
       waitForStart: 100,
-      isPageNavigationAction: true,
     };
     await taiko.openTab('example.com');
     expect(actualOptions).to.deep.equal(expectedOptions);


### PR DESCRIPTION
 - since in cases like new tab open `loadEventFired` can be missed before taiko makes a new connection wait for page's readyState to be complete rather