### PR TITLE
docs: Fix simple typo, timout -> timeout

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1285,7 +1285,7 @@ async function click(selector, options = {}, ...args) {
  *
  * @param {selector|string} selector - A selector to search for element to click. If there are multiple elements satisfying the selector, the first will be double clicked.
  * @param {Object} options
- * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the click. Default navigation timout is 30 seconds, to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
+ * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the click. Default navigation timeout is 30 seconds, to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
  * @param {relativeSelector[]} args - Proximity selectors
  *
  * @returns {Promise}
@@ -1314,7 +1314,7 @@ module.exports.doubleClick = async (selector, options = {}, ...args) => {
  *
  * @param {selector|string} selector - A selector to search for element to right click. If there are multiple elements satisfying the selector, the first will be clicked.
  * @param {Object} options - Click options.
- * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the click. Default navigation timout is 30 seconds, to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
+ * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the click. Default navigation timeout is 30 seconds, to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
  * @param {relativeSelector[]} args - Proximity selectors
  *
  * @returns {Promise}


### PR DESCRIPTION
There is a small typo in lib/taiko.js.

Should read `timeout` rather than `timout`.

