### PR TITLE
Set up a redirect to list of devices

### DIFF
--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -118,7 +118,7 @@ if (isTaikoRunner(processArgv[1])) {
     .option('-w, --wait-time <time in ms>', 'runs script with provided delay\n', parseInt)
     .option(
       '--emulate-device <device>',
-      'Allows to simulate device viewport. Visit https://github.com/getgauge/taiko/blob/master/lib/devices.js for all the available devices\n',
+      'Allows to simulate device viewport. Visit https://docs.taiko.dev/devices for all the available devices\n',
       setupEmulateDevice,
     )
     .option(

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -574,7 +574,7 @@ module.exports.emulateNetwork = async (networkType) => {
  * @example
  * await emulateDevice('iPhone 6')
  *
- * @param {string} deviceModel - See [device model](https://github.com/getgauge/taiko/blob/master/lib/data/devices.js) for a list of all device models.
+ * @param {string} deviceModel - See [device model](https://docs.taiko.dev/devices) for a list of all device models.
  *
  * @returns {Promise}
  */

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "npm run doc"
+  publish = "docs/site"
+
+[[redirects]]
+  from = "/devices"
+  to = "https://github.com/getgauge/taiko/blob/master/lib/data/devices.js"


### PR DESCRIPTION
Fixes https://github.com/getgauge/taiko/issues/1196

This set's up a netlify redirect
for a readable link to list of devices.

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>