### PR TITLE
Reference type declarations in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "bin": {
     "taiko": "bin/taiko.js"
   },
+  "types": "./types/taiko/index.d.ts",
   "scripts": {
     "lint": "eslint --fix . --ext ts,tsx .",
     "doc": "documentation build lib/taiko.js -f md --shallow -o docs/index.md --markdown-toc=false && node docs/setup.js",


### PR DESCRIPTION
It makes type definitions to be correctly resolved by IDEs. Without, taiko has no discoverable typedefs.

See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package for further explanation.