### PR TITLE
Fix the switchTo documentation

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -377,22 +377,29 @@ function getEventProxy(target) {
 module.exports.client = () => clientProxy;
 
 /**
- * Allows switching between tabs using URL or page title or Open Window.
+ * Allows switching between tabs and windows using URL or page title or Window name.
  *
  * @example
- * # switch using URL
- * await switchTo('https://taiko.dev')
+ * # Switch using URL
+ * await switchTo(/taiko.dev/)
  * @example
- * # switch using Title
- * await switchTo('Taiko')
+ * # Switch using Title
+ * await switchTo(/Taiko/)
  * @example
- * # switch using regex URL
+ * # Switch using Regex URL
  * await switchTo(/http(s?):\/\/(www?).google.(com|co.in|co.uk)/)
  * @example
- * # switch using regex Title
+ * # Switch using wild cards in the Regex
  * await switchTo(/Go*gle/)
- *
- * @param {string} arg - URL/Page title of the tab to switch.
+ * @example
+ * # Switch to a window identifier
+ * await openBrowser();
+ * await goto('google.com');
+ * openIncognitoWindow({ name: "newyorktimes"});
+ * switchTo(/google.com/);
+ * switchTo({ name: "newyorktimes"});
+ * @param {string} arg - Regex (Regular expression) the tab's title/URL or `Object` with 
+ * window name for example `{ name: "windowname"}`
  *
  * @returns {Promise}
  */


### PR DESCRIPTION
It looks like switchTo only works with Regex and window name object
and does not work with string. Which is ok. The regex will cover
almost all scenarios.

Updated the document to reflect that and also added more examples of
using it with a window identifier.

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>