### PR TITLE
#1241  Fix closeBrowser issues

### DIFF
--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -24,7 +24,12 @@ async function exitOnUnhandledFailures(e) {
   if (!repl_mode) {
     console.error(e);
     if (taiko && (await taiko.client())) {
-      await taiko.closeBrowser();
+      try {
+        await taiko.closeBrowser();
+      } catch (error) {
+        console.error(error);
+        process.exit(1);
+      }
     }
     process.exit(1);
   }

--- a/lib/handlers/pageHandler.js
+++ b/lib/handlers/pageHandler.js
@@ -43,6 +43,10 @@ eventHandler.on('createdSession', async (client) => {
     logEvent('Lifecyle event: ' + p.name);
     eventHandler.emit(p.name, p);
   });
+  addJavascriptDialogOpeningListener();
+});
+
+const addJavascriptDialogOpeningListener = () => {
   page.javascriptDialogOpening(({ message, type, url }) => {
     const eventName = createJsDialogEventName(message, type);
     if (!eventHandler.listenerCount(eventName)) {
@@ -57,7 +61,7 @@ Please visit https://docs.taiko.dev/#${type} for more details`,
       type: type,
     });
   });
-});
+};
 
 const resetPromises = () => {
   frameNavigationPromise = {};
@@ -214,4 +218,5 @@ module.exports = {
   handleNavigation,
   resetPromises,
   captureScreenshot,
+  addJavascriptDialogOpeningListener
 };

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -408,6 +408,9 @@ const _closeBrowser = async () => {
   networkHandler.resetInterceptors();
   if (_client) {
     await reconnect();
+    // remove listeners other than JS dialog for beforeUnload on client first to stop executing them when closing
+    await _client.removeAllListeners();
+    pageHandler.addJavascriptDialogOpeningListener();
     await page.close();
     await new Promise((resolve) => {
       timeout = setTimeout(() => {
@@ -418,8 +421,8 @@ const _closeBrowser = async () => {
         resolve();
       });
     });
-    await _client.removeAllListeners();
     await _client.close();
+    clientProxy = null;
   }
   const waitForChromeToClose = new Promise((fulfill) => {
     chromeProcess.removeAllListeners();


### PR DESCRIPTION
- remove listeners on client before closing page and client to stop executing them while closing
- set clientproxy to null on closing browser which is returned by client() api
- catch error from closeBrowser on runner to avoid recursive action

Fixes #1241 

Signed-off-by: NivedhaSenthil <nivedhasenthil@gmail.com>