### PR TITLE
Add regex support for dropdown text selection

### DIFF
--- a/lib/elements/dropDown.js
+++ b/lib/elements/dropDown.js
@@ -55,10 +55,19 @@ class DropDown extends Element {
       return found_value;
     }
     const options = setNavigationOptions({});
+
+    // RegExp is not serialised. So loop through dropdown text and find a match
+    // before invoking via CDP API
+    let valueToSelect = value;
+    if (value instanceof RegExp) {
+      let options = await this.text();
+      valueToSelect = await options.split('\n').find((option) => value.exec(option));
+    }
+
     await doActionAwaitingNavigation(options, async () => {
       const { result } = await this.runtimeHandler.runtimeCallFunctionOn(selectBox, null, {
         objectId: this.get(),
-        arg: value instanceof RegExp ? value.toString() : value,
+        arg: valueToSelect,
         returnByValue: true,
       });
       const { stack, error } = result.value;

--- a/lib/elements/dropDown.js
+++ b/lib/elements/dropDown.js
@@ -28,11 +28,12 @@ class DropDown extends Element {
         });
         return true;
       };
-      if (this.options.length > value.index) {
+      if (value && this.options.length > value.index) {
         let ele = selectAndDispatchEvent(this, value.index);
         found_value['isAvailable'] = ele;
         return found_value;
       }
+
       for (var i = 0; i < this.options.length; i++) {
         let option = this.options[i];
         if (option.text === value || option.value === value) {

--- a/lib/elements/dropDown.js
+++ b/lib/elements/dropDown.js
@@ -28,7 +28,13 @@ class DropDown extends Element {
         });
         return true;
       };
-      if (value && this.options.length > value.index) {
+
+      if (!value) {
+        found_value['isAvailable'] = false;
+        return found_value;
+      }
+
+      if (this.options.length > value.index) {
         let ele = selectAndDispatchEvent(this, value.index);
         found_value['isAvailable'] = ele;
         return found_value;
@@ -52,7 +58,7 @@ class DropDown extends Element {
     await doActionAwaitingNavigation(options, async () => {
       const { result } = await this.runtimeHandler.runtimeCallFunctionOn(selectBox, null, {
         objectId: this.get(),
-        arg: value,
+        arg: value instanceof RegExp ? value.toString() : value,
         returnByValue: true,
       });
       const { stack, error } = result.value;

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2380,6 +2380,8 @@ function textBox(attrValuePairs, _options, ...args) {
  * await dropDown({id:'dropDownId'},below('text')).exists()
  * @example
  * await dropDown(below('text')).exists()
+ * @example
+ * await dropDown('Vehicle:').select(/Car/) // Only matches drop down text and not the value
  *
  * @param {object} attrValuePairs - Pairs of attribute and value like {"id":"name","class":"class-name"}
  * @param {Object} _options

--- a/test/unit-tests/dropDown.test.js
+++ b/test/unit-tests/dropDown.test.js
@@ -251,11 +251,16 @@ describe(test_name, () => {
 
   describe('regex based selection', () => {
     it('should select value specified by a regex ', async () => {
-      await dropDown('Cars').select(/mercedes/);
+      await dropDown('Cars').select(/Mercedes/);
       expect(await dropDown('Cars').value()).to.equal('mercedes');
     });
+
     it('should throw error when there are no items matching regex ', async () => {
-      await dropDown('Cars').select(/Renault/);
+      try {
+        expect(await dropDown('Cars').select(/Renault/));
+      } catch (err) {
+        expect(err.message).to.equal('Option /Renault/ not available in drop down');
+      }
     });
   });
 
@@ -265,6 +270,7 @@ describe(test_name, () => {
         'You are passing a `ElementWrapperList` to a `dropDown` selector. Refer https://docs.taiko.dev/api/dropdown/ for the correct parameters',
       );
     });
+
     it('should throw error for null values', async () => {
       try {
         expect(await dropDown('Cars').select(null));
@@ -272,6 +278,7 @@ describe(test_name, () => {
         expect(err.message).to.equal('Option null not available in drop down');
       }
     });
+
     it('should throw error for undefined values', async () => {
       try {
         expect(await dropDown('Cars').select(undefined));

--- a/test/unit-tests/dropDown.test.js
+++ b/test/unit-tests/dropDown.test.js
@@ -249,11 +249,35 @@ describe(test_name, () => {
     });
   });
 
+  describe('regex based selection', () => {
+    it('should select value specified by a regex ', async () => {
+      await dropDown('Cars').select(/mercedes/);
+      expect(await dropDown('Cars').value()).to.equal('mercedes');
+    });
+    it('should throw error when there are no items matching regex ', async () => {
+      await dropDown('Cars').select(/Renault/);
+    });
+  });
+
   describe('Parameters validation', () => {
     it('should throw a TypeError when an ElementWrapper is passed as argument', async () => {
       expect(() => dropDown($('div'))).to.throw(
         'You are passing a `ElementWrapperList` to a `dropDown` selector. Refer https://docs.taiko.dev/api/dropdown/ for the correct parameters',
       );
+    });
+    it('should throw error for null values', async () => {
+      try {
+        expect(await dropDown('Cars').select(null));
+      } catch (err) {
+        expect(err.message).to.equal('Option null not available in drop down');
+      }
+    });
+    it('should throw error for undefined values', async () => {
+      try {
+        expect(await dropDown('Cars').select(undefined));
+      } catch (err) {
+        expect(err.message).to.equal('Option undefined not available in drop down');
+      }
     });
   });
 });

--- a/test/unit-tests/dropDown.test.js
+++ b/test/unit-tests/dropDown.test.js
@@ -251,7 +251,7 @@ describe(test_name, () => {
 
   describe('regex based selection', () => {
     it('should select value specified by a regex ', async () => {
-      await dropDown('Cars').select(/Mercedes/);
+      await dropDown('Cars').select(/M.rc.d.s/);
       expect(await dropDown('Cars').value()).to.equal('mercedes');
     });
 


### PR DESCRIPTION
Fixes: #1111

### Usage

```
await dropDown('Cars').select(/M.rc.d.s/);
```

Also fixes raised error on passing null values.

#### Before

```
await dropDown('Cars').select(null)
Cannot destructure property \'stack\' of \'result.value\' as it is undefined.
```

#### After

```
await dropDown('Cars').select(null)
Option null not available in drop down
```
