### PR TITLE
Add regex and callback support for dialog handlers. #1293

### DIFF
--- a/lib/eventBus.js
+++ b/lib/eventBus.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
 const eventHandler = new EventEmitter();
 const descEvent = new EventEmitter();
+const eventRegexMap = new Map();
 
 eventHandler.on('uncaughtException', function (err) {
   console.error(err);
@@ -13,4 +14,5 @@ eventHandler.setMaxListeners(20);
 module.exports = {
   eventHandler,
   descEvent,
+  eventRegexMap,
 };

--- a/lib/handlers/pageHandler.js
+++ b/lib/handlers/pageHandler.js
@@ -1,6 +1,5 @@
-const { createJsDialogEventName } = require('../util');
 const { handleUrlRedirection, isElement, isSelector } = require('../helper');
-const { eventHandler } = require('../eventBus');
+const { eventHandler, eventRegexMap } = require('../eventBus');
 const { logEvent } = require('../logger');
 const { findElements } = require('../elementSearch');
 const nodeURL = require('url');
@@ -51,20 +50,32 @@ const createdSessionListener = async (client) => {
 };
 eventHandler.on('createdSession', createdSessionListener);
 
+const getJsDialogEventName = (message, type) => {
+  if (eventRegexMap.size) {
+    for (let [key, value] of eventRegexMap.entries()) {
+      if (key.startsWith(type) && value.test(message)) {
+        return key;
+      }
+    }
+  }
+  if (eventHandler.listenerCount(type)) {
+    return type;
+  }
+};
+
 const addJavascriptDialogOpeningListener = () => {
-  page.javascriptDialogOpening(({ message, type, url }) => {
-    const eventName = createJsDialogEventName(message, type);
-    if (!eventHandler.listenerCount(eventName)) {
+  page.javascriptDialogOpening((data) => {
+    const eventName = getJsDialogEventName(data.message, data.type);
+    if (eventName) {
+      eventHandler.emit(eventName, data);
+      eventRegexMap.delete(eventName);
+    } else {
       console.warn(
-        `There is no handler registered for ${type} popup displayed on the page ${url}.
-This might interfere with your test flow. You can use Taiko's ${type} API to handle this popup.
-Please visit https://docs.taiko.dev/#${type} for more details`,
+        `There is no handler registered for ${data.type} popup displayed on the page ${data.url}.
+          This might interfere with your test flow. You can use Taiko's ${data.type} API to handle this popup.
+          Please visit https://docs.taiko.dev/#${data.type} for more details`,
       );
     }
-    eventHandler.emit(eventName, {
-      message: message,
-      type: type,
-    });
   });
 };
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -15,7 +15,6 @@ const {
   isObject,
 } = require('./helper');
 const { getBrowserContexts, clearContexts } = require('./browserContext');
-const { createJsDialogEventName } = require('./util');
 const inputHandler = require('./handlers/inputHandler');
 const domHandler = require('./handlers/domHandler');
 const networkHandler = require('./handlers/networkHandler');
@@ -43,7 +42,8 @@ const {
 const fs = require('fs-extra');
 const path = require('path');
 const childProcess = require('child_process');
-const { eventHandler } = require('./eventBus');
+const crypto = require('crypto');
+const { eventHandler, eventRegexMap } = require('./eventBus');
 const overlayHandler = require('./handlers/overlayHandler');
 const { highlightElement } = require('./elements/elementHelper');
 const numRetries = defaultConfig.criConnectionRetries;
@@ -2485,19 +2485,37 @@ module.exports.near = (selector, opts = { offset: 30 }) => {
 };
 
 /**
- * Accept or dismiss an `alert` matching a text.<br>
+ * Accept or dismiss a `alert` matching a text.<br>
  *
  * @example
- * alert('Message', async () => await accept())
- * alert('Message', async () => await dismiss())
+ * alert('Are you sure', async () => await accept())
+ *
+ * alert('Are you sure', async () => await dismiss())
+ *
+ * // If alert message is unknown, A RegExp which matches
+ * // the text can be used
+ *
+ * alert(/^Close.*$/, async () => await accept())
+ *
+ * // If alert message is completely unknown, A callback can
+ * // be passed directly, it will get the message, url etc
+ * // as arguments which can be used to make a decision.
+ *
+ * alert(async ({message}) => {
+ *   if(message == "Are you sure?") {
+ *     await accept();
+ *    }
+ * })
+ *
  *
  * // Note: Taiko's `alert` listener has to be setup before the alert
- * // displays on the page. For example, if clicking on a button
- * // shows the alert, the Taiko script is
+ * // popup displays on the page. For example, if clicking on a button
+ * // shows the confirm popup, the Taiko script is
+ *
  * alert('Message', async () => await accept())
  * await click('Show Alert')
  *
- * @param {string} message - Identify alert based on this message.
+ * @param {string | RegExp | function } messageOrCallback - Identify prompt based on this message, regex or callback.
  * @param {function} callback - Action to perform. accept/dismiss.
  */
 module.exports.alert = (message, callback) => dialog('alert', message, callback);
@@ -2507,16 +2525,34 @@ module.exports.alert = (message, callback) => dialog('alert', message, callback)
  * Write into the `prompt` with `accept('Something')`.
  *
  * @example
- * prompt('Message', async () => await accept('Something'))
+ * prompt('Message', async () => await accept('something'))
+ *
  * prompt('Message', async () => await dismiss())
  *
- * // Note: Taiko's `prompt` listener has to be setup before the prompt
- * // displays on the page. For example, if clicking on a button
- * // shows the prompt, the Taiko script is
- * prompt('Message', async () => await accept('Something'))
- * await click('Show Prompt')
+ * // If prompt message is unknown, A RegExp which matches
+ * // the text can be used
  *
- * @param {string} message - Identify prompt based on this message.
+ * prompt(/^Please.+$name/, async () => await accept("NAME"))
+ *
+ * // If prompt message is completely unknown, A callback can
+ * // be passed directly, it will get the message, defaultPrompt etc
+ * // as arguments which can be used to make a decision.
+ *
+ * prompt(async ({message}) => {
+ *   if(message == "Please enter your age?") {
+ *     await accept('20')
+ *    }
+ * })
+ *
+ *
+ * // Note: Taiko's `prompt` listener has to be setup before the promt
+ * // popup displays on the page. For example, if clicking on a button
+ * // shows the prompt popup, the Taiko script is
+ *
+ * prompt('Message', async () => await accept())
+ * await click('Open Prompt')
+ *
+ * @param {string | RegExp | function } messageOrCallback - Identify prompt based on this message, regex or callback.
  * @param {function} callback - Action to perform. accept/dismiss.
  */
 module.exports.prompt = (message, callback) => dialog('prompt', message, callback);
@@ -2526,15 +2562,35 @@ module.exports.prompt = (message, callback) => dialog('prompt', message, callbac
  *
  * @example
  * confirm('Message', async () => await accept())
+ *
  * confirm('Message', async () => await dismiss())
+ *
+ * // If alert message is unknown, A RegExp which matches
+ * // the text can be used
+ *
+ * confirm(/^Are.+$sure, async () => await accept())
+ *
+ * // If alert message is completely unknown, A callback can
+ * // be passed directly, it will get the message, defaultPrompt etc
+ * // as arguments which can be used to make a decision.
+ *
+ * confirm(async ({message,defaultPrompt}) => {
+ *  if(message == "Continue?") {
+ *    await accept();
+ *  }else{
+ *    await dismiss();
+ *  }
+ * })
+ *
  *
  * // Note: Taiko's `confirm` listener has to be setup before the confirm
  * // popup displays on the page. For example, if clicking on a button
  * // shows the confirm popup, the Taiko script is
+ *
  * confirm('Message', async () => await accept())
  * await click('Show Confirm')
  *
- * @param {string} message - Identify confirm based on this message.
+ * @param {string | RegExp | function } messageOrCallback - Identify alert based on this message, regex or callback.
  * @param {function} callback - Action to perform. accept/dismiss.
  */
 module.exports.confirm = (message, callback) => dialog('confirm', message, callback);
@@ -2849,7 +2905,9 @@ const _focus = async (selector) => {
     return true;
   }
 };
+
 const promisesToBeResolvedBeforeCloseBrowser = [];
+
 const dialog = (dialogType, dialogMessage, callback) => {
   validate();
   let resolver = null;
@@ -2860,15 +2918,23 @@ const dialog = (dialogType, dialogMessage, callback) => {
       }),
     );
   }
-  return eventHandler.once(
-    createJsDialogEventName(dialogMessage, dialogType),
-    async ({ message }) => {
-      if (dialogMessage === message) {
-        await callback();
-        resolver && resolver();
-      }
-    },
-  );
+  let eventName = '';
+  if (dialogMessage instanceof Function) {
+    eventName = dialogType;
+    callback = dialogMessage;
+  } else {
+    eventName = createJsDialogEvent(dialogMessage, dialogType);
+    eventRegexMap.set(eventName, new RegExp(dialogMessage));
+  }
+  return eventHandler.once(eventName, async (args) => {
+    await callback(args);
+    resolver && resolver();
+  });
+};
+
+const createJsDialogEvent = (message, dType) => {
+  let hash = crypto.createHash('md5').update(message.toString()).digest('hex');
+  return dType + '_' + hash;
 };
 
 const evaluate = async (selector, func) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -29,13 +29,6 @@ module.exports.isTaikoRunner = (path) => {
   }
 };
 
-module.exports.createJsDialogEventName = (...args) => {
-  let eventName = args.reduce((acc, arg) => {
-    return `${acc}${arg.replace(/[^\w]+/g, '')}`;
-  }, '');
-  return `js${eventName}DialogOpened`;
-};
-
 module.exports.trimCharLeft = (baseString, char) => {
   if (!baseString) {
     return '';

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -474,12 +474,31 @@ declare module 'taiko' {
   /**
    * Events
    */
+  export interface DialogValue {
+    message: string;
+    type: string;
+    url: string;
+    defaultPrompt: string;
+  }
+
+  export type DialogHandler = (value: DialogValue) => void;
+
   // https://docs.taiko.dev/api/alert
-  export function alert(message: string, callback: Function): void;
+  export function alert(
+    messageOrCallback: string | RegExp | DialogHandler,
+    callback?: DialogHandler,
+  ): void;
   // https://docs.taiko.dev/api/prompt
-  export function prompt(message: string, callback: Function): void;
+  export function prompt(
+    messageOrCallback: string | RegExp | DialogHandler,
+    callback?: DialogHandler,
+  ): void;
   // https://docs.taiko.dev/api/confirm
-  export function confirm(message: string, callback: Function): void;
+  export function confirm(
+    messageOrCallback: string | RegExp | DialogHandler,
+    callback?: DialogHandler,
+  ): void;
+
   // https://docs.taiko.dev/api/beforeunload
   export function beforeunload(message: string, callback: Function): void;
 


### PR DESCRIPTION
Fixes #1293

Refer https://github.com/getgauge/taiko/issues/1293#issuecomment-659858918


The HTML snippet to verify

```html
<!DOCTYPE html>
<html lang="en">

<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Document</title>
</head>

<body>
    <h1>Foo</h1>
    <h2>Bar</h1>
    <h3>Baz</h1>
    <button type="submit" onclick="prompt1()">String</button>
    <button type="submit" onclick="prompt2()">Regex</button>
    <button type="submit" onclick="prompt3()">Global</button>
    <script>
        function prompt1() {
            value = prompt("Please enter your name", "Harry Potter");
            document.querySelector("h1").innerText = value;
        }
        function prompt2() {
            value = prompt("Please enter your name", "Harry Potter");
            document.querySelector("h2").innerText = value;
        }
        function prompt3() {
            value = prompt("Please enter your name", "Harry Potter");
            document.querySelector("h3").innerText = value;
        }
    </script>
</body>

</html>
```

The Taiko script
```js
const { accept, openBrowser, goto, click, button, closeBrowser } = requir;

(async () => {
  try {
    await openBrowser({ headless: false });
    await goto('file://****/index.html');
    await prompt('Please enter your name', async (data) => {
      console.log(data);
      await accept('String Match');
    });
    await click(button('String'));
    await prompt(/Please enter/, async (data) => {
      console.log(data);
      await accept('Regexp Match');
    });
    await click(button('Regex'));
    await prompt(async (data) => {
      console.log(data);
      await accept('Global Handler');
    });
    await click(button('Global'));
  } catch (e) {
    console.error(e);
  } finally {
    await closeBrowser();
  }
})();

```