### PR TITLE
Fixing type GlobalConfigurationOptions

### DIFF
--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -63,6 +63,7 @@ export interface GlobalConfigurationOptions {
   observeTime?: number;
   retryInterval?: number;
   retryTimeout?: number;
+  noOfElementToMatch?: number;
   observe?: boolean;
   waitForNavigation?: boolean;
   ignoreSSLErrors?: boolean;


### PR DESCRIPTION
Commit 18c5170 introduce the field noOfElementToMatch in config.js,
this was missing in the type definition as revealed by executing
`npm run dtslint`.
