### PR TITLE
Add protocol as options to openBrowser()

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -59,6 +59,7 @@ let page,
   dom,
   overlay,
   currentPort,
+  protocol,
   currentHost,
   targetWSDebugUrl,
   browserDebugUrl,
@@ -68,7 +69,7 @@ let page,
   eventHandlerProxy,
   clientProxy,
   browserContext,
-  localProtocol = false;
+  local = false;
 
 module.exports.emitter = descEvent;
 
@@ -150,7 +151,8 @@ const initCRI = async (target, n, options = {}) => {
       target,
       host: currentHost,
       port: currentPort,
-      localProtocol,
+      local,
+      protocol,
     });
     const promises = [];
     eventHandler.on('handlerActingOnNewSession', (promise) => {
@@ -196,7 +198,7 @@ const initCRI = async (target, n, options = {}) => {
 
 const connect_to_cri = async (target, options = {}) => {
   if (process.env.LOCAL_PROTOCOL) {
-    localProtocol = true;
+    local = true;
   }
   if (_client && _client._ws.readyState === 1 && !options.window) {
     if (!defaultConfig.firefox) {
@@ -289,11 +291,10 @@ module.exports.openBrowser = async (
       'Invalid option parameter. Refer https://docs.taiko.dev/api/openBrowser for the correct format.',
     );
   }
-
-  if (options.host && options.port) {
+  protocol = options.protocol;
+  if ((options.host && options.port) || options.target) {
     currentHost = options.host;
     currentPort = options.port;
-  } else if (options.target) {
     targetWSDebugUrl = options.target;
   } else {
     ({ currentHost, currentPort, browserDebugUrl } = await launchBrowser(options));


### PR DESCRIPTION
This address #660 We need to set protocol and target to get CRI connect to Selenoid cluster.

After the merge I shall add a taiko-selenoid plugin to get the integration work.

Signed-off-by: saikrishna321 <saikrishna321@yahoo.com>