### PR TITLE
Fix lint

### DIFF
--- a/lib/browserContext.js
+++ b/lib/browserContext.js
@@ -1,5 +1,3 @@
-const runtimeHandler = require('./handlers/runtimeHandler');
-
 let _target;
 let contexts = new Map();
 let openWindowOptions;

--- a/lib/elements/range.js
+++ b/lib/elements/range.js
@@ -37,25 +37,24 @@ class Range extends Element {
       rangeValues['max'] = this.max || 100;
       rangeValues['current'] = this.value;
 
-	    let selectAndDispatchEvent = function (self, value) {
-		    self.value = value;
-		    ['change', 'input'].forEach((ev) => {
-			    let event = new Event(ev, { bubbles: true });
-			    try {
-				    self.dispatchEvent(event);
-			    } catch (e) {
+      let selectAndDispatchEvent = function (self, value) {
+        self.value = value;
+        ['change', 'input'].forEach((ev) => {
+          let event = new Event(ev, { bubbles: true });
+          try {
+            self.dispatchEvent(event);
+          } catch (e) {
+            return {
+              error: `Error occurred while dispatching ${ev} event`,
+              stack: e.stack,
+            };
+          }
+        });
+        return true;
+      };
 
-				    return {
-					    error: `Error occurred while dispatching ${ev} event`,
-					    stack: e.stack,
-				    };
-			    }
-		    });
-		    return true;
-	    };
-
-	    selectAndDispatchEvent(this, this.value);
-	    return rangeValues;
+      selectAndDispatchEvent(this, this.value);
+      return rangeValues;
     }
     const options = setNavigationOptions({});
     let result;

