### PR TITLE
Type test for selectors

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2489,20 +2489,21 @@ function textBox(labelOrAttrValuePairs, _options, ...args) {
  * await dropDown(below('text')).exists()
  * @example
  * await dropDown('Vehicle:').select(/Car/) // Only matches drop down text and not the value
+ * @example
+ * awaitdropDown('Vehicle:', { selectHiddenElements: true }, below('text'))
  *
- * @param {object} attrValuePairs - Pairs of attribute and value like {"id":"name","class":"class-name"}
+ * @param {Object} labelOrAttrValuePairs - Either the label (human-visible name) of the text field or pairs of attribute and value like {"id":"name","class":"class-name"}
  * @param {Object} _options
  * @param {boolean} [_options.selectHiddenElements=false] - Option to include hidden elements.
- * @param {string} label - The label (human-visible name) of the drop down.
  * @param {...relativeSelector} args - Proximity selectors
  * @returns {DropDownWrapper}
  */
 module.exports.dropDown = dropDown;
 
-function dropDown(attrValuePairs, _options, ...args) {
+function dropDown(labelOrAttrValuePairs, _options, ...args) {
   validate();
   const DropDownWrapper = require('./elementWrapper/dropDownWrapper');
-  return new DropDownWrapper(attrValuePairs, _options, ...args);
+  return new DropDownWrapper(labelOrAttrValuePairs, _options, ...args);
 }
 
 /**
@@ -2516,18 +2517,19 @@ function dropDown(attrValuePairs, _options, ...args) {
  * await checkBox({id:'checkBoxId'},below('text')).exists()
  * @example
  * await checkBox(below('text')).exists()
+ * @example
+ * await checkBox('Vehicle', { selectHiddenElements: true }, below('text'))
  *
- * @param {Object} attrValuePairs - Pairs of attribute and value like {"id":"name","class":"class-name"}
+ * @param {Object} labelOrAttrValuePairs - Either the label (human-visible name) of the text field or pairs of attribute and value like {"id":"name","class":"class-name"}
  * @param {Object} _options
  * @param {boolean} [_options.selectHiddenElements=false] - Option to include hidden elements.
- * @param {string} label - The label (human-visible name) of the check box.
  * @param {...relativeSelector} args Proximity selectors
  * @returns {CheckBoxWrapper}
  */
-module.exports.checkBox = (attrValuePairs, _options, ...args) => {
+module.exports.checkBox = (labelOrAttrValuePairs, _options, ...args) => {
   validate();
   const CheckBoxWrapper = require('./elementWrapper/checkBoxWrapper');
-  return new CheckBoxWrapper(attrValuePairs, _options, ...args);
+  return new CheckBoxWrapper(labelOrAttrValuePairs, _options, ...args);
 };
 
 /**
@@ -2539,18 +2541,19 @@ module.exports.checkBox = (attrValuePairs, _options, ...args) => {
  * await radioButton({id:'radioButtonId'},below('text')).exists()
  * @example
  * await radioButton(below('text')).exists()
+ * @example
+ * await radioButton('Vehicle', { selectHiddenElements: true }, below('text'))
  *
- * @param {Object} attrValuePairs - Pairs of attribute and value like {"id":"name","class":"class-name"}
+ * @param {Object} labelOrAttrValuePairs - Either the label (human-visible name) of the text field or pairs of attribute and value like {"id":"name","class":"class-name"}
  * @param {Object} _options
  * @param {boolean} [_options.selectHiddenElements=false] - Option to include hidden elements.
- * @param {string} label - The label (human-visible name) of the radio button.
  * @param {...relativeSelector} args
  * @returns {RadioButtonWrapper}
  */
-module.exports.radioButton = (attrValuePairs, _options, ...args) => {
+module.exports.radioButton = (labelOrAttrValuePairs, _options, ...args) => {
   validate();
   const RadioButtonWrapper = require('./elementWrapper/radioButtonWrapper');
-  return new RadioButtonWrapper(attrValuePairs, _options, ...args);
+  return new RadioButtonWrapper(labelOrAttrValuePairs, _options, ...args);
 };
 
 /**
@@ -2564,10 +2567,13 @@ module.exports.radioButton = (attrValuePairs, _options, ...args) => {
  * await text('Vehicle', below('text')).exists()
  * @example
  * await text('Vehicle', { exactMatch: true }, below('text')).exists()
+ * @example
+ * text('Vehicle', { selectHiddenElements: true })
+ *
  * @param {string} text - Text to match.
  * @param {Object} _options
  * @param {boolean} [_options.selectHiddenElements=false] - Option to include hidden elements.
- * @param {boolean} [options.exactMatch=false] - Option to look for exact match.
+ * @param {boolean} [_options.exactMatch=false] - Option to look for exact match.
  * @param {...relativeSelector} args - Proximity selectors
  * @returns {TextWrapper}
  */

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2128,6 +2128,8 @@ module.exports.tap = async (selector, options = {}, ...args) => {
  * await $(`//*[text()='text']`).exists()
  * @example
  * $(`#id`,near('username'),below('login'))
+ * @example
+ * $(`#id`, { selectHiddenElements: true },near('username'),below('login'))
  *
  * @param {string} selector - XPath or CSS selector.
  * @param {Object} _options
@@ -2155,6 +2157,8 @@ module.exports.$ = (attrValuePairs, _options = {}, ...args) => {
  * await image({id:'imageId'},below('text')).exists()
  * @example
  * await image(below('text')).exists()
+ * * @example
+ * await image({ id: 'imageId' }, { selectHiddenElements: true }, below('text')).exists()
  *
  * @param {string} alt - The image's alt text.
  * @param {Object} _options
@@ -2209,6 +2213,8 @@ module.exports.link = (attrValuePairs, _options = {}, ...args) => {
  * await listItem({id:'listItemId'},below('text')).exists()
  * @example
  * await listItem(below('text')).exists()
+ * @example
+ * await listItem({id:'listItemId'},{ selectHiddenElements: true },below('text')).exists()
  *
  * @param {string} label - The label of the list item.
  * @param {Object} _options
@@ -2237,6 +2243,8 @@ module.exports.listItem = (attrValuePairs, _options = {}, ...args) => {
  * await button({id:'buttonId'},below('text')).exists()
  * @example
  * await button(below('text')).exists()
+ * @example
+ * await button({id:'buttonId'},{ selectHiddenElements: true },below('text')).exists()
  *
  * @param {string} label - The button label.
  * @param {Object} _options

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2272,6 +2272,8 @@ module.exports.button = (attrValuePairs, _options = {}, ...args) => {
  * await fileField({id:'fileFieldId'},below('text')).exists()
  * @example
  * await fileField(below('text')).exists()
+ * @example
+ * await fileField({id:'fileFieldId'},{ selectHiddenElements: true },below('text')).exists()
  *
  * @param {string} label - The label (human-visible name) of the file input field.
  * @param {Object} _options
@@ -2304,6 +2306,8 @@ function fileField(attrValuePairs, _options = {}, ...args) {
  * await timeField({id:'Birthday'},below('text')).exists()
  * @example
  * await timeField(below('text')).exists()
+ * @example
+ * await timeField({id:'Birthday'},{ selectHiddenElements: true },below('text')).exists()
  *
  * @param {string} label - The label (human-visible name) of the file input field.
  * @param {Object} _options
@@ -2330,6 +2334,8 @@ function timeField(attrValuePairs, _options = {}, ...args) {
  * await range({ id: 'range-1' }).select('10');
  * @example
  * await range({ id: 'range-1' }, below('head')).select(10);
+ * @example
+ * await range({ id: 'range-1' }, { selectHiddenElements: true }, below('head')).select(10);
  *
  * @param {Object} _options
  * @param {boolean} [_options.selectHiddenElements=false] - Option to include hidden elements.
@@ -2358,6 +2364,8 @@ function range(attrValuePairs, _options = {}, ...args) {
  * await color(below('text')).select('#f236cf')
  * @example
  * await color({'id':'colorId'}).select('#f236cf')
+ * @example
+ * await color({id:'colorId'},{ selectHiddenElements: true },below('text')).exists()
  *
  * @param {Object} attrValuePairs - Pairs of attribute and value like {"id":"name","class":"class-name"}
  * @param {Object} _options
@@ -2390,6 +2398,8 @@ function color(attrValuePairs, _options = {}, ...args) {
  * @example
  * tableCell({row:1,col:3}).text()
  * @example
+ * tableCell({row:1,col:3,selectHiddenElements:true}).text()
+ * @example
  * highlight(tableCell({row:2, col:3}, "Table Caption"))
  * @example
  * highlight(text("Table Cell 2",above(tableCell({row:2, col:2}, "Table Caption"))))
@@ -2399,7 +2409,6 @@ function color(attrValuePairs, _options = {}, ...args) {
  * click(link(above(tableCell({row:4,col:1},"Table Caption"))))
  * @example
  * highlight(link(above(tableCell({row:4,col:1},above("Code")))))
- *
  *
  * @param {Object} options - Pair of row and column like {row:1, col:3}
  * @param {boolean} [options.selectHiddenElements=false] - Option to include hidden elements.
@@ -2448,19 +2457,18 @@ function tableCell(_options = {}, attrValuePairs, ...args) {
  * @example
  * await textBox(below('text')).exists()
  *
- * @param {Object} attrValuePairs - Pairs of attribute and value like {"id":"name","class":"class-name"}
+ * @param {Object} labelOrAttrValuePairs - Either the label (human-visible name) of the text field or pairs of attribute and value like {"id":"name","class":"class-name"}
  * @param {Object} _options
  * @param {boolean} [_options.selectHiddenElements=false] - Option to include hidden elements.
- * @param {string} label - The label (human-visible name) of the text field.
  * @param {...relativeSelector} args - Proximity selectors
  * @returns {TextBoxWrapper}
  */
 module.exports.textBox = textBox;
 
-function textBox(attrValuePairs, _options, ...args) {
+function textBox(labelOrAttrValuePairs, _options, ...args) {
   validate();
   const TextBoxWrapper = require('./elementWrapper/textBoxWrapper');
-  return new TextBoxWrapper(attrValuePairs, _options, ...args);
+  return new TextBoxWrapper(labelOrAttrValuePairs, _options, ...args);
 }
 
 /**

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -438,27 +438,35 @@ export function tap(
  */
 
 // https://docs.taiko.dev/api/$
-export function $(selector: string, ...args: RelativeSearchElement[]): Selector;
+export function $(
+  selector: string,
+  _options?: SelectionOptions | RelativeSearchElement,
+  ...args: RelativeSearchElement[]
+): ElementWrapper;
 // https://docs.taiko.dev/api/image
 export function image(
   selector: SearchElement,
   options?: SelectionOptions | RelativeSearchElement,
   ...args: RelativeSearchElement[]
-): SearchElement;
+): ElementWrapper;
 // https://docs.taiko.dev/api/link
 export function link(
   selector: SearchElement,
   options?: SelectionOptions | RelativeSearchElement,
   ...args: SearchElement[]
-): SearchElement;
+): ElementWrapper;
 // https://docs.taiko.dev/api/listitem
-export function listItem(selector: SearchElement, ...args: RelativeSearchElement[]): SearchElement;
+export function listItem(
+  selector: SearchElement,
+  options?: SelectionOptions | RelativeSearchElement,
+  ...args: RelativeSearchElement[]
+): ElementWrapper;
 // https://docs.taiko.dev/api/button
 export function button(
   selector: SearchElement,
   options?: SelectionOptions | RelativeSearchElement,
   ...args: RelativeSearchElement[]
-): SearchElement;
+): ElementWrapper;
 // https://docs.taiko.dev/api/filefield
 export function fileField(
   selector: SearchElement,

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -140,8 +140,8 @@ export interface TableCellOptions extends SelectionOptions {
   col: number;
 }
 
-export interface MatchingOptions {
-  exactMatch: boolean;
+export interface MatchingOptions extends SelectionOptions {
+  exactMatch?: boolean;
 }
 
 export interface OpenWindowOrTabOptions extends NavigationOptions {
@@ -513,13 +513,13 @@ export function textBox(
 ): ElementWrapper;
 // https://docs.taiko.dev/api/dropdown
 export function dropDown(
-  selector: SearchElement,
+  labelOrAttrValuePairs?: string | AttrValuePairs | SelectionOptions | RelativeSearchElement,
   options?: SelectionOptions | RelativeSearchElement,
   ...args: RelativeSearchElement[]
 ): ElementWrapper;
 // https://docs.taiko.dev/api/checkbox
 export function checkBox(
-  selector: SearchElement,
+  labelOrAttrValuePairs?: string | AttrValuePairs | SelectionOptions | RelativeSearchElement,
   options?: SelectionOptions | RelativeSearchElement,
   ...args: RelativeSearchElement[]
 ): ElementWrapper;

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -132,7 +132,12 @@ export interface EvaluateElementOptions {
 }
 
 export interface SelectionOptions {
-  selectHiddenElements: boolean;
+  selectHiddenElements?: boolean;
+}
+
+export interface TableCellOptions extends SelectionOptions {
+  row: number;
+  col: number;
 }
 
 export interface MatchingOptions {
@@ -222,6 +227,9 @@ export type Selector = BasicSelector | ElementWrapper;
 // SearchElement mimics isSelector, isString, isElement and also allows relative search elements
 export type SearchElement = string | Selector | Element | RelativeSearchElement | object;
 
+export interface AttrValuePairs {
+  [key: string]: string;
+}
 /**
  * Intercept
  */
@@ -493,12 +501,16 @@ export function color(
 ): ElementWrapper;
 // https://docs.taiko.dev/api/tableCell
 export function tableCell(
-  options: SelectionOptions | RelativeSearchElement | undefined,
-  selector: SearchElement,
+  options?: TableCellOptions | SearchElement,
+  selector?: SearchElement,
   ...args: RelativeSearchElement[]
 ): ElementWrapper;
 // https://docs.taiko.dev/api/textbox
-export function textBox(selector: SearchElement, ...args: RelativeSearchElement[]): ElementWrapper;
+export function textBox(
+  labelOrAttrValuePairs?: string | AttrValuePairs | SelectionOptions | RelativeSearchElement,
+  options?: SelectionOptions | RelativeSearchElement,
+  ...args: RelativeSearchElement[]
+): ElementWrapper;
 // https://docs.taiko.dev/api/dropdown
 export function dropDown(
   selector: SearchElement,

--- a/types/taiko/test/taiko-types-test-selectors.ts
+++ b/types/taiko/test/taiko-types-test-selectors.ts
@@ -14,6 +14,10 @@ import {
   tableCell,
   above,
   textBox,
+  text,
+  dropDown,
+  checkBox,
+  radioButton,
 } from '..';
 
 // ------------------------------------------
@@ -133,3 +137,39 @@ textBox('Username:'); // $ExpectType ElementWrapper
 textBox('Username:', { id: 'textBoxId' }); // $ExpectError
 textBox({ id: 'textBoxId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
 textBox({ selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// dropDown
+// https://docs.taiko.dev/api/dropDown
+// ------------------------------------------
+dropDown('Vehicle:'); // $ExpectType ElementWrapper
+dropDown({ id: 'dropDownId' }, below('text')); // $ExpectType ElementWrapper
+dropDown(below('text')); // $ExpectType ElementWrapper
+dropDown('Vehicle:', { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// checkBox
+// https://docs.taiko.dev/api/checkBox
+// ------------------------------------------
+checkBox('Vehicle'); // $ExpectType ElementWrapper
+checkBox({ id: 'checkBoxId' }, below('text')); // $ExpectType ElementWrapper
+checkBox(below('text')); // $ExpectType ElementWrapper
+checkBox('Vehicle', { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// radioButton
+// https://docs.taiko.dev/api/radioButton
+// ------------------------------------------
+radioButton('Vehicle'); // $ExpectType ElementWrapper
+radioButton({ id: 'radioButtonId' }, below('text')); // $ExpectType ElementWrapper
+radioButton(below('text')); // $ExpectType ElementWrapper
+radioButton('Vehicle', { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// text
+// https://docs.taiko.dev/api/text
+// ------------------------------------------
+text('Vehicle'); // $ExpectType ElementWrapper
+text('Vehicle', below('text')); // $ExpectType ElementWrapper
+text('Vehicle', { exactMatch: true }, below('text')); // $ExpectType ElementWrapper
+text('Vehicle', { selectHiddenElements: true }); // $ExpectType ElementWrapper

--- a/types/taiko/test/taiko-types-test-selectors.ts
+++ b/types/taiko/test/taiko-types-test-selectors.ts
@@ -1,5 +1,20 @@
 /* eslint-disable no-undef */
-import { $, button, below, near, image, link, listItem } from '..';
+import {
+  $,
+  button,
+  below,
+  near,
+  image,
+  link,
+  listItem,
+  fileField,
+  timeField,
+  range,
+  color,
+  tableCell,
+  above,
+  textBox,
+} from '..';
 
 // ------------------------------------------
 // $
@@ -55,3 +70,66 @@ button({ id: 'buttonId' }); // $ExpectType ElementWrapper
 button({ id: 'buttonId' }, below('text')); // $ExpectType ElementWrapper
 button(below('text')); // $ExpectType ElementWrapper
 button({ id: 'buttonId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// filefield
+// https://docs.taiko.dev/api/filefield
+// ------------------------------------------
+fileField('Please select a file:'); // $ExpectType ElementWrapper
+fileField('Please select a file:', { selectHiddenElements: true }); // $ExpectType ElementWrapper
+fileField({ id: 'file' }); // $ExpectType ElementWrapper
+fileField({ id: 'fileFieldId' }, below('text')); // $ExpectType ElementWrapper
+fileField(below('text')); // $ExpectType ElementWrapper
+fileField({ selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+fileField({ id: 'fileFieldId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// timefield
+// https://docs.taiko.dev/api/timefield
+// ------------------------------------------
+timeField('Birthday:'); // $ExpectType ElementWrapper
+timeField('Birthday:', { selectHiddenElements: true }); // $ExpectType ElementWrapper
+timeField({ id: 'Birthday' }); // $ExpectType ElementWrapper
+timeField({ id: 'Birthday' }, below('text')); // $ExpectType ElementWrapper
+timeField(below('text')); // $ExpectType ElementWrapper
+timeField({ selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+timeField({ id: 'fileFieldId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// range
+// https://docs.taiko.dev/api/range
+// ------------------------------------------
+range({ id: 'range-1' }); // $ExpectType ElementWrapper
+range({ id: 'range-1' }, { selectHiddenElements: true }); // $ExpectType ElementWrapper
+range({ id: 'range-1' }, below('head')); // $ExpectType ElementWrapper
+range({ id: 'range-1' }, { selectHiddenElements: true }, below('head')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// color
+// https://docs.taiko.dev/api/color
+// ------------------------------------------
+color({ id: 'colorId' }); // $ExpectType ElementWrapper
+color({ id: 'colorId' }, below('text')); // $ExpectType ElementWrapper
+color(below('text')); // $ExpectType ElementWrapper
+color(below('text')); // $ExpectType ElementWrapper
+color({ id: 'colorId' }); // $ExpectType ElementWrapper
+color({ id: 'colorId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// tableCell
+// https://docs.taiko.dev/api/tableCell
+// ------------------------------------------
+tableCell({ row: 1, col: 1 }, 'Table Caption'); // $ExpectType ElementWrapper
+tableCell({ id: 'myColumn' }); // $ExpectType ElementWrapper
+tableCell({ row: 1, col: 3 }); // $ExpectType ElementWrapper
+tableCell({ row: 4, col: 1 }, above('Code')); // $ExpectType ElementWrapper
+tableCell({ row: 4, col: 1, selectHiddenElements: true }, above('Code')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// textBox
+// https://docs.taiko.dev/api/textBox
+// ------------------------------------------
+textBox('Username:'); // $ExpectType ElementWrapper
+textBox('Username:', { id: 'textBoxId' }); // $ExpectError
+textBox({ id: 'textBoxId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+textBox({ selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper

--- a/types/taiko/test/taiko-types-test-selectors.ts
+++ b/types/taiko/test/taiko-types-test-selectors.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef */
+import { $, button, below, near, image, link, listItem } from '..';
+
+// ------------------------------------------
+// $
+// https://docs.taiko.dev/api/$
+// ------------------------------------------
+
+$('//*[text()="text"]'); // $ExpectType ElementWrapper
+$('//*[text()="text"]', { selectHiddenElements: true }); // $ExpectType ElementWrapper
+$('#id', near('username'), below('login')); // $ExpectType ElementWrapper
+$('#id', { selectHiddenElements: true }, near('username'), below('login')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// image
+// https://docs.taiko.dev/api/image
+// ------------------------------------------
+image('alt'); // $ExpectType ElementWrapper
+image('alt', { selectHiddenElements: true }); // $ExpectType ElementWrapper
+image({ id: 'imageId' }); // $ExpectType ElementWrapper
+image({ id: 'imageId' }, below('text')); // $ExpectType ElementWrapper
+image(below('text')); // $ExpectType ElementWrapper
+image({ selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+image({ id: 'imageId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// link
+// https://docs.taiko.dev/api/link
+// ------------------------------------------
+link('Get Started'); // $ExpectType ElementWrapper
+link('Get Started', { selectHiddenElements: true }); // $ExpectType ElementWrapper
+link({ id: 'linkId' }); // $ExpectType ElementWrapper
+link({ id: 'linkId' }, below('text')); // $ExpectType ElementWrapper
+link({ id: 'linkId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+link(below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// listitem
+// https://docs.taiko.dev/api/listitem
+// ------------------------------------------
+listItem('Get Started'); // $ExpectType ElementWrapper
+listItem('Get Started', { selectHiddenElements: true }); // $ExpectType ElementWrapper
+listItem({ id: 'listId' }); // $ExpectType ElementWrapper
+listItem({ id: 'listItemId' }, below('text')); // $ExpectType ElementWrapper
+listItem(below('text')); // $ExpectType ElementWrapper
+listItem({ id: 'listItemId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper
+
+// ------------------------------------------
+// button
+// https://docs.taiko.dev/api/button
+// ------------------------------------------
+button('Get Started'); // $ExpectType ElementWrapper
+button('Get Started', { selectHiddenElements: true }); // $ExpectType ElementWrapper
+button({ id: 'buttonId' }); // $ExpectType ElementWrapper
+button({ id: 'buttonId' }, below('text')); // $ExpectType ElementWrapper
+button(below('text')); // $ExpectType ElementWrapper
+button({ id: 'buttonId' }, { selectHiddenElements: true }, below('text')); // $ExpectType ElementWrapper


### PR DESCRIPTION
Adding type test for selectors:
- $
- image
- link
- lstitem
- button
- filefield
- timefield
- range
- color
- tableCell
- textBox
- dropDown
- checkBox
- radioButton
- text

Some of the type declaration required fixings. Also documentation was subject to some fine-tuning.

Fixes issue #1465

