### PR TITLE
Add dtslint to husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged && npm run test:api",
-      "pre-push": "npm test"
+      "pre-push": "npm run dtslint && npm test"
     }
   },
   "author": "getgauge",

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -63,6 +63,7 @@ export interface GlobalConfigurationOptions {
   observeTime?: number;
   retryInterval?: number;
   retryTimeout?: number;
+  noOfElementToMatch?: number;
   observe?: boolean;
   waitForNavigation?: boolean;
   ignoreSSLErrors?: boolean;


### PR DESCRIPTION
This PR have dtslint run automatically before each push to git to verify the correctness of types and, primarily, check that other changes in the code are not breaking the type declarations.

This is related to issue #1571 

It also includes a fix for a misaligned type which would fail dtslint immediately 😉