### PR TITLE
Remove types for intervalSecs timeoutSecs

### DIFF
--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -532,10 +532,6 @@ declare module 'taiko' {
     handlerCallback?: (element: HTMLElement, args?: EvaluateElementOptions) => Record<string, any>,
     options?: NavigationOptions,
   ): Promise<Record<string, any>>;
-  // https://docs.taiko.dev/api/intervalsecs
-  export function intervalSecs(secs: number): number;
-  // https://docs.taiko.dev/api/timeoutsecs
-  export function timeoutSecs(secs: number): number;
   // https://docs.taiko.dev/api/to
   export function to(value: SearchElement): SearchElement;
   // https://docs.taiko.dev/api/into


### PR DESCRIPTION
Ciao,

As discussed in issue #1383 there are a few inconsistencies in the "types" definition `index.d.ts`.

This PR simply removes from `inde.d.ts` two functions (`intervalSec` and `timeoutSecs`) which were removed from `taiko.js` some months ago, but the corresponding type declaration has stayed untouched.

This is a very small PR just to get me started working on the topic.
Since this is my first PR I am new to this workflow, I am making this very small PR in order to check if everything is fine in the process. If everything's fine I'll propose some more beefy PR to address other types' inconsistencies and I will also try and introduce some testing for the types.

Thanks,
Filippo