### PR TITLE
Support for firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 # What’s Taiko?
 
-Taiko is a free and open source browser automation tool built by the team behind [Gauge](https://gauge.org/) from [ThoughtWorks](https://www.thoughtworks.com/). Taiko is a Node.js library with a clear and concise API to automate **Chromium based browsers**(Chrome, Microsoft Edge, Opera). Tests written in Taiko are highly readable and maintainable.
+Taiko is a free and open source browser automation tool built by the team behind [Gauge](https://gauge.org/) from [ThoughtWorks](https://www.thoughtworks.com/). Taiko is a Node.js library with a clear and concise API to automate **Chromium based browsers**(Chrome, Microsoft Edge, Opera) and Firefox. Tests written in Taiko are highly readable and maintainable.
 
 With Taiko it’s easy to
 
@@ -187,6 +187,21 @@ Install Gauge using npm and initialize an initialize and sample Taiko project us
     $ gauge init js
 
 Learn more about [Gauge](https://docs.gauge.org)!
+
+### Experimental Firefox Support
+
+#### To launch taiko with firefox:
+- Download and install [firefox nightly](https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly) 
+- Set `TAIKO_BROWSER_PATH` to firefox nightly's executable.
+
+Example: `TAIKO_BROWSER_PATH="/Applications/Firefoxnightly.app/Contents/MacOS/firefox" taiko`
+
+#### Known Issues for now:  
+- Highlighting element on action is set to false as overlay domain is not supported
+- openTab/closeTab does not work as expected since `New` is not available in firefox yet
+- Autofocus on first input field does not happen
+- file:// protocol does not emit events
+- waitFoNavigation does not wait for network calls and frame loads
 
 ### Experimental TypeScript Support
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,9 +9,10 @@ Taiko can be used to automate the latest versions of
 * Microsoft Edge
 * Opera (unverified)
 
+Experimental support for Firefox is available. Can be used against Nightly version of Firefox with some limitations.
+
 The following browsers are NOT supported
 
-* Firefox
 * Safari
 
 </details>

--- a/docs/layout/partials/header.html
+++ b/docs/layout/partials/header.html
@@ -387,7 +387,7 @@ openBrowser({args:<span class="hljs-string">['--window-size=1440,900']</span>}) 
 
 <section class="taiko-firefox-support">
   <h2 id="taiko-firefox-support">
-    Experiment Firefox support
+    Experimental Firefox support
   </h2>
   <p>To launch taiko with firefox:</p>
   <ul class="desc-list">

--- a/docs/layout/partials/header.html
+++ b/docs/layout/partials/header.html
@@ -3,7 +3,8 @@
   <p class="banner-text-container_desc">
     <a href="https://github.com/getgauge/taiko">Taiko</a> is a free and open source browser automation tool built by the
     team behind <a href="https://gauge.org">Gauge by ThoughtWorks</a>. It is a node library with a clear and concise API
-    to automate the chrome browser. Taiko uses the Chrome DevTools API and is built ground up to test modern web
+    to automate the chromium based browsers and Firefox. Taiko uses the Chrome DevTools Protocol and is built ground up
+    to test modern web
     applications.
   </p>
 </section>
@@ -42,11 +43,11 @@
     We built Taiko to make browser automation reliable. To fix the underlying problem behind ‘flaky tests’ and improve
     the browser automation experience, Taiko comes with an <a href="#interactive-recorder">interactive recorder</a> and
     a powerful API that provides
-    <ul class="desc-list">
-      <li><a href="#smart-selectors">Smart Selectors</a></li>
-      <li><a href="#xhr-dynamic-content">Ability to handle XHR and dynamic content</a></li>
-      <li><a href="#request-response">Request/Response stubbing and mocking</a></li>
-    </ul>
+  <ul class="desc-list">
+    <li><a href="#smart-selectors">Smart Selectors</a></li>
+    <li><a href="#xhr-dynamic-content">Ability to handle XHR and dynamic content</a></li>
+    <li><a href="#request-response">Request/Response stubbing and mocking</a></li>
+  </ul>
   </p>
 </section>
 
@@ -88,11 +89,11 @@ write(<span class="hljs-string">"taiko test automation"</span>)
 click(<span class="hljs-string">"Google Search"</span>)</code></pre>
     </div>
     <p>These commands get the browser to
-      <ul class="desc-list">
-        <li>go to Google’s home page, </li>
-        <li>type the text "taiko test automation" and then </li>
-        <li>click on the "Google Search" button.</li>
-      </ul>
+    <ul class="desc-list">
+      <li>go to Google’s home page, </li>
+      <li>type the text "taiko test automation" and then </li>
+      <li>click on the "Google Search" button.</li>
+    </ul>
     </p>
     <p>You can see the browser performing these actions as you type and press enter for each command.
     </p>
@@ -374,12 +375,27 @@ openBrowser({args:<span class="hljs-string">['--window-size=1440,900']</span>}) 
       action</li>
     <li><span class="highlight">TAIKO_CHROMIUM_URL</span> - set to host url of mirror to download chromium </li>
     <li><span class="highlight">TAIKO_BROWSER_PATH</span> - set to launch browser from different location</li>
-    <li><span class="highlight">TAIKO_BROWSER_ARGS</span> - set ',' separated browser command line switches to launch browser with extra args</li>
+    <li><span class="highlight">TAIKO_BROWSER_ARGS</span> - set ',' separated browser command line switches to launch
+      browser with extra args</li>
     <li><span class="highlight">TAIKO_EMULATE_DEVICE</span> - set to device model to emulate device view port</li>
     <li><span class="highlight">TAIKO_EMULATE_NETWORK</span> - set to the network type for Taiko to simulate. Available
       options are GPRS, Regular2G, Good2G, Regular3G, Good3G, Regular4G, DSL, WiFi, Offline</li>
     <li><span class="highlight">TAIKO_PLUGIN</span> - set to the plugin which you want Taiko to load. Takes comma
       separated values.</li>
+  </ul>
+</section>
+
+<section class="taiko-firefox-support">
+  <h2 id="taiko-firefox-support">
+    Experiment Firefox support
+  </h2>
+  <p>To launch taiko with firefox:</p>
+  <ul class="desc-list">
+  <li>Download and install <a href="https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly">firefox
+      nightly</a></li>
+  <li>Set <span class="highlight">TAIKO_BROWSER_PATH</span> to firefox nightly's executable.</li>
+  Example: <span class="highlight">TAIKO_BROWSER_PATH="/Applications/Firefoxnightly.app/Contents/MacOS/firefox"
+    taiko</span>
   </ul>
 </section>
 

--- a/lib/browserFetcher.js
+++ b/lib/browserFetcher.js
@@ -40,10 +40,10 @@ const downloadURLs = {
   win64: '%s/chromium-browser-snapshots/Win_x64/%d/%s.zip',
 };
 
-const readdirAsync = helper.promisify(fs.readdir.bind(fs));
-const mkdirAsync = helper.promisify(fs.mkdir.bind(fs));
-const unlinkAsync = helper.promisify(fs.unlink.bind(fs));
-const chmodAsync = helper.promisify(fs.chmod.bind(fs));
+const readdirAsync = util.promisify(fs.readdir.bind(fs));
+const mkdirAsync = util.promisify(fs.mkdir.bind(fs));
+const unlinkAsync = util.promisify(fs.unlink.bind(fs));
+const chmodAsync = util.promisify(fs.chmod.bind(fs));
 
 function existsAsync(filePath) {
   let fulfill = null;

--- a/lib/browserFetcher.js
+++ b/lib/browserFetcher.js
@@ -230,17 +230,17 @@ class BrowserFetcher {
     return executablePath;
   }
 
-  waitForWSEndpoint(chromeProcess, timeout) {
+  waitForWSEndpoint(browserProcess, timeout) {
     return new Promise((resolve, reject) => {
       const rl = readline.createInterface({
-        input: chromeProcess.stderr,
+        input: browserProcess.stderr,
       });
       let stderr = '';
       const listeners = [
         helper.addEventListener(rl, 'line', onLine),
         helper.addEventListener(rl, 'close', () => onClose()),
-        helper.addEventListener(chromeProcess, 'exit', () => onClose()),
-        helper.addEventListener(chromeProcess, 'error', (error) => onClose(error)),
+        helper.addEventListener(browserProcess, 'exit', () => onClose()),
+        helper.addEventListener(browserProcess, 'error', (error) => onClose(error)),
       ];
       const timeoutId = timeout ? setTimeout(onTimeout, timeout) : 0;
 
@@ -251,14 +251,14 @@ class BrowserFetcher {
         cleanup();
         reject(
           new Error(
-            'Failed to launch chrome!' + (error ? ' ' + error.message : '') + '\n' + stderr,
+            'Failed to launch browser!' + (error ? ' ' + error.message : '') + '\n' + stderr,
           ),
         );
       }
 
       function onTimeout() {
         cleanup();
-        reject(new Error(`Timed out after ${timeout} ms while trying to connect to Chrome!`));
+        reject(new Error(`Timed out after ${timeout} ms while trying to connect to Browser!`));
       }
 
       /**

--- a/lib/browserLauncher.js
+++ b/lib/browserLauncher.js
@@ -1,11 +1,261 @@
 const path = require('path');
 const fs = require('fs-extra');
+const os = require('os');
 const childProcess = require('child_process');
 const { setBrowserOptions, defaultConfig } = require('./config');
 const { eventHandler } = require('./eventBus');
+const util = require('util');
+const mkdtempAsync = util.promisify(fs.mkdtemp);
+const writeFileAsync = util.promisify(fs.writeFile);
 let temporaryUserDataDir, chromeProcess;
 
 async function setBrowserArgs(options) {
+  return defaultConfig.firefox ? setFirefoxBrowserArgs(options) : setChromeBrowserArgs(options);
+}
+
+function updateArgsFromOptions(args, options) {
+  args = options.args ? args.concat(options.args) : args;
+  args = process.env.TAIKO_BROWSER_ARGS
+    ? args.concat(
+        process.env.TAIKO_BROWSER_ARGS.split(/\s*,?\s*--/)
+          .filter((arg) => arg !== '')
+          .map((arg) => `--${arg}`),
+      )
+    : args;
+  return args;
+}
+
+function setHeadlessArgs(args, options) {
+  if (options.headless) {
+    args.push('--headless');
+    if (!args.some((arg) => arg.startsWith('--window-size'))) {
+      args.push('--window-size=1440,900');
+    }
+  }
+}
+
+async function createProfile(extraPrefs) {
+  const profilePath = await mkdtempAsync(path.join(os.tmpdir(), 'taiko_dev_firefox_profile-'));
+  const prefsJS = [];
+  const userJS = [];
+  const server = 'dummy.test';
+  const defaultPreferences = {
+    // Make sure Shield doesn't hit the network.
+    'app.normandy.api_url': '',
+    // Disable Firefox old build background check
+    'app.update.checkInstallTime': false,
+    // Disable automatically upgrading Firefox
+    'app.update.disabledForTesting': true,
+
+    // Increase the APZ content response timeout to 1 minute
+    'apz.content_response_timeout': 60000,
+
+    // Prevent various error message on the console
+    // jest-puppeteer asserts that no error message is emitted by the console
+    'browser.contentblocking.features.standard': '-tp,tpPrivate,cookieBehavior0,-cm,-fp',
+
+    // Enable the dump function: which sends messages to the system
+    // console
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1543115
+    'browser.dom.window.dump.enabled': true,
+    // Disable topstories
+    'browser.newtabpage.activity-stream.feeds.section.topstories': false,
+    // Always display a blank page
+    'browser.newtabpage.enabled': false,
+    // Background thumbnails in particular cause grief: and disabling
+    // thumbnails in general cannot hurt
+    'browser.pagethumbnails.capturing_disabled': true,
+
+    // Disable safebrowsing components.
+    'browser.safebrowsing.blockedURIs.enabled': false,
+    'browser.safebrowsing.downloads.enabled': false,
+    'browser.safebrowsing.malware.enabled': false,
+    'browser.safebrowsing.passwords.enabled': false,
+    'browser.safebrowsing.phishing.enabled': false,
+
+    // Disable updates to search engines.
+    'browser.search.update': false,
+    // Do not restore the last open set of tabs if the browser has crashed
+    'browser.sessionstore.resume_from_crash': false,
+    // Skip check for default browser on startup
+    'browser.shell.checkDefaultBrowser': false,
+
+    // Disable newtabpage
+    'browser.startup.homepage': 'about:blank',
+    // Do not redirect user when a milstone upgrade of Firefox is detected
+    'browser.startup.homepage_override.mstone': 'ignore',
+    // Start with a blank page about:blank
+    'browser.startup.page': 0,
+
+    // Do not allow background tabs to be zombified on Android: otherwise for
+    // tests that open additional tabs: the test harness tab itself might get
+    // unloaded
+    'browser.tabs.disableBackgroundZombification': false,
+    // Do not warn when closing all other open tabs
+    'browser.tabs.warnOnCloseOtherTabs': false,
+    // Do not warn when multiple tabs will be opened
+    'browser.tabs.warnOnOpen': false,
+
+    // Disable the UI tour.
+    'browser.uitour.enabled': false,
+    // Turn off search suggestions in the location bar so as not to trigger
+    // network connections.
+    'browser.urlbar.suggest.searches': false,
+    // Disable first run splash page on Windows 10
+    'browser.usedOnWindows10.introURL': '',
+    // Do not warn on quitting Firefox
+    'browser.warnOnQuit': false,
+
+    // Do not show datareporting policy notifications which can
+    // interfere with tests
+    'datareporting.healthreport.about.reportUrl': `http://${server}/dummy/abouthealthreport/`,
+    'datareporting.healthreport.documentServerURI': `http://${server}/dummy/healthreport/`,
+    'datareporting.healthreport.logging.consoleEnabled': false,
+    'datareporting.healthreport.service.enabled': false,
+    'datareporting.healthreport.service.firstRun': false,
+    'datareporting.healthreport.uploadEnabled': false,
+    'datareporting.policy.dataSubmissionEnabled': false,
+    'datareporting.policy.dataSubmissionPolicyAccepted': false,
+    'datareporting.policy.dataSubmissionPolicyBypassNotification': true,
+
+    // DevTools JSONViewer sometimes fails to load dependencies with its require.js.
+    // This doesn't affect Puppeteer but spams console (Bug 1424372)
+    'devtools.jsonview.enabled': false,
+
+    // Disable popup-blocker
+    'dom.disable_open_during_load': false,
+
+    // Enable the support for File object creation in the content process
+    // Required for |Page.setFileInputFiles| protocol method.
+    'dom.file.createInChild': true,
+
+    // Disable the ProcessHangMonitor
+    'dom.ipc.reportProcessHangs': false,
+
+    // Disable slow script dialogues
+    'dom.max_chrome_script_run_time': 0,
+    'dom.max_script_run_time': 0,
+
+    // Only load extensions from the application and user profile
+    // AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
+    'extensions.autoDisableScopes': 0,
+    'extensions.enabledScopes': 5,
+
+    // Disable metadata caching for installed add-ons by default
+    'extensions.getAddons.cache.enabled': false,
+
+    // Disable installing any distribution extensions or add-ons.
+    'extensions.installDistroAddons': false,
+
+    // Disabled screenshots extension
+    'extensions.screenshots.disabled': true,
+
+    // Turn off extension updates so they do not bother tests
+    'extensions.update.enabled': false,
+
+    // Turn off extension updates so they do not bother tests
+    'extensions.update.notifyUser': false,
+
+    // Make sure opening about:addons will not hit the network
+    'extensions.webservice.discoverURL': `http://${server}/dummy/discoveryURL`,
+
+    // Allow the application to have focus even it runs in the background
+    'focusmanager.testmode': true,
+    // Disable useragent updates
+    'general.useragent.updates.enabled': false,
+    // Always use network provider for geolocation tests so we bypass the
+    // macOS dialog raised by the corelocation provider
+    'geo.provider.testing': true,
+    // Do not scan Wifi
+    'geo.wifi.scan': false,
+    // No hang monitor
+    'hangmonitor.timeout': 0,
+    // Show chrome errors and warnings in the error console
+    'javascript.options.showInConsole': true,
+
+    // Disable download and usage of OpenH264: and Widevine plugins
+    'media.gmp-manager.updateEnabled': false,
+    // Prevent various error message on the console
+    // jest-puppeteer asserts that no error message is emitted by the console
+    'network.cookie.cookieBehavior': 0,
+
+    // Do not prompt for temporary redirects
+    'network.http.prompt-temp-redirect': false,
+
+    // Disable speculative connections so they are not reported as leaking
+    // when they are hanging around
+    'network.http.speculative-parallel-limit': 0,
+
+    // Do not automatically switch between offline and online
+    'network.manage-offline-status': false,
+
+    // Make sure SNTP requests do not hit the network
+    'network.sntp.pools': server,
+
+    // Disable Flash.
+    'plugin.state.flash': 0,
+
+    'privacy.trackingprotection.enabled': false,
+
+    // Enable Remote Agent
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1544393
+    'remote.enabled': true,
+
+    // Don't do network connections for mitm priming
+    'security.certerrors.mitm.priming.enabled': false,
+    // Local documents have access to all other local documents,
+    // including directory listings
+    'security.fileuri.strict_origin_policy': false,
+    // Do not wait for the notification button security delay
+    'security.notification_enable_delay': 0,
+
+    // Ensure blocklist updates do not hit the network
+    'services.settings.server': `http://${server}/dummy/blocklist/`,
+
+    // Do not automatically fill sign-in forms with known usernames and
+    // passwords
+    'signon.autofillForms': false,
+    // Disable password capture, so that tests that include forms are not
+    // influenced by the presence of the persistent doorhanger notification
+    'signon.rememberSignons': false,
+
+    // Disable first-run welcome page
+    'startup.homepage_welcome_url': 'about:blank',
+
+    // Disable first-run welcome page
+    'startup.homepage_welcome_url.additional': '',
+
+    // Disable browser animations (tabs, fullscreen, sliding alerts)
+    'toolkit.cosmeticAnimations.enabled': false,
+
+    // We want to collect telemetry, but we don't want to send in the results
+    'toolkit.telemetry.server': `https://${server}/dummy/telemetry/`,
+    // Prevent starting into safe mode after application crashes
+    'toolkit.startup.max_resumed_crashes': -1,
+  };
+
+  Object.assign(defaultPreferences, extraPrefs);
+  for (const [key, value] of Object.entries(defaultPreferences)) {
+    userJS.push(`user_pref(${JSON.stringify(key)}, ${JSON.stringify(value)});`);
+  }
+  await writeFileAsync(path.join(profilePath, 'user.js'), userJS.join('\n'));
+  await writeFileAsync(path.join(profilePath, 'prefs.js'), prefsJS.join('\n'));
+  return profilePath;
+}
+
+async function setFirefoxBrowserArgs(options) {
+  let args = ['--no-remote', '--foreground', 'about:blank', '--remote-debugging-port=0'];
+  args = updateArgsFromOptions(args, options);
+  setHeadlessArgs(args, options);
+  if (!args.includes('-profile') && !args.includes('--profile')) {
+    temporaryUserDataDir = await createProfile(options.extraPrefsFirefox);
+    args.push('--profile');
+    args.push(temporaryUserDataDir);
+  }
+  return args;
+}
+
+async function setChromeBrowserArgs(options) {
   let args = [
     `--remote-debugging-port=${options.port}`,
     '--disable-features=site-per-process,TranslateUI',
@@ -27,26 +277,14 @@ async function setBrowserArgs(options) {
     '--disable-notifications',
     'about:blank',
   ];
-  args = options.args ? args.concat(options.args) : args;
-  args = process.env.TAIKO_BROWSER_ARGS
-    ? args.concat(
-        process.env.TAIKO_BROWSER_ARGS.split(/\s*,?\s*--/)
-          .filter((arg) => arg !== '')
-          .map((arg) => `--${arg}`),
-      )
-    : args;
+  args = updateArgsFromOptions(args, options);
   if (!args.some((arg) => arg.startsWith('--user-data-dir'))) {
     const os = require('os');
     const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'taiko_dev_profile-');
-    temporaryUserDataDir = await fs.mkdtemp(CHROME_PROFILE_PATH);
+    temporaryUserDataDir = await mkdtempAsync(CHROME_PROFILE_PATH);
     args.push(`--user-data-dir=${temporaryUserDataDir}`);
   }
-  if (options.headless) {
-    args.push('--headless');
-    if (!args.some((arg) => arg.startsWith('--window-size'))) {
-      args.push('--window-size=1440,900');
-    }
-  }
+  setHeadlessArgs(args, options);
   return args;
 }
 

--- a/lib/browserLauncher.js
+++ b/lib/browserLauncher.js
@@ -7,7 +7,7 @@ const { eventHandler } = require('./eventBus');
 const util = require('util');
 const mkdtempAsync = util.promisify(fs.mkdtemp);
 const writeFileAsync = util.promisify(fs.writeFile);
-let temporaryUserDataDir, chromeProcess;
+let temporaryUserDataDir, browserProcess;
 
 async function setBrowserArgs(options) {
   return defaultConfig.firefox ? setFirefoxBrowserArgs(options) : setChromeBrowserArgs(options);
@@ -288,50 +288,50 @@ async function setChromeBrowserArgs(options) {
   return args;
 }
 
-function errorMessageForChromeProcessCrash() {
+function errorMessageForBrowserProcessCrash() {
   let message;
   if (!hasChromeProcessKilled()) {
     return;
   }
-  if (chromeProcess.exitCode === 0) {
+  if (browserProcess.exitCode === 0) {
     throw new Error(
       'The Browser instance was closed either via `closeBrowser()` call, or it exited for reasons unknown to Taiko. You can try launching a fresh instance using `openBrowser()` or inspect the logs for details of the possible crash.',
     );
   }
-  if (chromeProcess.exitCode === null) {
-    message = `Chrome process with pid ${chromeProcess.pid} exited with signal ${chromeProcess.signalCode}.`;
+  if (browserProcess.exitCode === null) {
+    message = `Chrome process with pid ${browserProcess.pid} exited with signal ${browserProcess.signalCode}.`;
   } else {
-    message = `Chrome process with pid ${chromeProcess.pid} exited with status code ${chromeProcess.exitCode}.`;
+    message = `Chrome process with pid ${browserProcess.pid} exited with status code ${browserProcess.exitCode}.`;
   }
   return message;
 }
 
 const browserExitEventHandler = () => {
-  chromeProcess.killed = true;
-  eventHandler.emit('browserCrashed', new Error(errorMessageForChromeProcessCrash()));
+  browserProcess.killed = true;
+  eventHandler.emit('browserCrashed', new Error(errorMessageForBrowserProcessCrash()));
 };
 
 function hasChromeProcessKilled() {
-  return chromeProcess && chromeProcess.killed;
+  return browserProcess && browserProcess.killed;
 }
 
-const launchChrome = async (options) => {
-  if (chromeProcess && !chromeProcess.killed) {
-    throw new Error('OpenBrowser cannot be called again as there is a chromium instance open.');
+const launchBrowser = async (options) => {
+  if (browserProcess && !browserProcess.killed) {
+    throw new Error('openBrowser cannot be called again as there is a browser instance open.');
   }
   const BrowserFetcher = require('./browserFetcher');
   const browserFetcher = new BrowserFetcher();
   const chromeExecutable = browserFetcher.getExecutablePath();
   options = setBrowserOptions(options);
   let args = await setBrowserArgs(options);
-  chromeProcess = await childProcess.spawn(chromeExecutable, args);
+  browserProcess = await childProcess.spawn(chromeExecutable, args);
   if (options.dumpio) {
-    chromeProcess.stderr.pipe(process.stderr);
-    chromeProcess.stdout.pipe(process.stdout);
+    browserProcess.stderr.pipe(process.stderr);
+    browserProcess.stdout.pipe(process.stdout);
   }
-  chromeProcess.once('exit', browserExitEventHandler);
+  browserProcess.once('exit', browserExitEventHandler);
   const endpoint = await browserFetcher.waitForWSEndpoint(
-    chromeProcess,
+    browserProcess,
     defaultConfig.navigationTimeout,
   );
   return {
@@ -341,23 +341,23 @@ const launchChrome = async (options) => {
   };
 };
 
-const closeChrome = async () => {
+const closeBrowser = async () => {
   let timeout;
   const waitForChromeToClose = new Promise((fulfill) => {
-    chromeProcess.removeAllListeners();
-    chromeProcess.once('exit', () => {
+    browserProcess.removeAllListeners();
+    browserProcess.once('exit', () => {
       fulfill();
     });
-    if (chromeProcess.killed) {
+    if (browserProcess.killed) {
       fulfill();
     }
     timeout = setTimeout(() => {
       fulfill();
-      chromeProcess.removeAllListeners();
-      chromeProcess.kill('SIGKILL');
+      browserProcess.removeAllListeners();
+      browserProcess.kill('SIGKILL');
     }, defaultConfig.retryTimeout);
   });
-  chromeProcess.kill('SIGTERM');
+  browserProcess.kill('SIGTERM');
   await waitForChromeToClose;
   clearTimeout(timeout);
   if (temporaryUserDataDir) {
@@ -367,4 +367,8 @@ const closeChrome = async () => {
   }
 };
 
-module.exports = { launchChrome, closeChrome, errorMessageForChromeProcessCrash };
+module.exports = {
+  launchBrowser,
+  closeBrowser,
+  errorMessageForBrowserProcessCrash,
+};

--- a/lib/browserLauncher.js
+++ b/lib/browserLauncher.js
@@ -1,0 +1,132 @@
+const path = require('path');
+const fs = require('fs-extra');
+const childProcess = require('child_process');
+const { setBrowserOptions, defaultConfig } = require('./config');
+const { eventHandler } = require('./eventBus');
+let temporaryUserDataDir, chromeProcess;
+
+async function setBrowserArgs(options) {
+  let args = [
+    `--remote-debugging-port=${options.port}`,
+    '--disable-features=site-per-process,TranslateUI',
+    '--enable-features=NetworkService,NetworkServiceInProcess',
+    '--disable-renderer-backgrounding',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-background-timer-throttling',
+    '--disable-background-networking',
+    '--disable-breakpad',
+    '--disable-default-apps',
+    '--disable-hang-monitor',
+    '--disable-prompt-on-repost',
+    '--disable-sync',
+    '--force-color-profile=srgb',
+    '--safebrowsing-disable-auto-update',
+    '--password-store=basic',
+    '--use-mock-keychain',
+    '--enable-automation',
+    '--disable-notifications',
+    'about:blank',
+  ];
+  args = options.args ? args.concat(options.args) : args;
+  args = process.env.TAIKO_BROWSER_ARGS
+    ? args.concat(
+        process.env.TAIKO_BROWSER_ARGS.split(/\s*,?\s*--/)
+          .filter((arg) => arg !== '')
+          .map((arg) => `--${arg}`),
+      )
+    : args;
+  if (!args.some((arg) => arg.startsWith('--user-data-dir'))) {
+    const os = require('os');
+    const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'taiko_dev_profile-');
+    temporaryUserDataDir = await fs.mkdtemp(CHROME_PROFILE_PATH);
+    args.push(`--user-data-dir=${temporaryUserDataDir}`);
+  }
+  if (options.headless) {
+    args.push('--headless');
+    if (!args.some((arg) => arg.startsWith('--window-size'))) {
+      args.push('--window-size=1440,900');
+    }
+  }
+  return args;
+}
+
+function errorMessageForChromeProcessCrash() {
+  let message;
+  if (!hasChromeProcessKilled()) {
+    return;
+  }
+  if (chromeProcess.exitCode === 0) {
+    throw new Error(
+      'The Browser instance was closed either via `closeBrowser()` call, or it exited for reasons unknown to Taiko. You can try launching a fresh instance using `openBrowser()` or inspect the logs for details of the possible crash.',
+    );
+  }
+  if (chromeProcess.exitCode === null) {
+    message = `Chrome process with pid ${chromeProcess.pid} exited with signal ${chromeProcess.signalCode}.`;
+  } else {
+    message = `Chrome process with pid ${chromeProcess.pid} exited with status code ${chromeProcess.exitCode}.`;
+  }
+  return message;
+}
+
+const browserExitEventHandler = () => {
+  chromeProcess.killed = true;
+  eventHandler.emit('browserCrashed', new Error(errorMessageForChromeProcessCrash()));
+};
+
+function hasChromeProcessKilled() {
+  return chromeProcess && chromeProcess.killed;
+}
+
+const launchChrome = async (options) => {
+  if (chromeProcess && !chromeProcess.killed) {
+    throw new Error('OpenBrowser cannot be called again as there is a chromium instance open.');
+  }
+  const BrowserFetcher = require('./browserFetcher');
+  const browserFetcher = new BrowserFetcher();
+  const chromeExecutable = browserFetcher.getExecutablePath();
+  options = setBrowserOptions(options);
+  let args = await setBrowserArgs(options);
+  chromeProcess = await childProcess.spawn(chromeExecutable, args);
+  if (options.dumpio) {
+    chromeProcess.stderr.pipe(process.stderr);
+    chromeProcess.stdout.pipe(process.stdout);
+  }
+  chromeProcess.once('exit', browserExitEventHandler);
+  const endpoint = await browserFetcher.waitForWSEndpoint(
+    chromeProcess,
+    defaultConfig.navigationTimeout,
+  );
+  return {
+    currentHost: endpoint.host,
+    currentPort: endpoint.port,
+    browserDebugUrl: endpoint.browser,
+  };
+};
+
+const closeChrome = async () => {
+  let timeout;
+  const waitForChromeToClose = new Promise((fulfill) => {
+    chromeProcess.removeAllListeners();
+    chromeProcess.once('exit', () => {
+      fulfill();
+    });
+    if (chromeProcess.killed) {
+      fulfill();
+    }
+    timeout = setTimeout(() => {
+      fulfill();
+      chromeProcess.removeAllListeners();
+      chromeProcess.kill('SIGKILL');
+    }, defaultConfig.retryTimeout);
+  });
+  chromeProcess.kill('SIGTERM');
+  await waitForChromeToClose;
+  clearTimeout(timeout);
+  if (temporaryUserDataDir) {
+    try {
+      fs.removeSync(temporaryUserDataDir);
+    } catch (e) {}
+  }
+};
+
+module.exports = { launchChrome, closeChrome, errorMessageForChromeProcessCrash };

--- a/lib/browserLauncher.js
+++ b/lib/browserLauncher.js
@@ -290,7 +290,7 @@ async function setChromeBrowserArgs(options) {
 
 function errorMessageForBrowserProcessCrash() {
   let message;
-  if (!hasChromeProcessKilled()) {
+  if (!hasBrowserProcessKilled()) {
     return;
   }
   if (browserProcess.exitCode === 0) {
@@ -299,9 +299,9 @@ function errorMessageForBrowserProcessCrash() {
     );
   }
   if (browserProcess.exitCode === null) {
-    message = `Chrome process with pid ${browserProcess.pid} exited with signal ${browserProcess.signalCode}.`;
+    message = `Browser process with pid ${browserProcess.pid} exited with signal ${browserProcess.signalCode}.`;
   } else {
-    message = `Chrome process with pid ${browserProcess.pid} exited with status code ${browserProcess.exitCode}.`;
+    message = `Browser process with pid ${browserProcess.pid} exited with status code ${browserProcess.exitCode}.`;
   }
   return message;
 }
@@ -311,7 +311,7 @@ const browserExitEventHandler = () => {
   eventHandler.emit('browserCrashed', new Error(errorMessageForBrowserProcessCrash()));
 };
 
-function hasChromeProcessKilled() {
+function hasBrowserProcessKilled() {
   return browserProcess && browserProcess.killed;
 }
 
@@ -321,10 +321,10 @@ const launchBrowser = async (options) => {
   }
   const BrowserFetcher = require('./browserFetcher');
   const browserFetcher = new BrowserFetcher();
-  const chromeExecutable = browserFetcher.getExecutablePath();
+  const browserExecutable = browserFetcher.getExecutablePath();
   options = setBrowserOptions(options);
   let args = await setBrowserArgs(options);
-  browserProcess = await childProcess.spawn(chromeExecutable, args);
+  browserProcess = await childProcess.spawn(browserExecutable, args);
   if (options.dumpio) {
     browserProcess.stderr.pipe(process.stderr);
     browserProcess.stdout.pipe(process.stdout);
@@ -343,7 +343,7 @@ const launchBrowser = async (options) => {
 
 const closeBrowser = async () => {
   let timeout;
-  const waitForChromeToClose = new Promise((fulfill) => {
+  const waitForBrowserToClose = new Promise((fulfill) => {
     browserProcess.removeAllListeners();
     browserProcess.once('exit', () => {
       fulfill();
@@ -358,7 +358,7 @@ const closeBrowser = async () => {
     }, defaultConfig.retryTimeout);
   });
   browserProcess.kill('SIGTERM');
-  await waitForChromeToClose;
+  await waitForBrowserToClose;
   clearTimeout(timeout);
   if (temporaryUserDataDir) {
     try {

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,10 +10,10 @@ const defaultConfig = {
   criConnectionRetries: process.env.TAIKO_CRI_CONNECTION_RETRIES || 50,
   firefox: process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox'),
   highlightOnAction:
-    !(process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox')) &&
-    (process.env.TAIKO_HIGHLIGHT_ON_ACTION || 'true'),
+    process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox')
+      ? 'false'
+      : process.env.TAIKO_HIGHLIGHT_ON_ACTION || 'true',
 };
-
 const setConfig = (options) => {
   for (const key in options) {
     if (Object.prototype.hasOwnProperty.call(defaultConfig, key)) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,10 @@ const defaultConfig = {
   ignoreSSLErrors: false,
   headful: false,
   criConnectionRetries: process.env.TAIKO_CRI_CONNECTION_RETRIES || 50,
-  highlightOnAction: process.env.TAIKO_HIGHLIGHT_ON_ACTION || 'true',
+  firefox: process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox'),
+  highlightOnAction:
+    !(process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox')) &&
+    (process.env.TAIKO_HIGHLIGHT_ON_ACTION || 'true'),
 };
 
 const setConfig = (options) => {

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,8 @@ const defaultConfig = {
   ignoreSSLErrors: false,
   headful: false,
   criConnectionRetries: process.env.TAIKO_CRI_CONNECTION_RETRIES || 50,
-  firefox: process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox'),
+  firefox:
+    (process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox')) || false,
   highlightOnAction:
     process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox')
       ? 'false'

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,9 +9,12 @@ const defaultConfig = {
   headful: false,
   criConnectionRetries: process.env.TAIKO_CRI_CONNECTION_RETRIES || 50,
   firefox:
-    (process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox')) || false,
+    (process.env.TAIKO_BROWSER_PATH &&
+      process.env.TAIKO_BROWSER_PATH.toLowerCase().includes('firefox')) ||
+    false,
   highlightOnAction:
-    process.env.TAIKO_BROWSER_PATH && process.env.TAIKO_BROWSER_PATH.includes('firefox')
+    process.env.TAIKO_BROWSER_PATH &&
+    process.env.TAIKO_BROWSER_PATH.toLowerCase().includes('firefox')
       ? 'false'
       : process.env.TAIKO_HIGHLIGHT_ON_ACTION || 'true',
 };

--- a/lib/doActionAwaitingNavigation.js
+++ b/lib/doActionAwaitingNavigation.js
@@ -25,13 +25,15 @@ const doActionAwaitingNavigation = async (options, action) => {
       );
     });
   } else {
-    let func = addPromiseToWait(promises);
-    listenerCallbackMap['xhrEvent'] = func;
-    listenerCallbackMap['frameEvent'] = func;
-    listenerCallbackMap['frameNavigationEvent'] = func;
-    eventHandler.addListener('xhrEvent', func);
-    eventHandler.addListener('frameEvent', func);
-    eventHandler.addListener('frameNavigationEvent', func);
+    if (!defaultConfig.firefox) {
+      let func = addPromiseToWait(promises);
+      listenerCallbackMap['xhrEvent'] = func;
+      listenerCallbackMap['frameEvent'] = func;
+      listenerCallbackMap['frameNavigationEvent'] = func;
+      eventHandler.addListener('xhrEvent', func);
+      eventHandler.addListener('frameEvent', func);
+      eventHandler.addListener('frameNavigationEvent', func);
+    }
     const waitForTargetCreated = () => {
       promises = [
         new Promise((resolve) => {

--- a/lib/handlers/domHandler.js
+++ b/lib/handlers/domHandler.js
@@ -18,6 +18,7 @@
  */
 const { eventHandler } = require('../eventBus');
 const { isElement } = require('../helper');
+const { defaultConfig } = require('../config');
 let dom;
 
 const createdSessionListener = (client) => {
@@ -63,11 +64,23 @@ async function assertBoundingBox(e) {
 }
 
 async function getBoxModel(e) {
-  return await dom
+  let result;
+  result = await dom
     .getBoxModel({
       objectId: isElement(e) ? e.objectId : e,
     })
-    .catch();
+    .catch(async (error) => {
+      if (defaultConfig.firefox) {
+        result = await dom.getContentQuads({
+          objectId: isElement(e) ? e.objectId : e,
+        });
+        result = { model: { border: result.quads[0] } };
+        return result;
+      } else {
+        throw error;
+      }
+    });
+  return result;
 }
 
 async function getBoundingClientRect(e) {

--- a/lib/handlers/networkHandler.js
+++ b/lib/handlers/networkHandler.js
@@ -1,6 +1,7 @@
 const { isFunction, isString, isObject } = require('../helper');
 const { eventHandler } = require('../eventBus');
 const { logEvent } = require('../logger');
+const { defaultConfig } = require('../config');
 const networkPresets = require('../data/networkConditions');
 let requestPromises;
 const defaultErrorReason = 'Failed';
@@ -29,7 +30,9 @@ const resetPromises = () => {
 
 const registerInterceptHandler = () => {
   network.setCacheDisabled({ cacheDisabled: true });
-  network.setRequestInterception({ patterns: [{ urlPattern: '*' }] });
+  if (!defaultConfig.firefox) {
+    network.setRequestInterception({ patterns: [{ urlPattern: '*' }] });
+  }
   network.requestIntercepted(handleInterceptor);
 };
 

--- a/lib/handlers/runtimeHandler.js
+++ b/lib/handlers/runtimeHandler.js
@@ -100,9 +100,17 @@ const runtimeCallFunctionOn = async (exp, executionContextId, opt = {}) => {
     }
   }
   if (
-    runtimeResult &&
-    runtimeResult.result.subtype === 'error' &&
-    runtimeResult.result.description.includes('TypeError: window[arg.funcName] is not a function')
+    (runtimeResult &&
+      runtimeResult.result &&
+      runtimeResult.result.subtype === 'error' &&
+      runtimeResult.result.description.includes(
+        'TypeError: window[arg.funcName] is not a function',
+      )) ||
+    (runtimeResult &&
+      runtimeResult.exceptionDetails &&
+      runtimeResult.exceptionDetails.text.includes(
+        'window[("taiko_" + (intermediate value))] is not a function',
+      ))
   ) {
     await runtimeEvaluate(`window['taiko_${exp.name}'] = ${exp}`, executionContextId);
     runtimeResult = await runtime.callFunctionOn(options);

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -13,10 +13,8 @@ const createdSessionListener = async (client) => {
   await criTarget.setDiscoverTargets({ discover: true });
   criTarget.targetCreated((target) => {
     if (target.targetInfo.type === 'page') {
-      if (target.targetInfo.openerId) {
-        logEvent(`Target Created: Target id: ${target.targetInfo.targetId}`);
-        eventHandler.emit('targetCreated', target);
-      }
+      logEvent(`Target Created: Target id: ${target.targetInfo.targetId}`);
+      eventHandler.emit('targetCreated', target);
     }
   });
 };

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -5,6 +5,7 @@ const { handleUrlRedirection } = require('../helper');
 const { eventHandler } = require('../eventBus');
 const { trimCharLeft, escapeHtml } = require('../util');
 const { logEvent } = require('../logger');
+const { defaultConfig } = require('../config');
 
 let criTarget;
 
@@ -13,8 +14,10 @@ const createdSessionListener = async (client) => {
   await criTarget.setDiscoverTargets({ discover: true });
   criTarget.targetCreated((target) => {
     if (target.targetInfo.type === 'page') {
-      logEvent(`Target Created: Target id: ${target.targetInfo.targetId}`);
-      eventHandler.emit('targetCreated', target);
+      if (target.targetInfo.openerId || defaultConfig.firefox) {
+        logEvent(`Target Created: Target id: ${target.targetInfo.targetId}`);
+        eventHandler.emit('targetCreated', target);
+      }
     }
   });
 };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -50,24 +50,6 @@ class Helper {
     }
     listeners.splice(0, listeners.length);
   }
-
-  static promisify(nodeFunction) {
-    function promisified(...args) {
-      return new Promise((resolve, reject) => {
-        function callback(err, ...result) {
-          if (err) {
-            return reject(err);
-          }
-          if (result.length === 1) {
-            return resolve(result[0]);
-          }
-          return resolve(result);
-        }
-        nodeFunction.call(null, ...args, callback);
-      });
-    }
-    return promisified;
-  }
 }
 
 /**

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -122,7 +122,7 @@ const waitUntil = async (condition, retryInterval, retryTimeout) => {
         break;
       }
     } catch (e) {
-      if (e.message.match(/Chrome process with pid \d+ exited with/)) {
+      if (e.message.match(/Browser process with pid \d+ exited with/)) {
         throw e;
       }
       actualError = e;

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -331,7 +331,9 @@ const _closeBrowser = async () => {
     // remove listeners other than JS dialog for beforeUnload on client first to stop executing them when closing
     await _client.removeAllListeners();
     pageHandler.addJavascriptDialogOpeningListener();
-    await page.close();
+    if (!defaultConfig.firefox) {
+      await page.close();
+    }
     await new Promise((resolve) => {
       timeout = setTimeout(() => {
         resolve();

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1,10 +1,7 @@
 const { doActionAwaitingNavigation } = require('./doActionAwaitingNavigation');
-
 const cri = require('chrome-remote-interface');
-const childProcess = require('child_process');
 const isReachable = require('is-reachable');
 const {
-  helper,
   wait,
   isString,
   isStrictObject,
@@ -54,7 +51,6 @@ const {
   defaultConfig,
   setNavigationOptions,
   setClickOptions,
-  setBrowserOptions,
 } = require('./config');
 const fs = require('fs-extra');
 const path = require('path');
@@ -62,10 +58,13 @@ const { eventHandler } = require('./eventBus');
 const overlayHandler = require('./handlers/overlayHandler');
 const { highlightElement } = require('./elements/elementHelper');
 const numRetries = defaultConfig.criConnectionRetries;
+const {
+  launchChrome,
+  closeChrome,
+  errorMessageForChromeProcessCrash,
+} = require('./browserLauncher');
 
-let chromeProcess,
-  temporaryUserDataDir,
-  page,
+let page,
   network,
   input,
   _client,
@@ -115,7 +114,11 @@ const createProxyForCDPDomain = (cdpClient, cdpDomainName) => {
         return async (...args) => {
           return await new Promise((resolve, reject) => {
             eventHandler.removeAllListeners('browserCrashed');
-            eventHandler.on('browserCrashed', reject);
+            eventHandler.on('browserCrashed', () => {
+              _client.removeAllListeners();
+              clientProxy = null;
+              reject();
+            });
             let res = domainApi.apply(null, args);
             if (res instanceof Promise) {
               res.then(resolve).catch(reject);
@@ -123,11 +126,8 @@ const createProxyForCDPDomain = (cdpClient, cdpDomainName) => {
               resolve(res);
             }
           }).catch((e) => {
-            if (
-              e.message.match(/WebSocket is not open: readyState 3/) &&
-              hasChromeProcessCrashed()
-            ) {
-              throw new Error(errorMessageForChromeprocessCrash());
+            if (e.message.match(/WebSocket is not open: readyState 3/)) {
+              errorMessageForChromeProcessCrash();
             }
             throw e;
           });
@@ -210,10 +210,6 @@ const connect_to_cri = async (target, options = {}) => {
   return initCRI(tgt, numRetries, options);
 };
 
-function hasChromeProcessCrashed() {
-  return chromeProcess && chromeProcess.killed && chromeProcess.exitCode !== 0;
-}
-
 async function reconnect() {
   const response = await isReachable(`${currentHost}:${currentPort}`);
   if (response) {
@@ -251,59 +247,6 @@ eventHandler.addListener('targetCreated', async (newTarget) => {
     });
   }
 });
-
-const browserExitEventHandler = () => {
-  chromeProcess.killed = true;
-  _client.removeAllListeners();
-  clientProxy = null;
-  eventHandler.emit('browserCrashed', new Error(errorMessageForChromeprocessCrash()));
-};
-
-async function setBrowserArgs(options) {
-  let args = [
-    `--remote-debugging-port=${options.port}`,
-    '--disable-features=site-per-process,TranslateUI',
-    '--enable-features=NetworkService,NetworkServiceInProcess',
-    '--disable-renderer-backgrounding',
-    '--disable-backgrounding-occluded-windows',
-    '--disable-background-timer-throttling',
-    '--disable-background-networking',
-    '--disable-breakpad',
-    '--disable-default-apps',
-    '--disable-hang-monitor',
-    '--disable-prompt-on-repost',
-    '--disable-sync',
-    '--force-color-profile=srgb',
-    '--safebrowsing-disable-auto-update',
-    '--password-store=basic',
-    '--use-mock-keychain',
-    '--enable-automation',
-    '--disable-notifications',
-    'about:blank',
-  ];
-  args = options.args ? args.concat(options.args) : args;
-  args = process.env.TAIKO_BROWSER_ARGS
-    ? args.concat(
-        process.env.TAIKO_BROWSER_ARGS.split(/\s*,?\s*--/)
-          .filter((arg) => arg !== '')
-          .map((arg) => `--${arg}`),
-      )
-    : args;
-  if (!args.some((arg) => arg.startsWith('--user-data-dir'))) {
-    const os = require('os');
-    const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'taiko_dev_profile-');
-    const mkdtempAsync = helper.promisify(fs.mkdtemp);
-    temporaryUserDataDir = await mkdtempAsync(CHROME_PROFILE_PATH);
-    args.push(`--user-data-dir=${temporaryUserDataDir}`);
-  }
-  if (options.headless) {
-    args.push('--headless');
-    if (!args.some((arg) => arg.startsWith('--window-size'))) {
-      args.push('--window-size=1440,900');
-    }
-  }
-  return args;
-}
 
 /**
  * Launches a browser with a tab. The browser will be closed when the parent node.js process is closed.<br>
@@ -343,32 +286,11 @@ module.exports.openBrowser = async (
     );
   }
 
-  if (chromeProcess && !chromeProcess.killed) {
-    throw new Error('OpenBrowser cannot be called again as there is a chromium instance open.');
-  }
-
   if (options.host && options.port) {
     currentHost = options.host;
     currentPort = options.port;
   } else {
-    const BrowserFetcher = require('./browserFetcher');
-    const browserFetcher = new BrowserFetcher();
-    const chromeExecutable = browserFetcher.getExecutablePath();
-    options = setBrowserOptions(options);
-    let args = await setBrowserArgs(options);
-    chromeProcess = await childProcess.spawn(chromeExecutable, args);
-    if (options.dumpio) {
-      chromeProcess.stderr.pipe(process.stderr);
-      chromeProcess.stdout.pipe(process.stdout);
-    }
-    chromeProcess.once('exit', browserExitEventHandler);
-    const endpoint = await browserFetcher.waitForWSEndpoint(
-      chromeProcess,
-      defaultConfig.navigationTimeout,
-    );
-    currentHost = endpoint.host;
-    currentPort = endpoint.port;
-    browserDebugUrl = endpoint.browser;
+    ({ currentHost, currentPort, browserDebugUrl } = await launchChrome(options));
   }
   await connect_to_cri();
   var description = device ? `Browser opened with viewport ${device}` : 'Browser opened';
@@ -419,39 +341,8 @@ const _closeBrowser = async () => {
     await _client.close();
     clientProxy = null;
   }
-  const waitForChromeToClose = new Promise((fulfill) => {
-    chromeProcess.removeAllListeners();
-    chromeProcess.once('exit', () => {
-      fulfill();
-    });
-    if (chromeProcess.killed) {
-      fulfill();
-    }
-    timeout = setTimeout(() => {
-      fulfill();
-      chromeProcess.removeAllListeners();
-      chromeProcess.kill('SIGKILL');
-    }, defaultConfig.retryTimeout);
-  });
-  chromeProcess.kill('SIGTERM');
-  await waitForChromeToClose;
-  clearTimeout(timeout);
-  if (temporaryUserDataDir) {
-    try {
-      fs.removeSync(temporaryUserDataDir);
-    } catch (e) {}
-  }
+  await closeChrome();
 };
-
-function errorMessageForChromeprocessCrash() {
-  let message;
-  if (chromeProcess.exitCode === null) {
-    message = `Chrome process with pid ${chromeProcess.pid} exited with signal ${chromeProcess.signalCode}.`;
-  } else {
-    message = `Chrome process with pid ${chromeProcess.pid} exited with status code ${chromeProcess.exitCode}.`;
-  }
-  return message;
-}
 
 function getEventProxy(target) {
   let unsupportedClientMethods = [
@@ -3384,11 +3275,7 @@ const validate = () => {
     throw new Error('Browser or page not initialized. Call `openBrowser()` before using this API');
   }
   if (_client._ws.readyState > 1) {
-    if (chromeProcess && chromeProcess.killed) {
-      throw new Error(
-        'The Browser instance was closed either via `closeBrowser()` call, or it crashed for reasons unknown to Taiko. You can try launching a fresh instance using `openBrowser()` or inspect the logs for details of the possible crash.',
-      );
-    }
+    errorMessageForChromeProcessCrash();
     throw new Error(
       "Connection to browser lost. This probably isn't a problem with Taiko, inspect logs for possible causes.",
     );

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -617,9 +617,9 @@ module.exports.openIncognitoWindow = async (url, options = {}) => {
   if (url !== 'about:blank' && !/^https?:\/\//i.test(url) && !/^file/i.test(url)) {
     url = 'http://' + url;
   }
-  _client.removeAllListeners();
   browser = await connect_to_cri(browserDebugUrl, { window: true });
   browserContext = new BrowserContext(browser, this);
+  _client.removeAllListeners();
   const targetId = await browserContext.createBrowserContext(url, options);
   await connect_to_cri(targetId);
   if (url !== 'about:blank') {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -204,9 +204,11 @@ const connect_to_cri = async (target, options = {}) => {
     localProtocol = true;
   }
   if (_client && _client._ws.readyState === 1 && !options.window) {
-    await network.setRequestInterception({
-      patterns: [],
-    });
+    if (!defaultConfig.firefox) {
+      await network.setRequestInterception({
+        patterns: [],
+      });
+    }
     _client.removeAllListeners();
   }
   var tgt = target || (await createTarget(numRetries));
@@ -1780,7 +1782,7 @@ async function scrollTo(selector) {
 
   function scrollToNode() {
     const element = this.nodeType === Node.TEXT_NODE ? this.parentElement : this;
-    element.scrollIntoViewIfNeeded();
+    element.scrollIntoView({ block: 'center', inline: 'center' });
     return 'result';
   }
   await evaluate(selector, scrollToNode);
@@ -3271,8 +3273,8 @@ const dialog = (dialogType, dialogMessage, callback) => {
 
 const evaluate = async (selector, func) => {
   let objectId = (await findFirstElement(selector)).get();
-  const { result } = await runtimeHandler.runtimeCallFunctionOn(func, null, { objectId: objectId });
-  return result;
+  let { result } = await runtimeHandler.runtimeCallFunctionOn(func, null, { objectId: objectId });
+  return result || {};
 };
 
 const validate = () => {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -54,7 +54,7 @@ const {
 } = require('./config');
 const fs = require('fs-extra');
 const path = require('path');
-const childProcess = require('childProcess');
+const childProcess = require('child_process');
 const { eventHandler } = require('./eventBus');
 const overlayHandler = require('./handlers/overlayHandler');
 const { highlightElement } = require('./elements/elementHelper');

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -54,6 +54,7 @@ const {
 } = require('./config');
 const fs = require('fs-extra');
 const path = require('path');
+const childProcess = require('childProcess');
 const { eventHandler } = require('./eventBus');
 const overlayHandler = require('./handlers/overlayHandler');
 const { highlightElement } = require('./elements/elementHelper');

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -618,6 +618,7 @@ module.exports.openIncognitoWindow = async (url, options = {}) => {
   if (url !== 'about:blank' && !/^https?:\/\//i.test(url) && !/^file/i.test(url)) {
     url = 'http://' + url;
   }
+  _client.removeAllListeners();
   browser = await connect_to_cri(browserDebugUrl, { window: true });
   browserContext = new BrowserContext(browser, this);
   _client.removeAllListeners();

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1435,7 +1435,7 @@ module.exports.write = async (text, into, options = { delay: 0 }) => {
           }
           return true;
         } catch (e) {
-          if (e.message.match(/Chrome process with pid \d+ exited with/)) {
+          if (e.message.match(/Browser process with pid \d+ exited with/)) {
             throw e;
           }
         }

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -165,13 +165,16 @@ const initCRI = async (target, n, options = {}) => {
     });
     if (!options.window) {
       initCRIProperties(c);
-      await Promise.all([
+      const domainEnablePromises = [
         network.enable(),
         page.enable(),
         dom.enable(),
-        overlay.enable(),
         security.enable(),
-      ]);
+      ];
+      if (!defaultConfig.firefox) {
+        domainEnablePromises.push(overlay.enable());
+      }
+      await Promise.all(domainEnablePromises);
       _client.on('disconnect', reconnect);
       // Should be emitted after enabling all domains. All handlers can then perform any action on domains properly.
       eventHandler.emit('createdSession', _client);

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -60,9 +60,9 @@ const overlayHandler = require('./handlers/overlayHandler');
 const { highlightElement } = require('./elements/elementHelper');
 const numRetries = defaultConfig.criConnectionRetries;
 const {
-  launchChrome,
-  closeChrome,
-  errorMessageForChromeProcessCrash,
+  launchBrowser,
+  closeBrowser,
+  errorMessageForBrowserProcessCrash,
 } = require('./browserLauncher');
 
 let page,
@@ -128,7 +128,7 @@ const createProxyForCDPDomain = (cdpClient, cdpDomainName) => {
             }
           }).catch((e) => {
             if (e.message.match(/WebSocket is not open: readyState 3/)) {
-              errorMessageForChromeProcessCrash();
+              errorMessageForBrowserProcessCrash();
             }
             throw e;
           });
@@ -296,7 +296,7 @@ module.exports.openBrowser = async (
     currentHost = options.host;
     currentPort = options.port;
   } else {
-    ({ currentHost, currentPort, browserDebugUrl } = await launchChrome(options));
+    ({ currentHost, currentPort, browserDebugUrl } = await launchBrowser(options));
   }
   await connect_to_cri();
   var description = device ? `Browser opened with viewport ${device}` : 'Browser opened';
@@ -349,7 +349,7 @@ const _closeBrowser = async () => {
     await _client.close();
     clientProxy = null;
   }
-  await closeChrome();
+  await closeBrowser();
 };
 
 function getEventProxy(target) {
@@ -3284,7 +3284,7 @@ const validate = () => {
     throw new Error('Browser or page not initialized. Call `openBrowser()` before using this API');
   }
   if (_client._ws.readyState > 1) {
-    errorMessageForChromeProcessCrash();
+    errorMessageForBrowserProcessCrash();
     throw new Error(
       "Connection to browser lost. This probably isn't a problem with Taiko, inspect logs for possible causes.",
     );

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "doc": "documentation build lib/taiko.js -f md --shallow -o docs/index.md --markdown-toc=false && node docs/setup.js",
     "test:api": "node test/unit-tests/taiko-test.js",
     "examples": "cd examples && npm install && npm test",
-    "test:unit:silent": "mocha 'test/unit-tests/**/*.test.js' --timeout 6000 -R dot",
+    "test:unit:silent": "mocha 'test/unit-tests/**/*.test.js' --timeout 6000 -R dot --trace-warnings",
     "test:unit": "mocha 'test/unit-tests/**/*.test.js' --timeout 6000 --trace-warnings",
     "test": "npm run test:api && npm run test:unit:silent",
     "test-functional": "cd test/functional-tests && npm install && npm test",

--- a/test/unit-tests/browserLauncher.test.js
+++ b/test/unit-tests/browserLauncher.test.js
@@ -33,10 +33,10 @@ describe('OpenBrowser', () => {
   });
 
   describe('browser crashes', () => {
-    let chromeProcess;
+    let browserProcess;
     beforeEach(async () => {
-      await browserLauncher.launchChrome(openBrowserArgs);
-      chromeProcess = browserLauncher.__get__('chromeProcess');
+      await browserLauncher.launchBrowser(openBrowserArgs);
+      browserProcess = browserLauncher.__get__('browserProcess');
     });
 
     afterEach(() => {
@@ -48,7 +48,7 @@ describe('OpenBrowser', () => {
       eventHandler.on('browserCrashed', () => {
         browserCrashedEmitted = true;
       });
-      chromeProcess.kill('SIGKILL');
+      browserProcess.kill('SIGKILL');
       await new Promise((resolve) => {
         setTimeout(resolve, 100);
       });
@@ -56,7 +56,7 @@ describe('OpenBrowser', () => {
     });
 
     it('should allow to open a browser after chrome process crashes', async () => {
-      chromeProcess.kill('SIGKILL');
+      browserProcess.kill('SIGKILL');
       await openBrowser(openBrowserArgs);
       await closeBrowser();
     });

--- a/test/unit-tests/browserLauncher.test.js
+++ b/test/unit-tests/browserLauncher.test.js
@@ -1,0 +1,64 @@
+const chai = require('chai');
+const expect = chai.expect;
+const rewire = require('rewire');
+let { openBrowserArgs } = require('./test-util');
+const { openBrowser, closeBrowser } = require('../../lib/taiko');
+const { eventHandler } = require('../../lib/eventBus');
+
+describe('OpenBrowser', () => {
+  let browserLauncher;
+  before(() => {
+    browserLauncher = rewire('../../lib/browserLauncher');
+  });
+  after(() => {
+    browserLauncher = rewire('../../lib/browserLauncher');
+  });
+
+  describe('should set args', async () => {
+    it('from env variable TAIKO_BROWSER_ARGS', async () => {
+      process.env.TAIKO_BROWSER_ARGS =
+        '--test-arg, --test-arg1,--test-arg2=testArg2zValue1,testArg2zValue2, --test-arg3';
+      const setBrowserArgs = browserLauncher.__get__('setBrowserArgs');
+      const testArgs = await setBrowserArgs({ args: ['something'] });
+      const expectedArgs = [
+        'something',
+        '--test-arg',
+        '--test-arg1',
+        '--test-arg2=testArg2zValue1,testArg2zValue2',
+        '--test-arg3',
+      ];
+      expect(testArgs).to.include.members(expectedArgs);
+      delete process.env.TAIKO_BROWSER_ARGS;
+    });
+  });
+
+  describe('browser crashes', () => {
+    let chromeProcess;
+    beforeEach(async () => {
+      await browserLauncher.launchChrome(openBrowserArgs);
+      chromeProcess = browserLauncher.__get__('chromeProcess');
+    });
+
+    afterEach(() => {
+      browserLauncher = rewire('../../lib/browserLauncher');
+    });
+
+    it('should emit browserCrashed event when chrome process crashes', async () => {
+      let browserCrashedEmitted = false;
+      eventHandler.on('browserCrashed', () => {
+        browserCrashedEmitted = true;
+      });
+      chromeProcess.kill('SIGKILL');
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      expect(browserCrashedEmitted).to.be.true;
+    });
+
+    it('should allow to open a browser after chrome process crashes', async () => {
+      chromeProcess.kill('SIGKILL');
+      await openBrowser(openBrowserArgs);
+      await closeBrowser();
+    });
+  });
+});

--- a/test/unit-tests/config.test.js
+++ b/test/unit-tests/config.test.js
@@ -29,6 +29,7 @@ describe('Config tests', () => {
           const newConfig = {
             headful: false,
             highlightOnAction: 'true',
+            firefox: false,
             ignoreSSLErrors: false,
             navigationTimeout: 2,
             observe: false,
@@ -230,6 +231,7 @@ describe('Config tests', () => {
         headful: true,
         highlightOnAction: 'true',
         ignoreSSLErrors: true,
+        firefox: false,
         navigationTimeout: 30000,
         observe: true,
         observeTime: 5000,

--- a/test/unit-tests/helper.test.js
+++ b/test/unit-tests/helper.test.js
@@ -50,12 +50,12 @@ describe('Helper', () => {
         waitUntil(
           async () => {
             await condition();
-            throw new Error('Chrome process with pid 2045 exited with signal SIGTERM');
+            throw new Error('Browser process with pid 2045 exited with signal SIGTERM');
           },
           1,
           20,
         ),
-      ).to.be.eventually.rejectedWith('Chrome process with pid 2045 exited with signal SIGTERM');
+      ).to.be.eventually.rejectedWith('Browser process with pid 2045 exited with signal SIGTERM');
       expect(callCount).to.be.equal(1);
     });
 


### PR DESCRIPTION
This PR tries to add basic support for firefox. 

#### To launch taiko with firefox:
- Download and install [firefox nightly](https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly) 
- Set `TAIKO_BROWSER_PATH` to firefox nightly's executable.

Example: `TAIKO_BROWSER_PATH="/Applications/Firefoxnightly.app/Contents/MacOS/firefox" taiko`

#### Known Issues for now:  
- Highlighting element on action is set to false as overlay domain is not supported
- openTab/closeTab does not work as expected since `New` is not available in firefox yet
- Autofocus on first input field does not happen
- file:// protocol does not emit events
- waitFoNavigation does not wait for network calls and frame loads
