### PR TITLE
Fix Jest example

### DIFF
--- a/docs/integrating_with_test_runners.md
+++ b/docs/integrating_with_test_runners.md
@@ -195,8 +195,6 @@ Add a Taiko script to `jest-test.js`
 ```
 const { openBrowser, goto, closeBrowser, write, press } = require('taiko');
 
-const { openBrowser, goto, closeBrowser, write, press } = require('taiko');
-
 describe('Taiko with Jest', () => {
     beforeAll(async() => {
         await openBrowser();


### PR DESCRIPTION
Jest integration example has `require` twice.

https://docs.taiko.dev/integrating_with_test_runners/#jest