### PR TITLE
Type signature for `waitFor` with boolean condition

### DIFF
--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -503,5 +503,6 @@ export interface Response extends BasicResponse{
   // https://docs.taiko.dev/#waitfor
   export function waitFor(time: number): Promise<void>;
   export function waitFor(element: SearchElement, time: number): Promise<void>;
+  export function waitFor(condition: () => Promise<boolean>, time: number): Promise<void>;
   export function clearIntercept(requestUrl?: string): void;
 }

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -120,15 +120,15 @@ declare module 'taiko' {
   export interface MatchingOptions {
     exactMatch: boolean;
   }
-  
-  export interface BasicResponse {
-    url: string,
-    status: {code :number, text: string}
-}
 
-export interface Response extends BasicResponse{
-    redirectedResponse?: BasicResponse[]
-}
+  export interface BasicResponse {
+    url: string;
+    status: { code: number; text: string };
+  }
+
+  export interface Response extends BasicResponse {
+    redirectedResponse?: BasicResponse[];
+  }
 
   /**
    * Elements, Selectors and Searches


### PR DESCRIPTION
The [docs for waitFor](https://docs.taiko.dev/#waitfor) show an usage example with a boolean callback parameter, but the current type signature for the method doesn't support such a call. Calling `waitFor` passing a `() => Promise<boolean>` callback indeed works as depicted in the documentation.

This PR adds the missing type signature, plus some minor automatic linting fixes.