### PR TITLE
Only decrement intercept.count when an intercept matches

### DIFF
--- a/lib/handlers/fetchHandler.js
+++ b/lib/handlers/fetchHandler.js
@@ -81,6 +81,8 @@ const handleInterceptor = (p) => {
     fetch.continueRequest(options).catch(() => {});
     return;
   }
+  interceptor.count = interceptor.count - 1;
+
   switch (true) {
     //Blocks matching url
     case !interceptor.action:
@@ -224,8 +226,6 @@ const statusTexts = {
 const getMatchingInterceptor = (interceptor, url) => {
   if (interceptor.count === 0) {
     return false;
-  } else {
-    interceptor.count = interceptor.count - 1;
   }
   if (url === interceptor.requestUrl) {
     return true;


### PR DESCRIPTION
Currently all registered intercepts with a non-zero count value gets their counts decremented for every call to `getMatchingInterceptor` regardless if the incoming request matches an intercept.

This bug causes intercepts with counts to not work as intended if there are other API calls made during a test. 

Signed-off-by: Marvin Khristian Zamora <mklzamora@gmail.com>