--- a/lib/handlers/networkHandler.js
+++ b/lib/handlers/networkHandler.js
@@ -59,10 +59,16 @@ const setNetworkEmulation = async (networkType) => {
   if (!networkType && _networkType) {
     networkType = _networkType;
   }
-  const defaultNetworkConditions = { offline: false, downloadThroughput: 0, uploadThroughput: 0, latency: 0 };
-  const emulate = typeof networkType === 'object'
-    ? Object.assign(defaultNetworkConditions, networkType)
-    : networkPresets[networkType];
+  const defaultNetworkConditions = {
+    offline: false,
+    downloadThroughput: 0,
+    uploadThroughput: 0,
+    latency: 0,
+  };
+  const emulate =
+    typeof networkType === 'object'
+      ? Object.assign(defaultNetworkConditions, networkType)
+      : networkPresets[networkType];
   let networkModes = Object.keys(networkPresets);
   if (emulate === undefined) {
     throw new Error(`Please set one of the given network types \n${networkModes.join('\n')}`);

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -49,12 +49,11 @@ const isMatchingRegex = function (target, targetRegex) {
   );
 };
 
-const prependHttp = function(targetUrl){
-	if (targetUrl && url.parse(targetUrl).host === null)
-	{
-		targetUrl = 'http://' + targetUrl;
-	}
-	return targetUrl;
+const prependHttp = function (targetUrl) {
+  if (targetUrl && url.parse(targetUrl).host === null) {
+    targetUrl = 'http://' + targetUrl;
+  }
+  return targetUrl;
 };
 
 const isMatchingUrl = function (target, targetUrl) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "types": "./types/taiko/index.d.ts",
   "scripts": {
-    "lint": "eslint --fix . --ext ts,tsx .",
+    "lint": "eslint --fix --ext js,ts .",
     "doc": "npm run doc:api && eleventy",
     "doc:serve": "npm run doc:api && eleventy --serve",
     "doc:api": "node lib/documentation.js",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "headless-browser"
   ],
   "lint-staged": {
-    "**/*.{js}": [
+    "**/*.{js,ts}": [
       "npm run lint",
       "git add"
     ]

--- a/test/unit-tests/handlers/networkHandler.test.js
+++ b/test/unit-tests/handlers/networkHandler.test.js
@@ -66,7 +66,7 @@ describe(test_name, () => {
       };
       const expectedNetworkCondition = {
         ...defaultNetworkCondition,
-        uploadThroughput: 2500
+        uploadThroughput: 2500,
       };
       await networkHandler.setNetworkEmulation({ uploadThroughput: 2500 });
       expect(actualNetworkCondition).to.deep.equal(expectedNetworkCondition);

--- a/test/unit-tests/handlers/targetHandler.test.js
+++ b/test/unit-tests/handlers/targetHandler.test.js
@@ -71,7 +71,6 @@ describe('TargetHandler', () => {
       expect(someOtherTarget.matching.length).to.be.equal(2);
     });
 
-	  
     it('should give all matching tabs if url is given without protocol ', async () => {
       _targets.push({
         id: '1',

--- a/test/unit-tests/incognito.test.js
+++ b/test/unit-tests/incognito.test.js
@@ -90,9 +90,9 @@ describe('Browser Context', () => {
     });
   });
 
-  describe('open incognito window without url',() => {
+  describe('open incognito window without url', () => {
     it('should open a blank page when url not given', async () => {
-      await openIncognitoWindow({name:'admin'});
+      await openIncognitoWindow({ name: 'admin' });
       expect(await currentURL()).to.equal('about:blank');
       await closeIncognitoWindow('admin');
     });

--- a/test/unit-tests/screenshot.test.js
+++ b/test/unit-tests/screenshot.test.js
@@ -7,7 +7,7 @@ let {
   setConfig,
   above,
   text,
-  $
+  $,
 } = require('../../lib/taiko');
 let { createHtml, removeFile, openBrowserArgs, resetConfig } = require('./test-util');
 let path = require('path');

--- a/updateChromium.js
+++ b/updateChromium.js
@@ -69,7 +69,7 @@ async function main() {
   let { executablePath } = browserFetcher.revisionInfo(revision);
   let out = execSync(`${executablePath} --version`);
   let versionInfo = out.toString();
-  let version = versionInfo.replace(/[^0-9\.]/g, '');
+  let version = versionInfo.replace(/[^0-9.]/g, '');
   updatePackageJSON('version', version);
 }
 

--- a/updateChromium.js
+++ b/updateChromium.js
@@ -5,12 +5,14 @@ const BrowserFetcher = require('./lib/browserFetcher');
 const supportedPlatforms = BrowserFetcher.supportedPlatforms;
 
 async function checkAvailableRevision(revision, browserFetcher) {
-  let results = await Promise.all(supportedPlatforms.map((platform) => browserFetcher.canDownload(revision, platform)));
+  let results = await Promise.all(
+    supportedPlatforms.map((platform) => browserFetcher.canDownload(revision, platform)),
+  );
   if (results.includes(false)) {
     return await checkAvailableRevision(--revision, browserFetcher);
   } else {
     return revision;
-  };
+  }
 }
 
 async function findLatestCommonRevision(chromiumReleases) {
@@ -47,16 +49,16 @@ async function getChromeReleasesInfo() {
       })
       .on('error', (e) => {
         reject(e);
-      })
+      });
   });
 }
 
 async function main() {
   let releasesInfo = await getChromeReleasesInfo();
   let revision = await findLatestCommonRevision(JSON.parse(releasesInfo));
-  let {chromium_revision} = require('./package.json').taiko;
-  if( chromium_revision >= revision ) {
-      console.log(
+  let { chromium_revision } = require('./package.json').taiko;
+  if (chromium_revision >= revision) {
+    console.log(
       `Skipping updating package.json as current chromium revision(${chromium_revision}) is similar or greater than available revision(${revision}).`,
     );
     return;
@@ -64,7 +66,7 @@ async function main() {
   updatePackageJSON('revision', revision);
   execSync('node ./lib/install.js');
   let browserFetcher = new BrowserFetcher();
-  let {executablePath} = browserFetcher.revisionInfo(revision);
+  let { executablePath } = browserFetcher.revisionInfo(revision);
   let out = execSync(`${executablePath} --version`);
   let versionInfo = out.toString();
   let version = versionInfo.replace(/[^0-9\.]/g, '');


### PR DESCRIPTION
In `package.json`, the `lint` was scanning only ts and tsx files, not js. Also, husky `lint-staged` hook was running only against .js files.

This PR fixes `lint-staged` hook and `lint` script to lint .js and .ts files.

Also, lint errors were fixed.