### PR TITLE
Test types for browser actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4754,6 +4754,12 @@
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
       "dev": true
     },
+    "devtools-protocol": {
+      "version": "0.0.802093",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.802093.tgz",
+      "integrity": "sha512-if0PDdWnDlEA+kcjEDe/c+7Ts7YkB+N5GUgfDuxvAz7cBXF+/CPpjIHHn5vfqkLB3N1kRt5yE+ioM5g4B8t2tA==",
+      "dev": true
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cssnano": "^4.1.10",
+    "devtools-protocol": "0.0.802093",
     "documentation": "^13.0.2",
     "dtslint": "^3.6.14",
     "eleventy-plugin-toc": "^1.0.1",

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -322,6 +322,7 @@ export function openIncognitoWindow(
 // https://docs.taiko.dev/api/closeincognitowindow
 export function closeIncognitoWindow(name: string): Promise<void>;
 // https://docs.taiko.dev/api/overridepermissions
+// TODO: use the proper type for the second param from devtools-protocol
 export function overridePermissions(origin: string, permissions: string[]): Promise<void>;
 // https://docs.taiko.dev/api/clearpermissionoverrides
 export function clearPermissionOverrides(): Promise<void>;

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -271,7 +271,8 @@ export function closeBrowser(): Promise<void>;
 // https://docs.taiko.dev/api/client
 export function client(): any; // TODO: no TS Bindings available: https://github.com/cyrus-and/chrome-remote-interface/issues/112
 // https://docs.taiko.dev/api/switchto
-export function switchTo(targetUrl: string): Promise<void>;
+// TODO: fix corresponding JSDoc in lib/taiko.js
+export function switchTo(target: RegExp | OpenWindowOptions): Promise<void>;
 // https://docs.taiko.dev/api/intercept
 // https://github.com/getgauge/taiko/issues/98#issuecomment-42024186
 export function intercept(

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -76,6 +76,7 @@ export interface ScreenshotOptions {
   encoding?: string;
 }
 
+// TODO: remove this type declaration and replace with devtools-protocol Emulation.SetDeviceMetricsOverrideRequest
 export interface ViewPortOptions {
   width: number;
   height: number;

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -219,7 +219,12 @@ export interface InterceptMockData {
   [key: string]: any;
 }
 export interface InterceptRequest {
-  continue(url: string): Promise<void>;
+  continue(overrides: {
+    url?: string;
+    method?: string;
+    postData?: string;
+    headers?: Record<string, unknown>;
+  }): Promise<void>;
   respond(response: InterceptMockData): Promise<void>;
 }
 export type interceptRequestHandler = (request: InterceptRequest) => Promise<void>;

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -35,7 +35,7 @@ export interface BasicNavigationOptions {
 
 export interface NavigationOptions extends BasicNavigationOptions, EventOptions {
   headers?: object;
-  waitForStart?: boolean;
+  waitForStart?: number;
 }
 
 export interface ClickOptions extends NavigationOptions {
@@ -127,7 +127,7 @@ export interface MatchingOptions {
   exactMatch: boolean;
 }
 
-export interface OpenWindowOptions extends NavigationOptions {
+export interface OpenWindowOrTabOptions extends NavigationOptions {
   name: string;
 }
 
@@ -278,7 +278,7 @@ export function closeBrowser(): Promise<void>;
 export function client(): any; // TODO: no TS Bindings available: https://github.com/cyrus-and/chrome-remote-interface/issues/112
 // https://docs.taiko.dev/api/switchto
 // TODO: fix corresponding JSDoc in lib/taiko.js
-export function switchTo(target: RegExp | OpenWindowOptions): Promise<void>;
+export function switchTo(target: RegExp | OpenWindowOrTabOptions): Promise<void>;
 // https://docs.taiko.dev/api/intercept
 // https://github.com/getgauge/taiko/issues/98#issuecomment-42024186
 export function intercept(
@@ -311,13 +311,13 @@ export function setViewPort(options: ViewPortOptions): Promise<void>;
 // https://docs.taiko.dev/api/emulateTimezone
 export function emulateTimezone(timezoneId: string): Promise<void>;
 // https://docs.taiko.dev/api/opentab
-export function openTab(targetUrl: string, options?: NavigationOptions): Promise<void>;
+export function openTab(targetUrl?: string, options?: OpenWindowOrTabOptions): Promise<void>;
 // https://docs.taiko.dev/api/closetab
 export function closeTab(targetUrl?: string): Promise<void>;
 // https://docs.taiko.dev/api/openincognitowindow
 export function openIncognitoWindow(
-  url?: string | OpenWindowOptions,
-  options?: OpenWindowOptions,
+  url?: string | OpenWindowOrTabOptions,
+  options?: OpenWindowOrTabOptions,
 ): Promise<void>;
 // https://docs.taiko.dev/api/closeincognitowindow
 export function closeIncognitoWindow(name: string): Promise<void>;

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -313,7 +313,7 @@ export function emulateTimezone(timezoneId: string): Promise<void>;
 // https://docs.taiko.dev/api/opentab
 export function openTab(targetUrl?: string, options?: OpenWindowOrTabOptions): Promise<void>;
 // https://docs.taiko.dev/api/closetab
-export function closeTab(targetUrl?: string): Promise<void>;
+export function closeTab(targetUrl?: string | RegExp): Promise<void>;
 // https://docs.taiko.dev/api/openincognitowindow
 export function openIncognitoWindow(
   url?: string | OpenWindowOrTabOptions,

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -1,5 +1,10 @@
 // Custom Typings for Taiko - https://docs.taiko.dev/api/reference
 
+// eslint-disable-next-line no-unused-vars
+import Protocol from 'devtools-protocol';
+
+export type Cookie = Protocol.Network.Cookie;
+
 export type BrowserEvent =
   | 'DOMContentLoaded'
   | 'loadEventFired'
@@ -335,7 +340,7 @@ export function setCookie(
 // https://docs.taiko.dev/api/deletecookies
 export function deleteCookies(cookieName?: string, options?: CookieOptions): Promise<void>;
 // https://docs.taiko.dev/api/getcookies
-export function getCookies(options?: { urls: string[] }): Promise<Array<Record<string, any>>>;
+export function getCookies(options?: { urls: string[] }): Cookie[];
 // https://docs.taiko.dev/api/setlocation
 export function setLocation(options: LocationOptions): Promise<void>;
 

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -1,4 +1,12 @@
-import { openBrowser, closeBrowser, switchTo, intercept } from '../../taiko';
+import {
+  openBrowser,
+  closeBrowser,
+  switchTo,
+  intercept,
+  emulateNetwork,
+  emulateDevice,
+  setViewPort,
+} from '../../taiko';
 
 // ------------------------------------------
 // openBrowser
@@ -31,7 +39,7 @@ closeBrowser({}); // $ExpectError
 
 // ------------------------------------------
 // switchTo
-// https://docs.taiko.dev/api/switchTo
+// https://docs.taiko.dev/api/switchto
 // ------------------------------------------
 
 switchTo(/taiko.dev/); // $ExpectType Promise<void>
@@ -65,6 +73,16 @@ intercept('http://localhost:3000/api/customers/11', {
 intercept('https://maps.gstatic.com/mapfiles/api-3/images/google4_hdpi.png', (request) => {
   request.continue({ url: 'http://localhost:3000/assets/images/female.png' });
 });
+// $ExpectType Promise<void>
+intercept('https://maps.gstatic.com/mapfiles/api-3/images/google4_hdpi.png', (request) => {
+  request.continue({
+    url: 'http://localhost:3000/assets/images/female.png',
+    headers: {
+      foo: 'bar', // set "foo" header
+      origin: undefined, // remove "origin" header
+    },
+  });
+});
 
 // Case 4: Redirect URL (Overrides male.png to female.png)
 // $ExpectType Promise<void>
@@ -85,4 +103,44 @@ intercept('http://localhost:3000/api/customers/1', (request) => {
       '{"productName":"Shoes","itemCost":199.99}],' +
       '"latitude":33.299,"longitude":-111.963}',
   });
+});
+
+// ------------------------------------------
+// emulateNetwork
+// https://docs.taiko.dev/api/emulatenetwork
+// ------------------------------------------
+
+emulateNetwork('Offline'); // $ExpectType Promise<void>
+emulateNetwork('Good2G'); // $ExpectType Promise<void>
+emulateNetwork({ offline: false, downloadThroughput: 6400, uploadThroughput: 2560, latency: 500 }); // $ExpectType Promise<void>
+emulateNetwork({ downloadThroughput: 6400, uploadThroughput: 2560, latency: 500 }); // $ExpectType Promise<void>
+
+// ------------------------------------------
+// emulateDevice
+// https://docs.taiko.dev/api/emulatedevice
+// ------------------------------------------
+
+emulateDevice('iPhone 6'); // $ExpectType Promise<void>
+
+// ------------------------------------------
+// setViewPort
+// https://docs.taiko.dev/api/setviewport
+// ------------------------------------------
+
+setViewPort({ width: 600, height: 800 }); // $ExpectType Promise<void>
+
+// $ExpectType Promise<void>
+setViewPort({
+  width: 600,
+  height: 800,
+  deviceScaleFactor: 1,
+  mobile: true,
+  scale: 1,
+  screenWidth: 1,
+  screenHeight: 1,
+  positionX: 1,
+  positionY: 1,
+  dontSetVisibleSize: true,
+  screenOrientation: { type: 'landscapePrimary', angle: 0 },
+  viewport: { x: 1, y: 1, width: 1, height: 1, scale: 1 },
 });

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -6,6 +6,7 @@ import {
   emulateNetwork,
   emulateDevice,
   setViewPort,
+  openTab,
 } from '../../taiko';
 
 // ------------------------------------------
@@ -143,4 +144,28 @@ setViewPort({
   dontSetVisibleSize: true,
   screenOrientation: { type: 'landscapePrimary', angle: 0 },
   viewport: { x: 1, y: 1, width: 1, height: 1, scale: 1 },
+});
+
+// ------------------------------------------
+// openTab
+// https://docs.taiko.dev/api/opentab
+// ------------------------------------------
+
+openTab('https://taiko.dev');
+openTab();
+openTab('https://taiko.dev', { name: 'taiko' });
+openTab('https://taiko.dev', {
+  waitForNavigation: true,
+  name: 'aaa',
+  navigationTimeout: 10000,
+  waitForStart: 200,
+  waitForEvents: [
+    'DOMContentLoaded',
+    'loadEventFired',
+    'networkAlmostIdle',
+    'networkIdle',
+    'firstPaint',
+    'firstContentfulPaint',
+    'firstMeaningfulPaint',
+  ],
 });

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -7,6 +7,7 @@ import {
   emulateDevice,
   setViewPort,
   openTab,
+  closeTab,
 } from '../../taiko';
 
 // ------------------------------------------
@@ -151,9 +152,10 @@ setViewPort({
 // https://docs.taiko.dev/api/opentab
 // ------------------------------------------
 
-openTab('https://taiko.dev');
-openTab();
-openTab('https://taiko.dev', { name: 'taiko' });
+openTab('https://taiko.dev'); // $ExpectType Promise<void>
+openTab(); // $ExpectType Promise<void>
+openTab('https://taiko.dev', { name: 'taiko' }); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
 openTab('https://taiko.dev', {
   waitForNavigation: true,
   name: 'aaa',
@@ -169,3 +171,14 @@ openTab('https://taiko.dev', {
     'firstMeaningfulPaint',
   ],
 });
+
+// ------------------------------------------
+// closeTab
+// https://docs.taiko.dev/api/closetab
+// ------------------------------------------
+
+closeTab(); // $ExpectType Promise<void>
+closeTab('Open Source Test Automation Framework | Gauge'); // $ExpectType Promise<void>
+closeTab('https://gauge.org'); // $ExpectType Promise<void>
+closeTab(/Go*gle/); // $ExpectType Promise<void>
+closeTab(/http(s?):\/\/(www?).google.(com|co.in|co.uk)/); // $ExpectType Promise<void>

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -12,6 +12,11 @@ import {
   closeIncognitoWindow,
   overridePermissions,
   clearPermissionOverrides,
+  setCookie,
+  deleteCookies,
+  getCookies,
+  setLocation,
+  clearIntercept,
 } from '../../taiko';
 
 // ------------------------------------------
@@ -233,3 +238,68 @@ overridePermissions('http://maps.google.com', ['geolocation']); // $ExpectType P
 // ------------------------------------------
 
 clearPermissionOverrides(); // $ExpectType Promise<void>
+
+// ------------------------------------------
+// setCookie
+// https://docs.taiko.dev/api/setCookie
+// ------------------------------------------
+
+setCookie('CSRFToken', 'csrfToken', { url: 'http://the-internet.herokuapp.com' }); // $ExpectType Promise<void>
+setCookie('CSRFToken', 'csrfToken', { domain: 'herokuapp.com' }); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
+setCookie('CSRFToken', 'csrfToken', {
+  url: 'an url',
+  domain: 'a domain',
+  path: 'a path',
+  secure: true,
+  httpOnly: true,
+  sameSite: 'a string',
+  expires: 1000000,
+});
+setCookie('CSRFToken', 'csrfToken', {}); // $ExpectType Promise<void>
+setCookie('CSRFToken', 'csrfToken'); // $ExpectType Promise<void>
+
+// ------------------------------------------
+// deleteCookies
+// https://docs.taiko.dev/api/deleteCookies
+// ------------------------------------------
+
+deleteCookies(); // $ExpectType Promise<void>
+deleteCookies('CSRFToken', { url: 'http://the-internet.herokuapp.com' }); // $ExpectType Promise<void>
+deleteCookies('CSRFToken', { domain: 'herokuapp.com' }); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
+deleteCookies('CSRFToken', {
+  url: 'an url',
+  domain: 'a domain',
+  path: 'a path',
+});
+
+// ------------------------------------------
+// getCookies
+// https://docs.taiko.dev/api/getCookies
+// ------------------------------------------
+
+getCookies(); // $ExpectType Cookie[]
+getCookies({ urls: ['https://the-internet.herokuapp.com'] }); // $ExpectType Cookie[]
+
+// ------------------------------------------
+// setLocation
+// https://docs.taiko.dev/api/setLocation
+// ------------------------------------------
+
+// $ExpectType Promise<void>
+setLocation({ latitude: 27.1752868, longitude: 78.040009, accuracy: 20 });
+// $ExpectType Promise<void>
+setLocation({ latitude: 27.1752868, longitude: 78.040009 });
+// $ExpectError
+setLocation({ latitude: 27.1752868 });
+// $ExpectError
+setLocation({ longitude: 78.040009 });
+
+// ------------------------------------------
+// clearIntercept
+// https://docs.taiko.dev/api/clearIntercept
+// ------------------------------------------
+
+clearIntercept('https://google.com'); // $ExpectType void
+clearIntercept(); // $ExpectType void

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -1,4 +1,4 @@
-import { openBrowser, closeBrowser, switchTo } from '../../taiko';
+import { openBrowser, closeBrowser, switchTo, intercept } from '../../taiko';
 
 // ------------------------------------------
 // openBrowser
@@ -40,3 +40,49 @@ switchTo(/http(s?):\/\/(www?).google.(com|co.in|co.uk)/); // $ExpectType Promise
 switchTo(/Go*gle/); // $ExpectType Promise<void>
 switchTo(/google.com/); // $ExpectType Promise<void>
 switchTo({ name: 'newyorktimes' }); // $ExpectType Promise<void>
+
+// ------------------------------------------
+// intercept
+// https://docs.taiko.dev/api/intercept
+// ------------------------------------------
+
+// Case 1: Block URL (Blocks all request for people.png)
+// $ExpectType Promise<void>
+intercept('http://localhost:3000/assets/images/people.png');
+
+// Case 2: Mock response (Mocks response to modify address from "888 Central St." to "12345 Central St." )
+// $ExpectType Promise<void>
+intercept('http://localhost:3000/api/customers/11', {
+  body:
+    '{"id":11,"firstName":"ward","lastName":"bell","gender":"male",' +
+    '"address":"12345 Central St.","city":"Los Angeles",' +
+    '"state":{"abbreviation":"CA","name":"California"},' +
+    '"latitude":34.042552,"longitude":-118.266429}',
+});
+
+// Case 3: Override request (Overrides google4_hdpi.png url to return female.png can be seen in map)
+// $ExpectType Promise<void>
+intercept('https://maps.gstatic.com/mapfiles/api-3/images/google4_hdpi.png', (request) => {
+  request.continue({ url: 'http://localhost:3000/assets/images/female.png' });
+});
+
+// Case 4: Redirect URL (Overrides male.png to female.png)
+// $ExpectType Promise<void>
+intercept(
+  'http://localhost:3000/assets/images/male.png',
+  'http://localhost:3000/assets/images/female.png',
+);
+
+// Case 5: Mock response based on request (Mocks response to modify address from "1234 Anywhere St." to "888 Anywhere St.")
+// $ExpectType Promise<void>
+intercept('http://localhost:3000/api/customers/1', (request) => {
+  request.respond({
+    body:
+      '{"id":1,"firstName":"ted","lastName":"james",' +
+      '"gender":"male","address":"888 Anywhere St.","city":" Phoenix ",' +
+      '"state":{"abbreviation":"AZ","name":"Arizona"},' +
+      '"orders":[{"productName":"Basketball","itemCost":7.99},' +
+      '{"productName":"Shoes","itemCost":199.99}],' +
+      '"latitude":33.299,"longitude":-111.963}',
+  });
+});

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -1,4 +1,4 @@
-import { openBrowser, closeBrowser } from '../../taiko';
+import { openBrowser, closeBrowser, switchTo } from '../../taiko';
 
 // ------------------------------------------
 // openBrowser
@@ -28,3 +28,15 @@ openBrowser({
 
 closeBrowser(); // $ExpectType Promise<void>
 closeBrowser({}); // $ExpectError
+
+// ------------------------------------------
+// switchTo
+// https://docs.taiko.dev/api/switchTo
+// ------------------------------------------
+
+switchTo(/taiko.dev/); // $ExpectType Promise<void>
+switchTo(/Taiko/); // $ExpectType Promise<void>
+switchTo(/http(s?):\/\/(www?).google.(com|co.in|co.uk)/); // $ExpectType Promise<void>
+switchTo(/Go*gle/); // $ExpectType Promise<void>
+switchTo(/google.com/); // $ExpectType Promise<void>
+switchTo({ name: 'newyorktimes' }); // $ExpectType Promise<void>

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -1,4 +1,30 @@
-import * as taiko from '../../taiko';
+import { openBrowser, closeBrowser } from '../../taiko';
+
+// ------------------------------------------
+// openBrowser
+// https://docs.taiko.dev/api/openbrowser
+// ------------------------------------------
+
+openBrowser(); // $ExpectType Promise<void>
+openBrowser({ headless: false }); // $ExpectType Promise<void>
+openBrowser({ args: ['--window-size=1440,900'] }); // $ExpectType Promise<void>
 
 // $ExpectType Promise<void>
-taiko.openBrowser();
+openBrowser({
+  args: [
+    '--disable-gpu',
+    '--disable-dev-shm-usage',
+    '--disable-setuid-sandbox',
+    '--no-first-run',
+    '--no-sandbox',
+    '--no-zygote',
+  ],
+});
+
+// ------------------------------------------
+// closeBrowser
+// https://docs.taiko.dev/api/closebrowser
+// ------------------------------------------
+
+closeBrowser(); // $ExpectType Promise<void>
+closeBrowser({}); // $ExpectError

--- a/types/taiko/test/taiko-types-test.ts
+++ b/types/taiko/test/taiko-types-test.ts
@@ -8,6 +8,10 @@ import {
   setViewPort,
   openTab,
   closeTab,
+  openIncognitoWindow,
+  closeIncognitoWindow,
+  overridePermissions,
+  clearPermissionOverrides,
 } from '../../taiko';
 
 // ------------------------------------------
@@ -182,3 +186,50 @@ closeTab('Open Source Test Automation Framework | Gauge'); // $ExpectType Promis
 closeTab('https://gauge.org'); // $ExpectType Promise<void>
 closeTab(/Go*gle/); // $ExpectType Promise<void>
 closeTab(/http(s?):\/\/(www?).google.(com|co.in|co.uk)/); // $ExpectType Promise<void>
+
+// ------------------------------------------
+// openIncognitoWindow
+// https://docs.taiko.dev/api/openIncognitoWindow
+// ------------------------------------------
+
+openIncognitoWindow(); // $ExpectType Promise<void>
+openIncognitoWindow('https://google.com'); // $ExpectType Promise<void>
+openIncognitoWindow('https://google.com', { name: 'windowName' }); // $ExpectType Promise<void>
+// $ExpectType Promise<void>
+openIncognitoWindow('https://google.com', {
+  waitForNavigation: true,
+  name: 'aaa',
+  navigationTimeout: 10000,
+  waitForStart: 200,
+  waitForEvents: [
+    'DOMContentLoaded',
+    'loadEventFired',
+    'networkAlmostIdle',
+    'networkIdle',
+    'firstPaint',
+    'firstContentfulPaint',
+    'firstMeaningfulPaint',
+  ],
+});
+
+// ------------------------------------------
+// closeIncognitoWindow
+// https://docs.taiko.dev/api/closeIncognitoWindow
+// ------------------------------------------
+
+closeIncognitoWindow('windowName'); // $ExpectType Promise<void>
+closeIncognitoWindow(); // $ExpectError
+
+// ------------------------------------------
+// overridePermissions
+// https://docs.taiko.dev/api/overridePermissions
+// ------------------------------------------
+
+overridePermissions('http://maps.google.com', ['geolocation']); // $ExpectType Promise<void>
+
+// ------------------------------------------
+// clearPermissionOverrides
+// https://docs.taiko.dev/api/clearPermissionOverrides
+// ------------------------------------------
+
+clearPermissionOverrides(); // $ExpectType Promise<void>


### PR DESCRIPTION
Hi!

With this PR I submit tests for all types related to taiko API's browser actions, i.e.:

- openBrowser
- closeBrowser
- client
- switchTo
- intercept
- emulateNetwork
- emulateDevice
- setViewPort
- openTab
- closeTab
- openIncognitoWindow
- closeIncognitoWindow
- overridePermissions
- clearPermissionOverrides
- setCookie
- deleteCookies
- getCookies
- setLocation
- clearIntercept

Some of them required to fix the type declaration in `index.d.ts`.

Also the last commit imports (as dev dependency) `devtools-protocol` which is the official repository of the protocol and provides some useful types that otherwise we should re-define. In this commit we use the type `Cookie` for `getCookies`. previously that was treated simply as an `object`, now it gets proper typing.

Sorry if the PR is quite _heavy_ and it may require some time to review.

Filippo