### PR TITLE
Replace babylon with @babel/parser

### DIFF
--- a/lib/repl/awaitEval.js
+++ b/lib/repl/awaitEval.js
@@ -1,7 +1,7 @@
 const os = require('os');
 const path = require('path');
 const recast = require('recast');
-const parser = require('babylon');
+const parser = require('@babel/parser');
 const history = require('./replHistory');
 const hFile = path.join(os.homedir(), '.taiko_repl_history');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -354,8 +354,7 @@
     "@babel/parser": {
       "version": "7.9.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-      "dev": true
+      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.8.3",
@@ -1841,11 +1840,6 @@
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
       "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
       "dev": true
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "bail": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "author": "getgauge",
   "license": "MIT",
   "dependencies": {
-    "babylon": "^6.18.0",
+    "@babel/parser": "^7.9.4",
     "chrome-remote-interface": "^0.28.1",
     "commander": "^5.0.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
`babylon` was renamed to `@babel/parser` since 7.x