### PR TITLE
Use identifiers for tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ lib/api.json
 tags
 _site
 apis.json
+
+
+# Ignore testscripts with this name in the root folder (created for debugging)
+test-script.js

--- a/lib/browserContext.js
+++ b/lib/browserContext.js
@@ -9,18 +9,15 @@ class BrowserContext {
     this.instance = instance;
   }
 
-  async createBrowserContext(url, options) {
+  async createBrowserContext(url) {
     _target = this.browser.Target;
-    let targetId;
     const { browserContextId } = await _target.createBrowserContext();
     openWindowOptions = {
       url,
       browserContextId,
     };
     const createdTarget = await _target.createTarget(openWindowOptions);
-    targetId = createdTarget.targetId;
-    targetHandler.register(options.name, { targetId, incognito: true });
-    return targetId;
+    return createdTarget.targetId;
   }
 
   async closeBrowserContext(arg) {

--- a/lib/browserContext.js
+++ b/lib/browserContext.js
@@ -33,21 +33,12 @@ class BrowserContext {
     targetHandler.unregister(arg);
   }
 
-  async switchBrowserContext(callback, arg) {
-    const targetId = targetHandler.register(arg.name).targetId;
-    if (targetId === undefined) {
-      throw new Error(`Could not find Window with name ${arg.name} to switch.`);
-    }
+  async switchBrowserContext(callback, targetId) {
     await _target.activateTarget({ targetId: targetId.toString() });
     await callback(targetId);
   }
 }
 
-const isIncognito = (arg) => {
-  return targetHandler.register(arg.name).incognito;
-};
-
 module.exports = {
-  isIncognito,
   BrowserContext,
 };

--- a/lib/browserContext.js
+++ b/lib/browserContext.js
@@ -1,5 +1,6 @@
 let _target;
-let contexts = new Map();
+const targetHandler = require('./handlers/targetHandler');
+
 let openWindowOptions;
 
 class BrowserContext {
@@ -11,12 +12,6 @@ class BrowserContext {
   async createBrowserContext(url, options) {
     _target = this.browser.Target;
     let targetId;
-    if (contexts.get(options.name) !== undefined) {
-      console.warn(
-        `Instance of window with name ${options.name} found, switching window to ${options.name}`,
-      );
-      return await this.instance.switchTo({ name: options.name });
-    }
     const { browserContextId } = await _target.createBrowserContext();
     openWindowOptions = {
       url,
@@ -24,25 +19,25 @@ class BrowserContext {
     };
     const createdTarget = await _target.createTarget(openWindowOptions);
     targetId = createdTarget.targetId;
-    contexts.set(options.name, { targetId, incognito: true });
+    targetHandler.register(options.name, { targetId, incognito: true });
     return targetId;
   }
 
   async closeBrowserContext(arg) {
-    if (contexts.get(arg) === undefined) {
+    if (targetHandler.register(arg) === undefined) {
       console.warn('Browser context with name ${arg} not available.');
       return;
     }
-    const targetId = contexts.get(arg).targetId;
+    const targetId = targetHandler.register(arg).targetId;
     if (targetId === undefined) {
       throw new Error(`Could not find Window with name ${arg} to close.`);
     }
     await _target.closeTarget({ targetId });
-    contexts.delete(arg);
+    targetHandler.unregister(arg);
   }
 
   async switchBrowserContext(callback, arg) {
-    const targetId = contexts.get(arg.name).targetId;
+    const targetId = targetHandler.register(arg.name).targetId;
     if (targetId === undefined) {
       throw new Error(`Could not find Window with name ${arg.name} to switch.`);
     }
@@ -51,26 +46,16 @@ class BrowserContext {
   }
 }
 
-const getBrowserContexts = () => {
-  return contexts;
-};
-
 const isIncognito = (arg) => {
-  return contexts.get(arg.name).incognito;
+  return targetHandler.register(arg.name).incognito;
 };
 
 const getTargets = async () => {
   return await _target.getTargets();
 };
 
-const clearContexts = async () => {
-  contexts = new Map();
-};
-
 module.exports = {
-  getBrowserContexts,
   getTargets,
   isIncognito,
-  clearContexts,
   BrowserContext,
 };

--- a/lib/browserContext.js
+++ b/lib/browserContext.js
@@ -47,12 +47,7 @@ const isIncognito = (arg) => {
   return targetHandler.register(arg.name).incognito;
 };
 
-const getTargets = async () => {
-  return await _target.getTargets();
-};
-
 module.exports = {
-  getTargets,
   isIncognito,
   BrowserContext,
 };

--- a/lib/browserContext.js
+++ b/lib/browserContext.js
@@ -1,5 +1,4 @@
 let _target;
-const targetHandler = require('./handlers/targetHandler');
 
 let openWindowOptions;
 
@@ -20,17 +19,8 @@ class BrowserContext {
     return createdTarget.targetId;
   }
 
-  async closeBrowserContext(arg) {
-    if (targetHandler.register(arg) === undefined) {
-      console.warn('Browser context with name ${arg} not available.');
-      return;
-    }
-    const targetId = targetHandler.register(arg).targetId;
-    if (targetId === undefined) {
-      throw new Error(`Could not find Window with name ${arg} to close.`);
-    }
+  async closeBrowserContext(targetId) {
     await _target.closeTarget({ targetId });
-    targetHandler.unregister(arg);
   }
 
   async switchBrowserContext(callback, targetId) {

--- a/lib/elements/element.js
+++ b/lib/elements/element.js
@@ -24,11 +24,11 @@ class Element {
 
   async getAttribute(value) {
     function getAttribute(value) {
-      return this.getAttribute(value)
+      return this.getAttribute(value);
     }
     const result = await this.runtimeHandler.runtimeCallFunctionOn(getAttribute, null, {
-      objectId:this.objectId,
-      arg: value
+      objectId: this.objectId,
+      arg: value,
     });
     return result.result.value;
   }

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -8,7 +8,7 @@ const { logEvent } = require('../logger');
 const { defaultConfig } = require('../config');
 
 let criTarget;
-
+let targetRegistry = {};
 const createdSessionListener = async (client) => {
   let resolve;
   eventHandler.emit(
@@ -82,6 +82,45 @@ const isMatchingUrl = function (target, targetUrl) {
   );
 };
 
+const isMatchingName = function (target, targetUrl) {
+  if (targetUrl instanceof RegExp) {
+    return false;
+  }
+
+  targetUrl = prependHttp(targetUrl);
+  const parsedUrl = url.parse(target.url, true);
+  const parsedTargetUrl = url.parse(targetUrl, true);
+
+  const host = parsedUrl.host ? parsedUrl.host : '';
+  const targetHost = parsedTargetUrl.host ? parsedTargetUrl.host : '';
+
+  const pathname = parsedUrl.pathname ? parsedUrl.pathname : '';
+  const targetPathname = parsedTargetUrl.pathname ? parsedTargetUrl.pathname : '';
+
+  const urlPath = path.join(host, pathname);
+  const targetUrlPath = path.join(targetHost, targetPathname);
+
+  target.url = handleUrlRedirection(target.url);
+  return (
+    target.title === escapeHtml(targetUrl) ||
+    urlPath === (targetUrlPath || targetUrl) ||
+    parsedUrl.href === targetUrl
+  );
+};
+
+const register = function (name, target) {
+  if (name && target) {
+    if (targetRegistry[name]) {
+      throw new Error(
+        `There is a tab/page already registered with the name '${name}' please use another name.`,
+      );
+    }
+    targetRegistry[name] = target;
+  } else {
+    return targetRegistry[name];
+  }
+};
+
 const getCriTargets = async function (targetObject, host, port) {
   let targets = await cri.List({ host: host, port: port });
   let pages = targets.filter((target) => target.type === 'page');
@@ -102,4 +141,4 @@ const getCriTargets = async function (targetObject, host, port) {
   return response;
 };
 
-module.exports = { getCriTargets, isMatchingUrl, isMatchingRegex };
+module.exports = { getCriTargets, isMatchingUrl, isMatchingRegex, register };

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -87,7 +87,7 @@ const register = function (name, target) {
   if (name && target) {
     if (targetRegistry.has(name)) {
       throw new Error(
-        `There is a tab/page already registered with the name '${name}' please use another name.`,
+        `There is a window or tab already registered with the name '${name}' please use another name.`,
       );
     }
     targetRegistry.set(name, target);

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -57,14 +57,14 @@ const prependHttp = function (targetUrl) {
   return targetUrl;
 };
 
-const isMatchingUrl = function (target, targetUrl) {
-  if (targetUrl instanceof RegExp) {
+const isMatchingUrl = function (target, identifier) {
+  if (identifier instanceof RegExp) {
     return false;
   }
 
-  targetUrl = prependHttp(targetUrl);
+  identifier = prependHttp(identifier);
   const parsedUrl = url.parse(target.url, true);
-  const parsedTargetUrl = url.parse(targetUrl, true);
+  const parsedTargetUrl = url.parse(identifier, true);
 
   const host = parsedUrl.host ? parsedUrl.host : '';
   const targetHost = parsedTargetUrl.host ? parsedTargetUrl.host : '';
@@ -73,14 +73,19 @@ const isMatchingUrl = function (target, targetUrl) {
   const targetPathname = parsedTargetUrl.pathname ? parsedTargetUrl.pathname : '';
 
   const urlPath = path.join(host, pathname);
-  const targetUrlPath = path.join(targetHost, targetPathname);
+  const identifierPath = path.join(targetHost, targetPathname);
 
   target.url = handleUrlRedirection(target.url);
   return (
-    target.title === escapeHtml(targetUrl) ||
-    urlPath === (targetUrlPath || targetUrl) ||
-    parsedUrl.href === targetUrl
+    target.title === escapeHtml(identifier) ||
+    urlPath === (identifierPath || identifier) ||
+    parsedUrl.href === identifier
   );
+};
+
+const isMatchingTarget = function (target, identifier) {
+  let storedTarget = register(identifier.name);
+  return storedTarget && storedTarget.id === target.id;
 };
 
 const register = function (name, target) {
@@ -99,17 +104,21 @@ const clearRegister = function () {
   targetRegistry.clear();
 };
 
-const getCriTargets = async function (targetObject, host, port) {
+const getCriTargets = async function (identifier, host, port) {
   let targets = await cri.List({ host: host, port: port });
   let pages = targets.filter((target) => target.type === 'page');
   let response = {
     matching: pages.slice(0, 1),
     others: pages.slice(1),
   };
-  if (targetObject) {
+  if (identifier) {
     response = { matching: [], others: [] };
     for (const target of pages) {
-      if (isMatchingUrl(target, targetObject) || isMatchingRegex(target, targetObject)) {
+      if (
+        isMatchingUrl(target, identifier) ||
+        isMatchingRegex(target, identifier) ||
+        isMatchingTarget(target, identifier)
+      ) {
         response.matching.push(target);
       } else {
         response.others.push(target);
@@ -123,6 +132,7 @@ module.exports = {
   getCriTargets,
   isMatchingUrl,
   isMatchingRegex,
+  isMatchingTarget,
   register,
   unregister,
   clearRegister,

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -8,7 +8,8 @@ const { logEvent } = require('../logger');
 const { defaultConfig } = require('../config');
 
 let criTarget;
-let targetRegistry = {};
+let targetRegistry = new Map();
+
 const createdSessionListener = async (client) => {
   let resolve;
   eventHandler.emit(
@@ -84,19 +85,23 @@ const isMatchingUrl = function (target, targetUrl) {
 
 const register = function (name, target) {
   if (name && target) {
-    if (targetRegistry[name]) {
+    if (targetRegistry.has(name)) {
       throw new Error(
         `There is a tab/page already registered with the name '${name}' please use another name.`,
       );
     }
-    targetRegistry[name] = target;
+    targetRegistry.set(name, target);
   } else {
-    return targetRegistry[name];
+    return targetRegistry.get(name);
   }
 };
 
 const unregister = function (name) {
-  delete targetRegistry[name];
+  delete targetRegistry.delete(name);
+};
+
+const clearRegister = function () {
+  targetRegistry.clear();
 };
 
 const getCriTargets = async function (targetObject, host, port) {
@@ -119,4 +124,11 @@ const getCriTargets = async function (targetObject, host, port) {
   return response;
 };
 
-module.exports = { getCriTargets, isMatchingUrl, isMatchingRegex, register, unregister };
+module.exports = {
+  getCriTargets,
+  isMatchingUrl,
+  isMatchingRegex,
+  register,
+  unregister,
+  clearRegister,
+};

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -58,7 +58,7 @@ const prependHttp = function (targetUrl) {
 };
 
 const isMatchingUrl = function (target, identifier) {
-  if (identifier instanceof RegExp) {
+  if (!(identifier instanceof String || typeof identifier === 'string')) {
     return false;
   }
 
@@ -85,7 +85,7 @@ const isMatchingUrl = function (target, identifier) {
 
 const isMatchingTarget = function (target, identifier) {
   let storedTarget = register(identifier.name);
-  return storedTarget && storedTarget.id === target.id;
+  return storedTarget && storedTarget === target.id;
 };
 
 const register = function (name, target) {

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -82,32 +82,6 @@ const isMatchingUrl = function (target, targetUrl) {
   );
 };
 
-const isMatchingName = function (target, targetUrl) {
-  if (targetUrl instanceof RegExp) {
-    return false;
-  }
-
-  targetUrl = prependHttp(targetUrl);
-  const parsedUrl = url.parse(target.url, true);
-  const parsedTargetUrl = url.parse(targetUrl, true);
-
-  const host = parsedUrl.host ? parsedUrl.host : '';
-  const targetHost = parsedTargetUrl.host ? parsedTargetUrl.host : '';
-
-  const pathname = parsedUrl.pathname ? parsedUrl.pathname : '';
-  const targetPathname = parsedTargetUrl.pathname ? parsedTargetUrl.pathname : '';
-
-  const urlPath = path.join(host, pathname);
-  const targetUrlPath = path.join(targetHost, targetPathname);
-
-  target.url = handleUrlRedirection(target.url);
-  return (
-    target.title === escapeHtml(targetUrl) ||
-    urlPath === (targetUrlPath || targetUrl) ||
-    parsedUrl.href === targetUrl
-  );
-};
-
 const register = function (name, target) {
   if (name && target) {
     if (targetRegistry[name]) {

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -92,7 +92,7 @@ const register = function (name, target) {
 };
 
 const unregister = function (name) {
-  delete targetRegistry.delete(name);
+  targetRegistry.delete(name);
 };
 
 const clearRegister = function () {

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -85,11 +85,6 @@ const isMatchingUrl = function (target, targetUrl) {
 
 const register = function (name, target) {
   if (name && target) {
-    if (targetRegistry.has(name)) {
-      throw new Error(
-        `There is a window or tab already registered with the name '${name}' please use another name.`,
-      );
-    }
     targetRegistry.set(name, target);
   } else {
     return targetRegistry.get(name);

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -1,7 +1,7 @@
 const cri = require('chrome-remote-interface');
 const url = require('url');
 const path = require('path');
-const { handleUrlRedirection } = require('../helper');
+const { handleUrlRedirection, isString, isRegex } = require('../helper');
 const { eventHandler } = require('../eventBus');
 const { trimCharLeft, escapeHtml } = require('../util');
 const { logEvent } = require('../logger');
@@ -34,7 +34,7 @@ const createdSessionListener = async (client) => {
 eventHandler.on('createdSession', createdSessionListener);
 
 const isMatchingRegex = function (target, targetRegex) {
-  if (!(targetRegex instanceof RegExp)) {
+  if (!isRegex(targetRegex)) {
     return false;
   }
   const parsedUrl = url.parse(target.url, true);
@@ -58,7 +58,7 @@ const prependHttp = function (targetUrl) {
 };
 
 const isMatchingUrl = function (target, identifier) {
-  if (!(identifier instanceof String || typeof identifier === 'string')) {
+  if (!isString(identifier)) {
     return false;
   }
 

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -121,6 +121,10 @@ const register = function (name, target) {
   }
 };
 
+const unregister = function (name) {
+  delete targetRegistry[name];
+};
+
 const getCriTargets = async function (targetObject, host, port) {
   let targets = await cri.List({ host: host, port: port });
   let pages = targets.filter((target) => target.type === 'page');
@@ -141,4 +145,4 @@ const getCriTargets = async function (targetObject, host, port) {
   return response;
 };
 
-module.exports = { getCriTargets, isMatchingUrl, isMatchingRegex, register };
+module.exports = { getCriTargets, isMatchingUrl, isMatchingRegex, register, unregister };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -73,6 +73,8 @@ const isString = (obj) => typeof obj === 'string' || obj instanceof String;
 
 const isObject = (obj) => typeof obj === 'object' || obj instanceof Object;
 
+const isRegex = (obj) => Object.prototype.toString.call(obj).includes('RegExp');
+
 const isStrictObject = (obj) =>
   obj &&
   typeof obj === 'object' &&
@@ -177,6 +179,7 @@ module.exports = {
   isFunction,
   isString,
   isObject,
+  isRegex,
   isStrictObject,
   wait,
   commandlineArgs,

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -758,7 +758,8 @@ module.exports.closeTab = async (identifier) => {
   if (
     !identifier ||
     targetHandler.isMatchingUrl(activeTab, identifier) ||
-    targetHandler.isMatchingRegex(activeTab, identifier)
+    targetHandler.isMatchingRegex(activeTab, identifier) ||
+    targetHandler.isMatchingTarget(activeTab, identifier)
   ) {
     _client.removeAllListeners();
     await _client.close();

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -313,11 +313,11 @@ module.exports.openBrowser = async (
 module.exports.closeBrowser = async () => {
   validate();
   await _closeBrowser();
+  targetHandler.clearRegister();
   descEvent.emit('success', 'Browser closed');
 };
 
 const _closeBrowser = async () => {
-  targetHandler.clearRegister();
   let timeout;
   fetchHandler.resetInterceptors();
   if (_client) {
@@ -602,7 +602,7 @@ module.exports.openTab = async (
       url: targetUrl,
     });
     await connect_to_cri(target);
-    targetHandler.register(options.name, target);
+    targetHandler.register(options.name, target.id);
   };
 
   if (targetUrl.includes('about:blank')) {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -731,16 +731,9 @@ const _switchContext = async (arg) => {
  *
  * @returns {Promise}
  */
-module.exports.closeTab = async (targetUrl) => {
-  validate();
-  if (
-    targetUrl != null &&
-    (Object.prototype.toString.call(targetUrl).includes('RegExp') || typeof targetUrl != 'string')
-  ) {
-    targetUrl = new RegExp(targetUrl);
-  }
+module.exports.closeTab = async (identifier) => {
   const { matching, others } = await targetHandler.getCriTargets(
-    targetUrl,
+    identifier,
     currentHost,
     currentPort,
   );
@@ -750,7 +743,7 @@ module.exports.closeTab = async (targetUrl) => {
     return;
   }
   if (!matching.length) {
-    throw new Error(`No tab(s) matching ${targetUrl} found`);
+    throw new Error(`No tab(s) matching ${identifier} found`);
   }
   let activeTab = { url: await currentURL(), title: await title() };
   let closedTabUrl;
@@ -763,18 +756,22 @@ module.exports.closeTab = async (targetUrl) => {
     });
   }
   if (
-    targetUrl === null ||
-    targetUrl === undefined ||
-    targetHandler.isMatchingUrl(activeTab, targetUrl) ||
-    targetHandler.isMatchingRegex(activeTab, targetUrl)
+    !identifier ||
+    targetHandler.isMatchingUrl(activeTab, identifier) ||
+    targetHandler.isMatchingRegex(activeTab, identifier)
   ) {
     _client.removeAllListeners();
     await _client.close();
     await connect_to_cri(others[0]);
   }
-  let message = targetUrl
-    ? `Closed tab(s) matching ${targetUrl}`
+  let message = identifier
+    ? `Closed tab(s) matching ${identifier.name ? identifier.name : identifier}`
     : `Closed current tab matching ${closedTabUrl}`;
+
+  if (identifier) {
+    targetHandler.unregister(identifier.name);
+  }
+
   descEvent.emit('success', message);
 };
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -593,6 +593,7 @@ module.exports.openTab = async (
       url: targetUrl,
     });
     await connect_to_cri(target);
+    targetHandler.register(options.name, target);
   };
 
   if (targetUrl.includes('about:blank')) {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -674,7 +674,11 @@ module.exports.closeIncognitoWindow = async (arg) => {
 };
 
 const _switchToIncognitoBrowser = async (arg) => {
-  await browserContext.switchBrowserContext(connect_to_cri, arg);
+  const targetId = targetHandler.register(arg.name).targetId;
+  if (targetId === undefined) {
+    throw new Error(`Could not find Window with name ${arg.name} to switch.`);
+  }
+  await browserContext.switchBrowserContext(connect_to_cri, targetId);
   await dom.getDocument();
 };
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -4,6 +4,7 @@ const isReachable = require('is-reachable');
 const {
   wait,
   isString,
+  isRegex,
   isStrictObject,
   isFunction,
   waitUntil,
@@ -403,21 +404,21 @@ module.exports.client = () => clientProxy;
 
 module.exports.switchTo = async (arg) => {
   validate();
-  if (isObject(arg) && !Object.prototype.toString.call(arg).includes('RegExp')) {
+  if (isObject(arg) && !isRegex(arg)) {
     await _switchContext(arg);
     descEvent.emit('success', `Switched to window/tab matching ${arg.name}`);
   } else {
-    if (typeof arg != 'string' && !Object.prototype.toString.call(arg).includes('RegExp')) {
+    if (!isString(arg) && !isRegex(arg)) {
       throw new TypeError(
-        'The "targetUrl" argument must be of type string or regex. Received type ' + typeof arg,
+        `The "targetUrl" argument must be of type string, regex or identifier. Received type ${typeof arg}`,
       );
     }
-    if (typeof arg === 'string' && arg.trim() === '') {
+    if (isString(arg) && arg.trim() === '') {
       throw new Error(
-        'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex',
+        'Cannot switch to tab or window as the targetUrl is empty. Please use a valid string, regex or identifier',
       );
     }
-    if (Object.prototype.toString.call(arg).includes('RegExp')) {
+    if (isRegex(arg)) {
       arg = new RegExp(arg);
     }
     const targets = await targetHandler.getCriTargets(arg, currentHost, currentPort);

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -581,6 +581,13 @@ module.exports.openTab = async (
   if (!/^https?:\/\//i.test(targetUrl) && !/^file/i.test(targetUrl)) {
     targetUrl = 'http://' + targetUrl;
   }
+
+  if (targetHandler.register(options.name)) {
+    throw new Error(
+      `There is a window or tab already registered with the name '${options.name}' please use another name.`,
+    );
+  }
+
   const newCritarget = async () => {
     _client.removeAllListeners();
     let target = await cri.New({

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -665,7 +665,15 @@ module.exports.closeIncognitoWindow = async (arg) => {
   if (typeof arg !== 'string') {
     throw new TypeError('Window name needs to be provided');
   }
-  await browserContext.closeBrowserContext(arg);
+
+  if (!targetHandler.register(arg) || !targetHandler.register(arg).targetId) {
+    console.warn(`Could not find Window with name ${arg} to close.`);
+    return;
+  }
+
+  await browserContext.closeBrowserContext(targetHandler.register(arg).targetId);
+  targetHandler.unregister(arg);
+
   const promiseReconnect = new Promise((resolve) => {
     eventHandler.once('reconnected', resolve);
   });

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -583,9 +583,18 @@ module.exports.openTab = async (
 ) => {
   validate();
   options = setNavigationOptions(options);
-  targetUrl = targetUrl ? targetUrl : 'about:blank';
+  if (isObject(targetUrl) && targetUrl.name) {
+    options.name = targetUrl.name;
+  }
 
-  if (!/^https?:\/\//i.test(targetUrl) && !/^file/i.test(targetUrl)) {
+  targetUrl = isString(targetUrl) ? targetUrl : 'about:blank';
+
+  if (
+    isString(targetUrl) &&
+    targetUrl != 'about:blank' &&
+    !/^https?:\/\//i.test(targetUrl) &&
+    !/^file/i.test(targetUrl)
+  ) {
     targetUrl = 'http://' + targetUrl;
   }
 
@@ -606,12 +615,8 @@ module.exports.openTab = async (
     targetHandler.register(options.name, target.id);
   };
 
-  if (targetUrl.includes('about:blank')) {
-    newCritarget();
-  } else {
-    await doActionAwaitingNavigation(options, newCritarget);
-  }
-  descEvent.emit('success', 'Opened tab with URL ' + targetUrl);
+  await doActionAwaitingNavigation(options, newCritarget);
+  descEvent.emit('success', `Opened tab with URL ${targetUrl}`);
 };
 
 /**

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -13,7 +13,6 @@ const {
   isElement,
   isObject,
 } = require('./helper');
-const { getBrowserContexts, clearContexts } = require('./browserContext');
 const inputHandler = require('./handlers/inputHandler');
 const domHandler = require('./handlers/domHandler');
 const networkHandler = require('./handlers/networkHandler');
@@ -318,7 +317,7 @@ module.exports.closeBrowser = async () => {
 };
 
 const _closeBrowser = async () => {
-  clearContexts();
+  targetHandler.clearRegister();
   let timeout;
   fetchHandler.resetInterceptors();
   if (_client) {
@@ -401,11 +400,8 @@ module.exports.client = () => clientProxy;
 module.exports.switchTo = async (arg) => {
   validate();
   if (isObject(arg) && !Object.prototype.toString.call(arg).includes('RegExp')) {
-    const contexts = getBrowserContexts();
-    if (contexts.size !== 0) {
-      await _switchToIncognitoBrowser(arg);
-      descEvent.emit('success', `Switched to Incognito window matching ${arg.name}`);
-    }
+    await _switchToIncognitoBrowser(arg);
+    descEvent.emit('success', `Switched to window/tab matching ${arg.name}`);
   } else {
     if (typeof arg != 'string' && !Object.prototype.toString.call(arg).includes('RegExp')) {
       throw new TypeError(
@@ -631,6 +627,12 @@ module.exports.openIncognitoWindow = async (url, options = {}) => {
 
   if (!options.name) {
     throw new TypeError('Window name needs to be provided');
+  }
+
+  if (targetHandler.register(options.name)) {
+    throw new Error(
+      `There is a already a window/tab with name ${options.name}. Please use another name`,
+    );
   }
 
   if (url !== 'about:blank' && !/^https?:\/\//i.test(url) && !/^file/i.test(url)) {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -400,7 +400,7 @@ module.exports.client = () => clientProxy;
 module.exports.switchTo = async (arg) => {
   validate();
   if (isObject(arg) && !Object.prototype.toString.call(arg).includes('RegExp')) {
-    await _switchToIncognitoBrowser(arg);
+    await _switchContext(arg);
     descEvent.emit('success', `Switched to window/tab matching ${arg.name}`);
   } else {
     if (typeof arg != 'string' && !Object.prototype.toString.call(arg).includes('RegExp')) {
@@ -681,13 +681,18 @@ module.exports.closeIncognitoWindow = async (arg) => {
   descEvent.emit('success', `Window with name ${arg} closed`);
 };
 
-const _switchToIncognitoBrowser = async (arg) => {
-  const targetId = targetHandler.register(arg.name).targetId;
-  if (targetId === undefined) {
-    throw new Error(`Could not find Window with name ${arg.name} to switch.`);
+const _switchContext = async (arg) => {
+  if (!targetHandler.register(arg.name)) {
+    throw new Error(`Could not find window/tab with name ${arg.name} to switch.`);
   }
-  await browserContext.switchBrowserContext(connect_to_cri, targetId);
-  await dom.getDocument();
+
+  let targetId = targetHandler.register(arg.name).targetId;
+  if (targetId) {
+    await browserContext.switchBrowserContext(connect_to_cri, targetId);
+    await dom.getDocument();
+  } else {
+    await connect_to_cri(targetHandler.register(arg.name));
+  }
 };
 
 /**

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -391,6 +391,10 @@ module.exports.client = () => clientProxy;
  * openIncognitoWindow({ name: "newyorktimes"});
  * switchTo(/google.com/);
  * switchTo({ name: "newyorktimes"});
+ * @example
+ * openTab('https://taiko.dev', {name: 'taiko'})
+ * openIncognitoWindow({ name: "newyorktimes"});
+ * switchTo({name: 'taiko'});
  * @param {string} arg - Regex (Regular expression) the tab's title/URL or `Object` with
  * window name for example `{ name: "windowname"}`
  *
@@ -558,10 +562,12 @@ module.exports.emulateTimezone = async (timezoneId) => {
  * await openTab('https://taiko.dev')
  * @example
  * await openTab() # opens a blank tab.
- *
+ * @example
+ * await openTab('https://taiko.dev', {name: 'taiko'}) # Tab with identifier
  * @param {string} [targetUrl=undefined] - Url of page to open in newly created tab.
  * @param {Object} options
  * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the reload. Default navigation timeout is 5000 milliseconds, to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
+ * @param {string} [options.name] - Tab identifier
  * @param {number} [options.navigationTimeout=5000] - Navigation timeout value in milliseconds for navigation after click. Accepts value in milliseconds.
  * @param {number} [options.waitForStart=100] - time to wait to check for occurrence of page load events. Accepts value in milliseconds.
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Page load events to implicitly wait for. Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']]

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -644,6 +644,8 @@ module.exports.openIncognitoWindow = async (url, options = {}) => {
   _client.removeAllListeners();
   const targetId = await browserContext.createBrowserContext(url, options);
   await connect_to_cri(targetId);
+  targetHandler.register(options.name, { targetId, incognito: true });
+
   if (url !== 'about:blank') {
     await doActionAwaitingNavigation(options, async () => {
       await pageHandler.handleNavigation(url);

--- a/test/unit-tests/closeTab.test.js
+++ b/test/unit-tests/closeTab.test.js
@@ -9,6 +9,8 @@ describe('closeTab', () => {
   let title = '';
   let _isMatchUrl = false;
   let _isMatchRegex = false;
+  let _isMatchTarget = false;
+
   let currentTarget, taiko, targetHandler;
   let descEmmitter = new EventEmitter();
 
@@ -40,6 +42,9 @@ describe('closeTab', () => {
       },
       isMatchingRegex: () => {
         return _isMatchRegex;
+      },
+      isMatchingTarget: () => {
+        return _isMatchTarget;
       },
       register: (name, target) => {
         return targetHandler.register(name, target);
@@ -255,6 +260,5 @@ describe('closeTab', () => {
     await taiko.closeTab({ name: 'google' });
     expect(targetHandler.register('google')).to.be.undefined;
     await validatePromise;
-    expect(currentTarget).to.be.undefined;
   });
 });

--- a/test/unit-tests/closeTab.test.js
+++ b/test/unit-tests/closeTab.test.js
@@ -41,6 +41,12 @@ describe('closeTab', () => {
       isMatchingRegex: () => {
         return _isMatchRegex;
       },
+      register: (name, target) => {
+        return targetHandler.register(name, target);
+      },
+      unregister: (name) => {
+        return targetHandler.unregister(name);
+      },
     };
 
     taiko.__set__('validate', () => {});
@@ -216,6 +222,38 @@ describe('closeTab', () => {
       'Closed tab(s) matching /http(s?):\\/\\/(www?).google.(com|co.in|co.uk)/',
     );
     await taiko.closeTab(/http(s?):\/\/(www?).google.(com|co.in|co.uk)/);
+    await validatePromise;
+    expect(currentTarget).to.be.undefined;
+  });
+
+  it('should close tab matching identifier', async () => {
+    let targetWithIdentifier = {
+      id: '1',
+      type: 'page',
+      url: 'https://www.google.com',
+    };
+
+    _targets.matching.push(targetWithIdentifier);
+
+    targetHandler.register('google', targetWithIdentifier);
+
+    _targets.others.push({
+      id: '2',
+      type: 'page',
+      url: 'https://www.google.co.uk',
+    });
+    _targets.others.push({
+      id: '3',
+      type: 'page',
+      url: 'https://amazon.com',
+    });
+    currentURL = 'https://amazon.com';
+    _isMatchUrl = false;
+    _isMatchRegex = false;
+
+    let validatePromise = validateEmitterEvent('success', 'Closed tab(s) matching google');
+    await taiko.closeTab({ name: 'google' });
+    expect(targetHandler.register('google')).to.be.undefined;
     await validatePromise;
     expect(currentTarget).to.be.undefined;
   });

--- a/test/unit-tests/closeTab.test.js
+++ b/test/unit-tests/closeTab.test.js
@@ -52,6 +52,7 @@ describe('closeTab', () => {
     taiko.__set__('cri', mockCri);
     taiko.__set__('connect_to_cri', async (target) => {
       currentTarget = target;
+      return currentTarget;
     });
     taiko.__set__('dom', { getDocument: async () => {} });
   });

--- a/test/unit-tests/handlers/targetHandler.test.js
+++ b/test/unit-tests/handlers/targetHandler.test.js
@@ -213,7 +213,7 @@ describe('TargetHandler', () => {
     });
   });
 
-  describe('.getCriTargets', () => {
+  describe('register and unregister', () => {
     let targetHandler;
 
     beforeEach(() => {
@@ -233,6 +233,16 @@ describe('TargetHandler', () => {
       }).to.throw(
         "There is a tab/page already registered with the name 'one' please use another name.",
       );
+    });
+
+    it('should unregister a tab with the given name', async () => {
+      targetHandler.register('one', { id: 'first', type: 'page' });
+      targetHandler.register('two', { id: 'second', type: 'page' });
+
+      targetHandler.unregister('one');
+
+      expect(targetHandler.register('one')).to.be.undefined;
+      expect(targetHandler.register('two').id).to.equal('second');
     });
   });
 });

--- a/test/unit-tests/handlers/targetHandler.test.js
+++ b/test/unit-tests/handlers/targetHandler.test.js
@@ -235,7 +235,7 @@ describe('TargetHandler', () => {
       expect(() => {
         targetHandler.register('one', { id: 'first', type: 'page' });
       }).to.throw(
-        "There is a tab/page already registered with the name 'one' please use another name.",
+        "There is a window or tab already registered with the name 'one' please use another name.",
       );
     });
 

--- a/test/unit-tests/handlers/targetHandler.test.js
+++ b/test/unit-tests/handlers/targetHandler.test.js
@@ -212,4 +212,27 @@ describe('TargetHandler', () => {
       expect(targets.others.length).to.be.equal(2);
     });
   });
+
+  describe('.getCriTargets', () => {
+    let targetHandler;
+
+    beforeEach(() => {
+      targetHandler = rewire('../../../lib/handlers/targetHandler');
+    });
+
+    it('should register a target with name', async () => {
+      targetHandler.register('one', { id: 'first', type: 'page' });
+      targetHandler.register('two', { id: 'second', type: 'page' });
+      expect(targetHandler.register('two').id).to.be.equal('second');
+    });
+
+    it('should throw error if there is a target already registered with same name', async () => {
+      targetHandler.register('one', { id: 'first', type: 'page' });
+      expect(() => {
+        targetHandler.register('one', { id: 'first', type: 'page' });
+      }).to.throw(
+        "There is a tab/page already registered with the name 'one' please use another name.",
+      );
+    });
+  });
 });

--- a/test/unit-tests/handlers/targetHandler.test.js
+++ b/test/unit-tests/handlers/targetHandler.test.js
@@ -217,7 +217,11 @@ describe('TargetHandler', () => {
     let targetHandler;
 
     beforeEach(() => {
-      targetHandler = rewire('../../../lib/handlers/targetHandler');
+      targetHandler = new require('../../../lib/handlers/targetHandler');
+    });
+
+    afterEach(() => {
+      targetHandler.clearRegister();
     });
 
     it('should register a target with name', async () => {

--- a/test/unit-tests/handlers/targetHandler.test.js
+++ b/test/unit-tests/handlers/targetHandler.test.js
@@ -230,15 +230,6 @@ describe('TargetHandler', () => {
       expect(targetHandler.register('two').id).to.be.equal('second');
     });
 
-    it('should throw error if there is a target already registered with same name', async () => {
-      targetHandler.register('one', { id: 'first', type: 'page' });
-      expect(() => {
-        targetHandler.register('one', { id: 'first', type: 'page' });
-      }).to.throw(
-        "There is a window or tab already registered with the name 'one' please use another name.",
-      );
-    });
-
     it('should unregister a tab with the given name', async () => {
       targetHandler.register('one', { id: 'first', type: 'page' });
       targetHandler.register('two', { id: 'second', type: 'page' });

--- a/test/unit-tests/incognito.test.js
+++ b/test/unit-tests/incognito.test.js
@@ -13,8 +13,6 @@ let {
 } = require('../../lib/taiko');
 let { openBrowserArgs, resetConfig } = require('./test-util');
 
-let { isIncognito } = require('../../lib/browserContext');
-
 let { createHtml, removeFile } = require('./test-util');
 
 describe('Browser Context', () => {
@@ -101,7 +99,6 @@ describe('Browser Context', () => {
   describe('Open window in Incognito Mode', () => {
     it('Open window in incognito', async () => {
       await openIncognitoWindow(url1, { name: 'admin' });
-      expect(isIncognito({ name: 'admin' })).to.be.true;
     });
     after(async () => {
       await closeIncognitoWindow('admin');
@@ -111,7 +108,6 @@ describe('Browser Context', () => {
   describe('Open window in Incognito Mode', () => {
     it('Open window in incognito and use the default window', async () => {
       await openIncognitoWindow(url1, { name: 'admin' });
-      expect(isIncognito({ name: 'admin' })).to.be.true;
       await closeIncognitoWindow('admin');
       await goto(url1);
       let backToDefaultBrowser = await text('Browser1').exists();

--- a/test/unit-tests/incognito.test.js
+++ b/test/unit-tests/incognito.test.js
@@ -13,7 +13,7 @@ let {
 } = require('../../lib/taiko');
 let { openBrowserArgs, resetConfig } = require('./test-util');
 
-let { isIncognito, getBrowserContexts } = require('../../lib/browserContext');
+let { isIncognito } = require('../../lib/browserContext');
 
 let { createHtml, removeFile } = require('./test-util');
 
@@ -120,10 +120,15 @@ describe('Browser Context', () => {
   });
 
   describe('Open window with same window name', () => {
-    it('Should switch to existing window', async () => {
+    it('Should throw error if window name is not unique', async () => {
       await openIncognitoWindow(url1, { name: 'admin' });
-      await openIncognitoWindow(url1, { name: 'admin' });
-      expect(getBrowserContexts().size).to.be.equal(1);
+      try {
+        await openIncognitoWindow(url1, { name: 'admin' });
+      } catch (err) {
+        expect(err.message).to.be.equal(
+          'There is a already a window/tab with name admin. Please use another name',
+        );
+      }
     });
     after(async () => {
       await closeIncognitoWindow('admin');

--- a/test/unit-tests/openTab.test.js
+++ b/test/unit-tests/openTab.test.js
@@ -2,6 +2,7 @@ const expect = require('chai').expect;
 const { EventEmitter } = require('events');
 const rewire = require('rewire');
 const { fail } = require('assert');
+const targetHandler = new require('../../lib/handlers/targetHandler');
 
 describe('openTab', () => {
   let actualTarget, actualOptions, actualUrl, taiko;
@@ -33,6 +34,10 @@ describe('openTab', () => {
 
   after(() => {
     taiko = rewire('../../lib/taiko');
+  });
+
+  afterEach(() => {
+    targetHandler.clearRegister();
   });
 
   it('Open tab without any url should call connectToCri', async () => {
@@ -86,5 +91,21 @@ describe('openTab', () => {
         "There is a window or tab already registered with the name 'example' please use another name.",
       );
     }
+  });
+
+  it('should register with identifier if no url and an identifier is passed', async () => {
+    await taiko.openTab({ name: 'github' });
+    expect(actualOptions.name).to.equal('github');
+    expect(targetHandler.register('github')).to.equal(target.id);
+  });
+
+  it('should set about:blank as the url with identifier', async () => {
+    await taiko.openTab({ name: 'github' });
+    expect(actualUrl).to.equal('about:blank');
+  });
+
+  it('should set about:blank when no parameters are passed', async () => {
+    await taiko.openTab();
+    expect(actualUrl).to.equal('about:blank');
   });
 });

--- a/test/unit-tests/switchTo.test.js
+++ b/test/unit-tests/switchTo.test.js
@@ -21,18 +21,20 @@ describe('switchTo', () => {
   });
 
   it('should throw error if no url specified', async () => {
-    await expect(taiko.switchTo()).to.eventually.rejectedWith(TypeError);
+    await expect(taiko.switchTo()).to.eventually.rejectedWith(
+      'The "targetUrl" argument must be of type string, regex or identifier. Received type undefined',
+    );
   });
 
   it('should throw error if url is empty', async () => {
     await expect(taiko.switchTo('')).to.eventually.rejectedWith(
-      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex',
+      'Cannot switch to tab or window as the targetUrl is empty. Please use a valid string, regex or identifier',
     );
   });
 
   it('should throw error if url is only spaces', async () => {
     await expect(taiko.switchTo('  ')).to.eventually.rejectedWith(
-      'Cannot switch to tab or window. Hint: The targetUrl is empty. Please use a valid string or regex',
+      'Cannot switch to tab or window as the targetUrl is empty. Please use a valid string, regex or identifier',
     );
   });
 

--- a/test/unit-tests/switchTo.test.js
+++ b/test/unit-tests/switchTo.test.js
@@ -7,12 +7,20 @@ chai.use(chaiAsPromised);
 
 describe('switchTo', () => {
   let argument, taiko;
+  let registeredTarget;
+
   before(async () => {
     taiko = rewire('../../lib/taiko');
     taiko.__set__('validate', () => {});
     taiko.__set__('targetHandler.getCriTargets', (arg) => {
       argument = arg;
       return { matching: [] };
+    });
+    taiko.__set__('targetHandler.register', () => {
+      return registeredTarget;
+    });
+    taiko.__set__('connect_to_cri', () => {
+      return registeredTarget;
     });
   });
 
@@ -43,5 +51,18 @@ describe('switchTo', () => {
       'No tab(s) matching /http(s):\\/\\/www.google.com/ found',
     );
     await expect(argument).to.deep.equal(new RegExp(/http(s):\/\/www.google.com/));
+  });
+
+  it('should accept window identifier', async () => {
+    await expect(taiko.switchTo({ name: 'github' })).to.eventually.rejectedWith(
+      'Could not find window/tab with name github to switch.',
+    );
+  });
+
+  it('should switch to tab matching identifier', async () => {
+    registeredTarget = {
+      id: 'github',
+    };
+    await expect(taiko.switchTo({ name: 'github' })).to.eventually.fulfilled;
   });
 });


### PR DESCRIPTION
Fixes: #1062
Fixes: ##1440

* target handler handles both window and tab identifier caching
* Logic for registering tabs and windows with windows is not out of `BrowserContext`

### Usage

```
openTab({ name: 'google'});
goto('google.com');
openTab('github.com', { name: 'github'});
openTab('taiko.dev')
switchTo({ name: 'github'});
switchTo(/google/);
closeTab({name: 'github'});
```

