### PR TITLE
Harmonizing setConfig/getConfig api doc

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2972,6 +2972,9 @@ getPlugins().forEach((pluginName) => {
  *
  * @param {String} optionName - Specifies the name of the configuration option/paramter you want to get (optional). If not specified, returns a shallow copy of the full global configuration.
  * @param {String} ["navigationTimeout"] Navigation timeout value in milliseconds for navigation after performing
+ * <a href="#opentab">openTab</a>, <a href="#goto">goto</a>, <a href="#reload">reload</a>, <a href="#goback">goBack</a>,
+ * <a href="#goforward">goForward</a>, <a href="#click">click</a>, <a href="#write">write</a>, <a href="#clear">clear</a>,
+ * <a href="#press">press</a> and <a href="#evaluate">evaluate</a>.
  * @param {String} ["observeTime"] Option to modify delay time in milliseconds for observe mode.
  * @param {String} ["retryInterval"] Option to modify delay time in milliseconds to retry the search of element existence.
  * @param {String} ["retryTimeout"] Option to modify timeout in milliseconds while retrying the search of element existence.
@@ -2992,16 +2995,20 @@ module.exports.getConfig = getConfig;
  * setConfig( { observeTime: 3000});
  *
  * @param {Object} options
- * @param {number} [options.observeTime = 3000 ] - Option to modify delay time in milliseconds for observe mode.
  * @param {number} [options.navigationTimeout = 30000 ] Navigation timeout value in milliseconds for navigation after performing
  * <a href="#opentab">openTab</a>, <a href="#goto">goto</a>, <a href="#reload">reload</a>, <a href="#goback">goBack</a>,
  * <a href="#goforward">goForward</a>, <a href="#click">click</a>, <a href="#write">write</a>, <a href="#clear">clear</a>,
  * <a href="#press">press</a> and <a href="#evaluate">evaluate</a>.
+ * @param {number} [options.observeTime = 3000 ] Option to modify delay time in milliseconds for observe mode.
  * @param {number} [options.retryInterval = 100 ] Option to modify delay time in milliseconds to retry the search of element existence.
  * @param {number} [options.retryTimeout = 10000 ] Option to modify timeout in milliseconds while retrying the search of element existence.
+ * @param {boolean} [options.observe = false ] Option to run each command after a delay. Useful to observe what is happening in the browser.
  * @param {boolean} [options.waitForNavigation = true ] Wait for navigation after performing <a href="#goto">goto</a>, <a href="#click">click</a>,
  * <a href="#doubleclick">doubleClick</a>, <a href="#rightclick">rightClick</a>, <a href="#write">write</a>, <a href="#clear">clear</a>,
  * <a href="#press">press</a> and <a href="#evaluate">evaluate</a>.
+ * @param {boolean} [options.ignoreSSLErrors = false ] Option to ignore SSL errors encountered by the browser.
+ * @param {boolean} [options.headful = false ] Option to open browser in headless/headful mode.
+ * @param {string} [options.highlightOnAction = 'false' ] Option to highlight an element on action.
  */
 module.exports.setConfig = setConfig;
 


### PR DESCRIPTION
Following comments in #1028 setConfig `ignoreSSLErrors` is not documented. This PR changes this by aligning setConfig and getConfig API documentation.