### PR TITLE
Fixed types for taiko.getConfig() and GlobalConfigurationOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "./types/taiko/index.d.ts",
   "scripts": {
     "lint": "eslint --fix --ext js,ts .",
-    "dtslint": "node ./test/types-test-support/generate-types-test.js && dtslint types/taiko",
+    "dtslint": "node ./test/types-test-support/generate-types-test.js && eslint --fix --ext js,ts . && dtslint types/taiko",
     "doc": "npm run doc:api && eleventy",
     "doc:serve": "npm run doc:api && eleventy --serve",
     "doc:api": "node lib/documentation.js",

--- a/test/types-test-support/generate-types-test.js
+++ b/test/types-test-support/generate-types-test.js
@@ -1,35 +1,94 @@
 const taiko = require('../../lib/taiko');
+const config = require('../../lib/config');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
 
-/**
- * This writes a TS file that simply instantiates every function exported by taiko.
- * Then it is possible to dtslint that file and see if any exported function lacks
- * a type definition in index.d.ts.
- */
 (async () => {
-  const BASE_DIR = './types/taiko/test/generated';
-  const FILENAME = 'generated-type-test.ts';
-  const filePath = path.join(BASE_DIR, FILENAME);
+  /**
+   * This writes a TS file that simply instantiates every function exported by taiko.
+   * Then it is possible to dtslint that file and see if any exported function lacks
+   * a type definition in index.d.ts.
+   */
+  async function genTypeTestForTaiko() {
+    const BASE_DIR = './types/taiko/test/generated';
+    const FILENAME = 'generated-type-test.ts';
+    const filePath = path.join(BASE_DIR, FILENAME);
 
-  async function writeTestFileContent(funcs, stream) {
-    await stream.write("import * as taiko from '../../../taiko';\n\n");
-    funcs.sort().forEach(async (item) => await stream.write(`taiko.${item};\n`));
+    try {
+      await util.promisify(fs.mkdir)(BASE_DIR, { recursive: true });
+      const writeStream = fs.createWriteStream(filePath);
+      writeStream.write(generateTestFileContent());
+      writeStream.close();
+      return filePath;
+    } catch (e) {
+      console.error(e);
+      process.exit(1);
+    }
+
+    /**
+     * Generate the test-file content
+     */
+    function generateTestFileContent() {
+      /**
+       * Generates import statements.
+       */
+      function generateImports() {
+        return "import * as taiko from '../../../taiko';\n\n";
+      }
+
+      /**
+       * Generates statements that instantiate each and every function exported by taiko.
+       * Dtslint will look ato those statements and complain if any of the instantiated
+       * functions lacks a type definition in index.d.ts.
+       */
+      function generateTestForTaikoFuncs() {
+        const funcs = Object.keys(taiko).filter(
+          (item) => item !== 'emitter' && item !== 'metadata',
+        );
+        let result = '';
+        funcs.sort().forEach(async (item) => (result += `taiko.${item};\n`));
+        result += '\n';
+        return result;
+      }
+
+      /**
+       * Generates a statement that instantiates a const of the specified type and assigns the
+       * literal to the const.
+       * Dtslint will look as the generated function and produce warnings if the fields in
+       * the literal and in the type declaration are not consinstent.
+       * The assignment is wrapped in an exported function to avoid irrelevant lint warnings.
+       *
+       * @param {string} typeName type to be assigned to the constant producing something
+       * like `const a: <typeName> = ...`
+       * @param {object} literal value to be assigned to the constant producing something
+       * like `const a: <typeName> = <literal>;`
+       *
+       */
+      function generateLiteralToObjectAssignment(typeName, literal) {
+        function createNamesFromType() {
+          function firstToUpper(str) {
+            return str.charAt(0).toUpperCase() + str.slice(1);
+          }
+          const simpleName = typeName.replace(/\./, '');
+          const functionName = 'get' + firstToUpper(simpleName);
+          const constName = 'c' + firstToUpper(simpleName);
+          return { functionName, constName };
+        }
+        const { functionName, constName } = createNamesFromType();
+        let result =
+          `export function ${functionName}(){\n` +
+          `const ${constName}: ${typeName} = ${JSON.stringify(literal)};\n` +
+          `return ${constName};\n` +
+          '}\n\n';
+        return result;
+      }
+      return (
+        generateImports() +
+        generateTestForTaikoFuncs() +
+        generateLiteralToObjectAssignment('taiko.GlobalConfigurationOptions', config.defaultConfig)
+      );
+    }
   }
-
-  try {
-    const allExportedFuncs = Object.keys(taiko).filter(
-      (item) => item !== 'emitter' && item !== 'metadata',
-    );
-
-    await util.promisify(fs.mkdir)(BASE_DIR, { recursive: true });
-    const writeStream = fs.createWriteStream(filePath);
-    await writeTestFileContent(allExportedFuncs, writeStream);
-    writeStream.close();
-    return filePath;
-  } catch (e) {
-    console.error(e);
-    process.exit(1);
-  }
+  return await genTypeTestForTaiko();
 })().then((filePath) => console.log('Generated ' + filePath));

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -44,10 +44,18 @@ export interface ClickOptions extends NavigationOptions {
   elementsToMatch?: number;
 }
 
-export interface GlobalConfigurationOptions extends BasicNavigationOptions {
+export interface GlobalConfigurationOptions {
+  navigationTimeout?: number;
   observeTime?: number;
   retryInterval?: number;
   retryTimeout?: number;
+  observe?: boolean;
+  waitForNavigation?: boolean;
+  ignoreSSLErrors?: boolean;
+  headful?: boolean;
+  criConnectionRetries?: number;
+  firefox?: boolean;
+  highlightOnAction?: 'true' | 'false';
 }
 
 export interface TapOptions extends BasicNavigationOptions, EventOptions {}
@@ -555,6 +563,8 @@ export function accept(text?: string): Promise<void>;
 export function dismiss(text?: string): Promise<void>;
 // https://docs.taiko.dev/api/setconfig
 export function setConfig(options: GlobalConfigurationOptions): void;
+// https://docs.taiko.dev/api/getconfig
+export function getConfig(option?: keyof GlobalConfigurationOptions): number | boolean | undefined;
 // https://docs.taiko.dev/api/currenturl
 export function currentURL(): Promise<string>;
 // https://docs.taiko.dev/api/waitfor


### PR DESCRIPTION
The function `taiko.getConfig()` had no type declaration in `index.d.ts`

`GlobalConfigurationOptions` is a type that was declared incorrectly in `index.d.ts`, meaning that it was
not consistent with the default configuration as declared in
`lib/config.js --> defaultConfig`

I extended `generate-types-test.js`: now it generates a test that finds
inconsistencies between `GlobalConfigurationOptions` and `defaultConfig`.
