### PR TITLE
Check package.json before reading version

### DIFF
--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -12,12 +12,16 @@ const processArgv = process.argv;
 let repl_mode = false;
 let taiko;
 function printVersion() {
-  const packageJson = require('../package.json');
-  let hash = 'RELEASE';
-  if (packageJson._resolved && packageJson._resolved.includes('#')) {
-    hash = packageJson._resolved.split('#')[1];
+  try {
+    const packageJson = require('../package.json');
+    let hash = 'RELEASE';
+    if (packageJson._resolved && packageJson._resolved.includes('#')) {
+      hash = packageJson._resolved.split('#')[1];
+    }
+    return `Version: ${packageJson.version} (Chromium: ${packageJson.taiko.chromium_version}) ${hash}`;
+  } catch (error) {
+    return 'Could not find the package.json file to read version information';
   }
-  return `Version: ${packageJson.version} (Chromium: ${packageJson.taiko.chromium_version}) ${hash}`;
 }
 
 async function exitOnUnhandledFailures(e) {

--- a/lib/browserFetcher.js
+++ b/lib/browserFetcher.js
@@ -210,8 +210,15 @@ class BrowserFetcher {
         : null;
       return { executablePath, missingText };
     }
-    let preferredRevision = require(path.join(helper.projectRoot(), 'package.json')).taiko
-      .chromium_revision;
+    const packageJsonPath = path.join(helper.projectRoot(), 'package.json');
+    if (!fs.existsSync(packageJsonPath)) {
+      return {
+        executablePath,
+        missingText:
+          'Could not locate package.json to find a browser executable, Please set TAIKO_BROWSER_PATH env variable',
+      };
+    }
+    let preferredRevision = require(packageJsonPath).taiko.chromium_revision;
     const revisionInfo = this.revisionInfo(preferredRevision);
     const missingText = !revisionInfo.local
       ? 'Chromium revision is not downloaded. Provide TAIKO_BROWSER_PATH or Install taiko again to download bundled chromium.'

--- a/lib/browserFetcher.js
+++ b/lib/browserFetcher.js
@@ -26,8 +26,6 @@ const util = require('util');
 const URL = require('url');
 const { helper, assert } = require('./helper');
 const readline = require('readline');
-const preferredRevision = require(path.join(helper.projectRoot(), 'package.json')).taiko
-  .chromium_revision;
 var url = require('url');
 const ProxyAgent = require('https-proxy-agent');
 const getProxyForUrl = require('proxy-from-env').getProxyForUrl;
@@ -212,6 +210,8 @@ class BrowserFetcher {
         : null;
       return { executablePath, missingText };
     }
+    let preferredRevision = require(path.join(helper.projectRoot(), 'package.json')).taiko
+      .chromium_revision;
     const revisionInfo = this.revisionInfo(preferredRevision);
     const missingText = !revisionInfo.local
       ? 'Chromium revision is not downloaded. Provide TAIKO_BROWSER_PATH or Install taiko again to download bundled chromium.'

--- a/lib/browserFetcher.js
+++ b/lib/browserFetcher.js
@@ -210,16 +210,18 @@ class BrowserFetcher {
         : null;
       return { executablePath, missingText };
     }
-    const packageJsonPath = path.join(helper.projectRoot(), 'package.json');
-    if (!fs.existsSync(packageJsonPath)) {
+
+    let metadata = require(path.join(helper.projectRoot(), 'package.json'));
+
+    if (!metadata.taiko) {
       return {
         executablePath,
         missingText:
-          'Could not locate package.json to find a browser executable, Please set TAIKO_BROWSER_PATH env variable',
+          'Cannot find browser executable information in package.json, please set TAIKO_BROWSER_PATH env variable',
       };
     }
-    let preferredRevision = require(packageJsonPath).taiko.chromium_revision;
-    const revisionInfo = this.revisionInfo(preferredRevision);
+
+    const revisionInfo = this.revisionInfo(metadata.taiko.chromium_revision);
     const missingText = !revisionInfo.local
       ? 'Chromium revision is not downloaded. Provide TAIKO_BROWSER_PATH or Install taiko again to download bundled chromium.'
       : null;


### PR DESCRIPTION
Fixes: #988

Packaging tools like web pack seems to strip non standard information from the `package.json` file. 
Taiko reads metadata from `package.json`, this PR adds a check to raise the right error when it 
cannot find browser version information.