### PR TITLE
Extend emulateNetwork to accept custom objects

### DIFF
--- a/lib/handlers/networkHandler.js
+++ b/lib/handlers/networkHandler.js
@@ -59,7 +59,7 @@ const setNetworkEmulation = async (networkType) => {
   if (!networkType && _networkType) {
     networkType = _networkType;
   }
-  const emulate = networkPresets[networkType];
+  const emulate = (typeof networkType === 'string') ? networkPresets[networkType] : networkType;
   let networkModes = Object.keys(networkPresets);
   if (emulate === undefined) {
     throw new Error(`Please set one of the given network types \n${networkModes.join('\n')}`);

--- a/lib/handlers/networkHandler.js
+++ b/lib/handlers/networkHandler.js
@@ -59,7 +59,10 @@ const setNetworkEmulation = async (networkType) => {
   if (!networkType && _networkType) {
     networkType = _networkType;
   }
-  const emulate = (typeof networkType === 'string') ? networkPresets[networkType] : networkType;
+  const defaultNetworkConditions = { offline: false, downloadThroughput: 0, uploadThroughput: 0, latency: 0 };
+  const emulate = typeof networkType === 'object'
+    ? Object.assign(defaultNetworkConditions, networkType)
+    : networkPresets[networkType];
   let networkModes = Object.keys(networkPresets);
   if (emulate === undefined) {
     throw new Error(`Please set one of the given network types \n${networkModes.join('\n')}`);

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -476,8 +476,10 @@ module.exports.intercept = async (requestUrl, option, count) => {
  * await emulateNetwork("Offline")
  * @example
  * await emulateNetwork("Good2G")
+ * @example
+ * await emulateNetwork({ offline: false, downloadThroughput: 6400, uploadThroughput: 2560, latency: 500 })
  *
- * @param {string} networkType - 'GPRS','Regular2G','Good2G','Good3G','Regular3G','Regular4G','DSL','WiFi, Offline'
+ * @param {(string|object)} networkType - 'GPRS','Regular2G','Good2G','Good3G','Regular3G','Regular4G','DSL','WiFi','Offline', {offline: boolean, downloadThroughput: number, uploadThroughput: number, latency: number}
  *
  * @returns {Promise}
  */

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -473,11 +473,17 @@ module.exports.intercept = async (requestUrl, option, count) => {
  * Activates emulation of network conditions.
  *
  * @example
+ * # Emulate offline conditions
  * await emulateNetwork("Offline")
  * @example
+ * # Emulate slow network conditions
  * await emulateNetwork("Good2G")
  * @example
+ * # Emulate precise network conditions
  * await emulateNetwork({ offline: false, downloadThroughput: 6400, uploadThroughput: 2560, latency: 500 })
+ * @example
+ * # Emulate precise network conditions with any subset of these properties, with default fallbacks of `offline` as true and all numbers as 0
+ * await emulateNetwork({ downloadThroughput: 6400, uploadThroughput: 2560, latency: 500 })
  *
  * @param {(string|object)} networkType - 'GPRS','Regular2G','Good2G','Good3G','Regular3G','Regular4G','DSL','WiFi','Offline', {offline: boolean, downloadThroughput: number, uploadThroughput: number, latency: number}
  *

--- a/test/unit-tests/handlers/networkHandler.test.js
+++ b/test/unit-tests/handlers/networkHandler.test.js
@@ -57,6 +57,21 @@ describe(test_name, () => {
       expect(actualNetworkCondition).to.deep.equal(expectedNetworkCondition);
     });
 
+    it('should invoke emulateNetworkConditions with the set defaults if an incomplete Object option is provided', async () => {
+      const defaultNetworkCondition = {
+        offline: false,
+        downloadThroughput: 0,
+        uploadThroughput: 0,
+        latency: 0,
+      };
+      const expectedNetworkCondition = {
+        ...defaultNetworkCondition,
+        uploadThroughput: 2500
+      };
+      await networkHandler.setNetworkEmulation({ uploadThroughput: 2500 });
+      expect(actualNetworkCondition).to.deep.equal(expectedNetworkCondition);
+    });
+
     it('should throw error for invalid network type', async () => {
       return expect(
         networkHandler.setNetworkEmulation('invalid network'),

--- a/test/unit-tests/handlers/networkHandler.test.js
+++ b/test/unit-tests/handlers/networkHandler.test.js
@@ -35,7 +35,7 @@ describe(test_name, () => {
     process.env.TAIKO_EMULATE_NETWORK = '';
   });
   describe('setNetworkEmulation', () => {
-    it('should invoke emulateNetworkConditions with correct options', async () => {
+    it('should invoke emulateNetworkConditions with a correct String option', async () => {
       const expectedNetworkCondition = {
         offline: false,
         downloadThroughput: 6400,
@@ -43,6 +43,17 @@ describe(test_name, () => {
         latency: 500,
       };
       await networkHandler.setNetworkEmulation('GPRS');
+      expect(actualNetworkCondition).to.deep.equal(expectedNetworkCondition);
+    });
+
+    it('should invoke emulateNetworkConditions with a correct Object option', async () => {
+      const expectedNetworkCondition = {
+        offline: false,
+        downloadThroughput: 6400,
+        uploadThroughput: 2560,
+        latency: 500,
+      };
+      await networkHandler.setNetworkEmulation(expectedNetworkCondition);
       expect(actualNetworkCondition).to.deep.equal(expectedNetworkCondition);
     });
 

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -268,7 +268,14 @@ declare module 'taiko' {
       | 'Regular3G'
       | 'Regular4G'
       | 'DSL'
-      | 'WiFi, Offline',
+      | 'WiFi'
+      | 'Offline'
+      | {
+        offline: boolean;
+        downloadThroughput: number;
+        uploadThroughput: number;
+        latency: number;
+      }
   ): Promise<void>;
   // https://docs.taiko.dev/api/emulatedevice
   export function emulateDevice(deviceModel: string);

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -271,11 +271,11 @@ declare module 'taiko' {
       | 'WiFi'
       | 'Offline'
       | {
-        offline: boolean;
-        downloadThroughput: number;
-        uploadThroughput: number;
-        latency: number;
-      }
+          offline?: boolean;
+          downloadThroughput?: number;
+          uploadThroughput?: number;
+          latency?: number;
+        },
   ): Promise<void>;
   // https://docs.taiko.dev/api/emulatedevice
   export function emulateDevice(deviceModel: string);


### PR DESCRIPTION
We have a few cases where we want to customize what throughput/latency values we want to use. With this PR, we can either use the preset values already present in Taiko, or supply an object that fits Chrome Dev Tools' needs. Hopefully this is still within the spirit of the repository, let us know if there are any changes you'd like us to make!