### PR TITLE
#1476 fix actions on shadowdom

### DIFF
--- a/lib/actions/dragAndDrop.js
+++ b/lib/actions/dragAndDrop.js
@@ -56,14 +56,18 @@ const dragAndDropHTML5Element = async (sourcePosition, destPosition, sourceEleme
   function simulateDragAndDrop(args) {
     let sourceElement, targetElement;
     sourceElement = document.elementFromPoint(args.sourcePosition.x, args.sourcePosition.y);
-    while (sourceElement.shadowRoot) {
+    let parsedShadowRoots = [];
+    while (sourceElement.shadowRoot && !parsedShadowRoots.includes(sourceElement.shadowRoot)) {
+      parsedShadowRoots.push(sourceElement.shadowRoot);
       sourceElement = sourceElement.shadowRoot.elementFromPoint(
         args.sourcePosition.x,
         args.sourcePosition.y,
       );
     }
     targetElement = document.elementFromPoint(args.destPosition.x, args.destPosition.y);
-    while (targetElement.shadowRoot) {
+    parsedShadowRoots = [];
+    while (targetElement.shadowRoot && !parsedShadowRoots.includes(targetElement.shadowRoot)) {
+      parsedShadowRoots.push(targetElement.shadowRoot);
       targetElement = targetElement.shadowRoot.elementFromPoint(
         args.destPosition.x,
         args.destPosition.y,

--- a/lib/handlers/runtimeHandler.js
+++ b/lib/handlers/runtimeHandler.js
@@ -153,7 +153,9 @@ const findElements = async (exp, arg) => {
 const activeElement = async () => {
   function getActiveElement() {
     let activeElement = document.activeElement;
-    while (activeElement.shadowRoot) {
+    const parsedShadowRoots = [];
+    while (activeElement.shadowRoot && !parsedShadowRoots.includes(activeElement.shadowRoot)) {
+      parsedShadowRoots.push(activeElement.shadowRoot);
       activeElement = activeElement.shadowRoot.activeElement;
     }
     return activeElement;

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1129,7 +1129,9 @@ const checkIfElementIsCovered = async (e) => {
     const x = (value.left + value.right) / 2;
 
     let nodes = document.elementsFromPoint(x, y);
-    while (nodes[0].shadowRoot) {
+    const parsedShadowRoots = [];
+    while (nodes[0].shadowRoot && !parsedShadowRoots.includes(nodes[0].shadowRoot)) {
+      parsedShadowRoots.push(nodes[0].shadowRoot);
       nodes = [nodes[0].shadowRoot.elementFromPoint(x, y)];
     }
     const isElementCoveredByAnotherElement = nodes[0] !== elem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "taiko",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Taiko is a Node.js library for automating Chromium based browsers",
   "main": "bin/taiko.js",
   "bin": {


### PR DESCRIPTION
- there can be cases where element at point being outside the shadowdom in which case recursive piercing can go infinity
- bump up version to 1.0.23 for release
- hence pierce through each shadow root only once

Signed-off-by: NivedhaSenthil <nivedhasenthil@gmail.com>
Fixes #1476 