### PR TITLE
Improving return types in docs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     ".local-chromium",
     "node_modules/",
     "test/functional-tests/reports/",
+    "test/docs-tests/gauge/reports/",
     "docs"
   ],
   "extends": [

--- a/docs/api/api.njk
+++ b/docs/api/api.njk
@@ -8,8 +8,10 @@ layout: api.njk
 ---
 
 {% macro linkToType(type) -%}
-    {% if type.name == 'Promise' -%}
+    {% if type.name == 'Promise' or type.name == 'Object' or type.name == 'string' or type.name == 'Array' -%}
         <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/{{ type.name }}">{{ type.name }}</a>
+    {%- elif type.name === 'void' -%}
+        <span>{{ type.name }}</span>
     {%- else -%}
         <a href="/api/{{ type.name }}">{{ type.name }}</a>
     {%- endif %}

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -281,7 +281,7 @@ eventHandler.addListener('targetCreated', async (newTarget) => {
  * @param {number} [options.observeTime=3000] - Option to modify delay time for observe mode. Accepts value in milliseconds.
  * @param {boolean} [options.dumpio=false] - Option to dump IO from browser.
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.openBrowser = async (
   options = {
@@ -317,7 +317,7 @@ module.exports.openBrowser = async (
  * @example
  * await closeBrowser()
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.closeBrowser = async () => {
   validate();
@@ -407,7 +407,7 @@ module.exports.client = () => clientProxy;
  * @param {string} arg - Regex (Regular expression) the tab's title/URL or `Object` with
  * window name for example `{ name: "windowname"}`
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 
 module.exports.switchTo = async (arg) => {
@@ -467,7 +467,7 @@ module.exports.switchTo = async (arg) => {
  * @param {function|Object} option action to be done after interception. For more examples refer to https://github.com/getgauge/taiko/issues/98#issuecomment-42024186
  * @param {number} count number of times the request has to be intercepted . Optional parameter
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.intercept = async (requestUrl, option, count) => {
   await fetchHandler.addInterceptor({
@@ -496,7 +496,7 @@ module.exports.intercept = async (requestUrl, option, count) => {
  *
  * @param {(string|object)} networkType - 'GPRS','Regular2G','Good2G','Good3G','Regular3G','Regular4G','DSL','WiFi','Offline', {offline: boolean, downloadThroughput: number, uploadThroughput: number, latency: number}
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 
 module.exports.emulateNetwork = async (networkType) => {
@@ -513,7 +513,7 @@ module.exports.emulateNetwork = async (networkType) => {
  *
  * @param {string} deviceModel - See [device model](https://docs.taiko.dev/devices) for a list of all device models.
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 
 module.exports.emulateDevice = emulateDevice;
@@ -542,7 +542,7 @@ async function emulateDevice(deviceModel) {
  *
  * @param {Object} options - See [chrome devtools setDeviceMetricsOverride](https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setDeviceMetricsOverride) for a list of options
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.setViewPort = async (options) => {
   validate();
@@ -581,7 +581,7 @@ module.exports.emulateTimezone = async (timezoneId) => {
  * @param {number} [options.waitForStart=100] - time to wait to check for occurrence of page load events. Accepts value in milliseconds.
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Page load events to implicitly wait for. Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']]
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.openTab = async (
   targetUrl,
@@ -640,7 +640,7 @@ module.exports.openTab = async (
  * @param {Object} options.headers - Map with extra HTTP headers.
  * @param {number} [options.waitForStart = 100] - time to wait for navigation to start. Accepts value in milliseconds.
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.openIncognitoWindow = async (url, options = {}) => {
   validate();
@@ -743,7 +743,7 @@ const _switchContext = async (arg) => {
  *
  * @param {string} [targetUrl=undefined] - URL/Page title of the tab to close.
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.closeTab = async (identifier) => {
   const { matching, others } = await targetHandler.getCriTargets(
@@ -799,7 +799,7 @@ module.exports.closeTab = async (identifier) => {
  * @param {string} origin - url origin to override permissions
  * @param {Array<string>} permissions - See [chrome devtools permission types](https://chromedevtools.github.io/devtools-protocol/tot/Browser/#type-PermissionType) for a list of permission types.
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.overridePermissions = async (origin, permissions) => {
   validate();
@@ -813,7 +813,7 @@ module.exports.overridePermissions = async (origin, permissions) => {
  * @example
  * await clearPermissionOverrides()
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.clearPermissionOverrides = async () => {
   validate();
@@ -840,7 +840,7 @@ module.exports.clearPermissionOverrides = async () => {
  * @param {string} [options.sameSite=undefined] - Represents the cookie's 'SameSite' status: Refer https://tools.ietf.org/html/draft-west-first-party-cookies.
  * @param {number} [options.expires=undefined] - UTC time in seconds, counted from January 1, 1970. eg: 2019-02-16T16:55:45.529Z
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.setCookie = async (name, value, options = {}) => {
   validate();
@@ -872,7 +872,7 @@ module.exports.setCookie = async (name, value, options = {}) => {
  * @param {string} [options.domain=undefined] - deletes only cookies with the exact domain. eg: google.com
  * @param {string} [options.path=undefined] - deletes only cookies with the exact path. eg: Google/Chrome/Default/Cookies/..
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.deleteCookies = async (cookieName, options = {}) => {
   validate();
@@ -918,7 +918,7 @@ module.exports.getCookies = async (options = {}) => {
  * @param {number} options.longitude - Mock longitude
  * @param {number} options.accuracy - Mock accuracy
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.setLocation = async (options) => {
   validate();
@@ -992,7 +992,7 @@ module.exports.goto = async (
  * @param {number} [options.waitForStart = 100] - time to wait for navigation to start. Accepts value in milliseconds.
  * @param {boolean} [options.ignoreCache = false] - Ignore Cache on reload - Default to false
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.reload = async (
   url,
@@ -1026,7 +1026,7 @@ module.exports.reload = async (
  * @param {number} [options.navigationTimeout=30000] - Navigation timeout value in milliseconds for navigation after click.
  * @param {number} [options.waitForStart = 100] - time to wait for navigation to start. Accepts value in milliseconds.
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.goBack = async (
   options = { navigationTimeout: defaultConfig.navigationTimeout },
@@ -1047,7 +1047,7 @@ module.exports.goBack = async (
  * @param {number} [options.navigationTimeout=30000] - Navigation timeout value in milliseconds for navigation after click.
  * @param {number} [options.waitForStart = 100] - time to wait for navigation to start. Accepts value in milliseconds.
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.goForward = async (
   options = { navigationTimeout: defaultConfig.navigationTimeout },
@@ -1238,7 +1238,7 @@ async function _click(selector, options, ...args) {
  * @param {number} [options.waitForStart=100] - time to wait for navigation to start. Accepts time in milliseconds.
  * @param {relativeSelector[]} args - Proximity selectors
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.click = click;
 
@@ -1290,7 +1290,7 @@ async function click(selector, options = {}, ...args) {
  * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the click. Default navigation timeout is 30 seconds, to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
  * @param {relativeSelector[]} args - Proximity selectors
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.doubleClick = async (selector, options = {}, ...args) => {
   validate();
@@ -1319,7 +1319,7 @@ module.exports.doubleClick = async (selector, options = {}, ...args) => {
  * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the click. Default navigation timeout is 30 seconds, to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
  * @param {relativeSelector[]} args - Proximity selectors
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.rightClick = async (selector, options = {}, ...args) => {
   validate();
@@ -1349,7 +1349,7 @@ module.exports.rightClick = async (selector, options = {}, ...args) => {
  * @param {selector|string|Object} destinationOrDistance - Element for dropping the dragged element
  *        or an object specifying the drag&drop distance to be moved from position of source element
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.dragAndDrop = async (source, destination) => {
   validate();
@@ -1439,7 +1439,7 @@ module.exports.focus = async (selector, options = {}) => {
  * @param {boolean} [options.hideText=false] - Prevent given text from being written to log output.
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.write = async (text, into, options = { delay: 0 }) => {
   if (text == null || text == undefined) {
@@ -1542,7 +1542,7 @@ const _write = async (activeElement, text, options) => {
  * @param {number} [options.navigationTimeout=30000] - Navigation timeout value in milliseconds for navigation after click.
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.clear = async (selector, options = {}) => {
   validate();
@@ -1648,7 +1648,7 @@ module.exports.attach = async (filepath, to) => {
  * @param {number} [options.navigationTimeout=30000] - Navigation timeout value in milliseconds for navigation after click.
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.press = async (keys, options = {}) => {
   validate();
@@ -1685,7 +1685,7 @@ async function _press(keys, options) {
  * @param {selector|string} selector - A selector of an element to highlight. If there are multiple elements satisfying the selector, the first will be highlighted.
  * @param {relativeSelector[]} args - Proximity selectors
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.highlight = highlight;
 
@@ -1732,7 +1732,7 @@ async function highlight(selector, ...args) {
  * @example
  * await clearHighlights();
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 
 module.exports.clearHighlights = async () => {
@@ -1838,7 +1838,7 @@ async function mouseAction(selector, action, coordinates, options = {}) {
  * @param {Object} options
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.scrollTo = async (selector, options = {}) => {
   validate();
@@ -1903,7 +1903,7 @@ const scroll = async (e, px, scrollPage, scrollElement, direction) => {
  * @param {selector|string|number} [e='Window']
  * @param {number} px - Accept px in pixels
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.scrollRight = async (e, px = 100) => {
   validate();
@@ -1938,7 +1938,7 @@ module.exports.scrollRight = async (e, px = 100) => {
  * @param {selector|string|number} [e='Window']
  * @param {number} px - Accept px in pixels
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.scrollLeft = async (e, px = 100) => {
   validate();
@@ -1973,7 +1973,7 @@ module.exports.scrollLeft = async (e, px = 100) => {
  * @param {selector|string|number} [e='Window']
  * @param {number} px - Accept px in pixels
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.scrollUp = async (e, px = 100) => {
   validate();
@@ -2008,7 +2008,7 @@ module.exports.scrollUp = async (e, px = 100) => {
  * @param {selector|string|number} [e='Window']
  * @param {number} px - Accept px in pixels
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.scrollDown = async (e, px = 100) => {
   validate();
@@ -2080,7 +2080,7 @@ module.exports.screenshot = async (selector, options = {}) => {
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']
  * @param {relativeSelector[]} args - Proximity selectors
  *
- * @returns {Promise}
+ * @returns {Promise<void>}
  */
 module.exports.tap = async (selector, options = {}, ...args) => {
   validate();

--- a/test/docs-tests/gauge/specs/returnType.spec
+++ b/test/docs-tests/gauge/specs/returnType.spec
@@ -1,12 +1,14 @@
 # API Function Return Type
 
 
-| Function Name                         | Return Type                  |
-|---------------------------------------|------------------------------|
-| functionReturningPromise              | Promise                      |
-| functionReturningPromiseOfObject      | Promise<Object>              |
-| functionReturningPromiseOfVoid        | Promise<void>                |
-| functionReturningArrayOfObjects       | Array<Object>                |
+| Function Name                              | Return Type                  |
+|--------------------------------------------|------------------------------|
+| functionReturningPromise                   | Promise                      |
+| functionReturningPromiseOfObject           | Promise<Object>              |
+| functionReturningPromiseOfVoid             | Promise<void>                |
+| functionReturningArrayOfObjects            | Array<Object>                |
+| functionReturningPromiseOfArrayOfObjects   | Promise<Array<Object>>       |
+
 ## <Function Name> should display <Return Type> after 'Returns'
 
 * Navigate to relative API reference page for <Function Name>

--- a/test/docs-tests/gauge/specs/returnType.spec
+++ b/test/docs-tests/gauge/specs/returnType.spec
@@ -5,11 +5,11 @@
 |---------------------------------------|------------------------------|
 | functionReturningPromise              | Promise                      |
 | functionReturningPromiseOfObject      | Promise<Object>              |
-
+| functionReturningPromiseOfVoid        | Promise<void>                |
+| functionReturningArrayOfObjects       | Array<Object>                |
 ## <Function Name> should display <Return Type> after 'Returns'
 
 * Navigate to relative API reference page for <Function Name>
 * Assert text "Returns" exists on the page.
 * Assert text "Description of the return" exists below "Returns".
 * Assert text <Return Type> exists below "Returns".
-

--- a/test/docs-tests/gauge/specs/returnType.spec
+++ b/test/docs-tests/gauge/specs/returnType.spec
@@ -1,16 +1,15 @@
 # API Function Return Type
 
-## functionReturningPromise should display 'Promise' after 'Returns'
 
-* Navigate to relative path "../tmp/docs/_site/api/functionReturningPromise/index.html"
+| Function Name                         | Return Type                  |
+|---------------------------------------|------------------------------|
+| functionReturningPromise              | Promise                      |
+| functionReturningPromiseOfObject      | Promise<Object>              |
+
+## <Function Name> should display <Return Type> after 'Returns'
+
+* Navigate to relative API reference page for <Function Name>
 * Assert text "Returns" exists on the page.
 * Assert text "Description of the return" exists below "Returns".
-* Assert text "Promise" exists below "Returns".
-
-## functionReturningPromiseOfObject should display 'Promise<Object>' after 'Returns'
-
-* Navigate to relative path "../tmp/docs/_site/api/functionReturningPromiseOfObject/index.html"
-* Assert text "Returns" exists on the page.
-* Assert text "Description of the return" exists below "Returns".
-* Assert text "Promise<Object>" exists below "Returns".
+* Assert text <Return Type> exists below "Returns".
 

--- a/test/docs-tests/gauge/specs/returnTypeLinks.spec
+++ b/test/docs-tests/gauge/specs/returnTypeLinks.spec
@@ -1,0 +1,15 @@
+# API Function Return Type Links
+
+
+| Function Name                          | TypeLink           |
+|----------------------------------------|--------------------|
+| functionReturningPromiseOfObject       | Promise            |
+| functionReturningString                | string             |
+| functionReturningPromiseOfObject       | Object             |
+| functionReturningArrayOfObjects        | Array              |
+## In <Function Name>'s reference page, clicking on <TypeLink> after 'Returns' should work
+
+
+* Navigate to relative API reference page for <Function Name>
+* Click link <TypeLink> below "Returns"
+* Assert text <TypeLink> exists on the page.

--- a/test/docs-tests/gauge/tests/click.ts
+++ b/test/docs-tests/gauge/tests/click.ts
@@ -1,0 +1,13 @@
+'use strict';
+import { getElements } from './selectors';
+
+import { link, click, below, SearchElement } from 'taiko';
+
+import { Step } from 'gauge-ts';
+
+export default class Click {
+  @Step('Click link <userlink> below <text>')
+  public async clickLinkBelowTable(userlink: SearchElement, text: string) {
+    await click(link(userlink, below(text)), { waitForNavigation: true });
+  }
+}

--- a/test/docs-tests/gauge/tests/htmlElementAPI.ts
+++ b/test/docs-tests/gauge/tests/htmlElementAPI.ts
@@ -174,6 +174,13 @@ export default class HtmlElementAPI {
     await goto('file:///' + absolutePath);
   }
 
+  @Step('Navigate to relative API reference page for <functionName>')
+  public async navigateToApiRefPage(functionName: string) {
+    const relativePath = '../tmp/docs/_site/api/' + functionName + '/index.html';
+    const absolutePath = _path.resolve(relativePath);
+    await goto('file:///' + absolutePath);
+  }
+
   @ContinueOnFailure()
   @Step('Scroll to element <div>')
   public async ScrollToElement(div: string) {

--- a/test/docs-tests/jsdoc-inputs/returnTypes.js
+++ b/test/docs-tests/jsdoc-inputs/returnTypes.js
@@ -13,7 +13,6 @@ async function functionReturningPromiseOfObject(url) {
     a: url,
   }));
 }
-
 module.exports.functionReturningPromiseOfObject = functionReturningPromiseOfObject;
 
 /**
@@ -31,5 +30,55 @@ async function functionReturningPromise(url) {
     a: url,
   }));
 }
-
 module.exports.functionReturningPromise = functionReturningPromise;
+
+/**
+ * Test description of a test function.
+ *
+ * @example
+ * await functionReturningPromiseOfVoid('https://google.com')
+ *
+ * @param {string} url - URL to navigate page to.
+ *
+ * @returns {Promise<void>} - Description of the return
+ */
+async function functionReturningPromiseOfVoid(url) {
+  return new Promise(() => ({
+    a: url,
+  }));
+}
+module.exports.functionReturningPromiseOfVoid = functionReturningPromiseOfVoid;
+
+/**
+ * Test description of a test function.
+ *
+ * @example
+ * await functionReturningString('https://google.com')
+ *
+ * @param {string} url - URL to navigate page to.
+ *
+ * @returns {string} - Description of the return
+ */
+async function functionReturningString(url) {
+  return new Promise(() => ({
+    a: url,
+  }));
+}
+module.exports.functionReturningString = functionReturningString;
+
+/**
+ * Test description of a test function.
+ *
+ * @example
+ * await functionReturningArrayOfObjects('https://google.com')
+ *
+ * @param {string} url - URL to navigate page to.
+ *
+ * @returns {Object[]} - Description of the return
+ */
+async function functionReturningArrayOfObjects(url) {
+  return new Promise(() => ({
+    a: url,
+  }));
+}
+module.exports.functionReturningArrayOfObjects = functionReturningArrayOfObjects;

--- a/test/docs-tests/jsdoc-inputs/returnTypes.js
+++ b/test/docs-tests/jsdoc-inputs/returnTypes.js
@@ -82,3 +82,20 @@ async function functionReturningArrayOfObjects(url) {
   }));
 }
 module.exports.functionReturningArrayOfObjects = functionReturningArrayOfObjects;
+
+/**
+ * Test description of a test function.
+ *
+ * @example
+ * await functionReturningPromiseOfArrayOfObjects('https://google.com')
+ *
+ * @param {string} url - URL to navigate page to.
+ *
+ * @returns {Promise<Object[]>} - Description of the return
+ */
+async function functionReturningPromiseOfArrayOfObjects(url) {
+  return new Promise(() => ({
+    a: url,
+  }));
+}
+module.exports.functionReturningPromiseOfArrayOfObjects = functionReturningPromiseOfArrayOfObjects;


### PR DESCRIPTION
This PR covers 2 things:

- fixing the links for standard types Array and Object (see issue #1567)
- changing return type from `Promise` to `Promise<void>`
