### PR TITLE
Adding missing types (and testing that we don't miss them again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ lib/api.json
 tags
 _site
 apis.json
+
+#generated types testing
+types/taiko/test/generated

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "./types/taiko/index.d.ts",
   "scripts": {
     "lint": "eslint --fix --ext js,ts .",
-    "dtslint": "dtslint types/taiko",
+    "dtslint": "node ./test/types-test-support/generate-types-test.js && dtslint types/taiko",
     "doc": "npm run doc:api && eleventy",
     "doc:serve": "npm run doc:api && eleventy --serve",
     "doc:api": "node lib/documentation.js",

--- a/test/types-test-support/generate-types-test.js
+++ b/test/types-test-support/generate-types-test.js
@@ -1,0 +1,35 @@
+const taiko = require('../../lib/taiko');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+/**
+ * This writes a TS file that simply instantiates every function exported by taiko.
+ * Then it is possible to dtslint that file and see if any exported function lacks
+ * a type definition in index.d.ts.
+ */
+(async () => {
+  const BASE_DIR = './types/taiko/test/generated';
+  const FILENAME = 'generated-type-test.ts';
+  const filePath = path.join(BASE_DIR, FILENAME);
+
+  async function writeTestFileContent(funcs, stream) {
+    await stream.write("import * as taiko from '../../../taiko';\n\n");
+    funcs.sort().forEach(async (item) => await stream.write(`taiko.${item};\n`));
+  }
+
+  try {
+    const allExportedFuncs = Object.keys(taiko).filter(
+      (item) => item !== 'emitter' && item !== 'metadata',
+    );
+
+    await util.promisify(fs.mkdir)(BASE_DIR, { recursive: true });
+    const writeStream = fs.createWriteStream(filePath);
+    await writeTestFileContent(allExportedFuncs, writeStream);
+    writeStream.close();
+    return filePath;
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})().then((filePath) => console.log('Generated ' + filePath));

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -447,6 +447,18 @@ export function range(
   options?: SelectionOptions | RelativeSearchElement,
   ...args: RelativeSearchElement[]
 ): ElementWrapper;
+// https://docs.taiko.dev/api/color
+export function color(
+  selector: SearchElement,
+  options?: SelectionOptions | RelativeSearchElement,
+  ...args: RelativeSearchElement[]
+): ElementWrapper;
+// https://docs.taiko.dev/api/tableCell
+export function tableCell(
+  options: SelectionOptions | RelativeSearchElement | undefined,
+  selector: SearchElement,
+  ...args: RelativeSearchElement[]
+): ElementWrapper;
 // https://docs.taiko.dev/api/textbox
 export function textBox(selector: SearchElement, ...args: RelativeSearchElement[]): ElementWrapper;
 // https://docs.taiko.dev/api/dropdown

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -254,7 +254,7 @@ export interface MouseCoordinates {
 
 /**
  * Browser Actions
- **/
+ */
 
 // https://docs.taiko.dev/api/openbrowser
 export function openBrowser(options?: BrowserOptions): Promise<void>;
@@ -319,7 +319,7 @@ export function setCookie(
 // https://docs.taiko.dev/api/deletecookies
 export function deleteCookies(cookieName?: string, options?: CookieOptions): Promise<void>;
 // https://docs.taiko.dev/api/getcookies
-export function getCookies(options?: { urls: string[] }): Promise<Record<string, any>[]>;
+export function getCookies(options?: { urls: string[] }): Promise<Array<Record<string, any>>>;
 // https://docs.taiko.dev/api/setlocation
 export function setLocation(options: LocationOptions): Promise<void>;
 
@@ -507,7 +507,7 @@ export function confirm(
 ): void;
 
 // https://docs.taiko.dev/api/beforeunload
-export function beforeunload(message: string, callback: Function): void;
+export function beforeunload(message: string, callback: () => Promise<void>): void;
 
 /**
  * Helpers
@@ -533,6 +533,8 @@ export function setConfig(options: GlobalConfigurationOptions): void;
 export function currentURL(): Promise<string>;
 // https://docs.taiko.dev/api/waitfor
 export function waitFor(time: number): Promise<void>;
-export function waitFor(element: SearchElement, time: number): Promise<void>;
-export function waitFor(condition: () => Promise<boolean>, time: number): Promise<void>;
+export function waitFor(
+  elementOrCondition: SearchElement | (() => Promise<boolean>),
+  time: number,
+): Promise<void>;
 export function clearIntercept(requestUrl?: string): void;

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -441,6 +441,12 @@ export function timeField(
   options?: SelectionOptions | RelativeSearchElement,
   ...args: RelativeSearchElement[]
 ): ElementWrapper;
+// https://docs.taiko.dev/api/range
+export function range(
+  selector: SearchElement,
+  options?: SelectionOptions | RelativeSearchElement,
+  ...args: RelativeSearchElement[]
+): ElementWrapper;
 // https://docs.taiko.dev/api/textbox
 export function textBox(selector: SearchElement, ...args: RelativeSearchElement[]): ElementWrapper;
 // https://docs.taiko.dev/api/dropdown

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -375,6 +375,8 @@ export function attach(filepath: string, to: SearchElement): Promise<void>;
 export function press(keys: string | string[], options?: KeyOptions): Promise<void>;
 // https://docs.taiko.dev/api/highlight
 export function highlight(selector: SearchElement, ...args: RelativeSearchElement[]): Promise<void>;
+// https://docs.taiko.dev/api/clearHighlights
+export function clearHighlights(): Promise<void>;
 // https://docs.taiko.dev/api/mouseaction
 export function mouseAction(
   selector: SearchElement | 'press' | 'move' | 'release',

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -435,6 +435,12 @@ export function fileField(
   options?: SelectionOptions | RelativeSearchElement,
   ...args: RelativeSearchElement[]
 ): ElementWrapper;
+// https://docs.taiko.dev/api/timefield
+export function timeField(
+  selector: SearchElement,
+  options?: SelectionOptions | RelativeSearchElement,
+  ...args: RelativeSearchElement[]
+): ElementWrapper;
 // https://docs.taiko.dev/api/textbox
 export function textBox(selector: SearchElement, ...args: RelativeSearchElement[]): ElementWrapper;
 // https://docs.taiko.dev/api/dropdown

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -1,0 +1,4 @@
+import * as taiko from '../../taiko';
+
+// $ExpectType Promise<void>
+taiko.openBrowser();

--- a/types/taiko/tslint.json
+++ b/types/taiko/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "no-relative-import-in-test": false
+    }
+}


### PR DESCRIPTION
Hi.

With this PR I would like to accomplish three things:

1. to have `dtslint` start analyzing the types
2. to introduce a test to check that all exported members of `taiko.js` are declared as types in `index.d.ts`
3. to add missing types and fix bug #1383 

The second point is achieved by automatically generating a typescript file that instantiates every member of `taiko.js` and giving it to `dtslint` for analyzing. Of course `dtslint` will complain for every member which is not declared in `index.d.ts`.

The first run gave errors on:

* clearHighlights
* timeField
* range
* tableCell
* color

All of them are fixed in this PR (which should also close bug #1383).

Please let me know what you think.

Thanks,
Filippo
