### PR TITLE
Making DropDownWrapper extend MultiValueWrapper

### DIFF
--- a/lib/elementWrapper/dropDownWrapper.js
+++ b/lib/elementWrapper/dropDownWrapper.js
@@ -1,5 +1,5 @@
 const DropDown = require('../elements/dropDown');
-const MultiValueWrapper = require('./MultiValueWrapper');
+const MultiValueWrapper = require('./multiValueWrapper');
 const { firstElement, getElementGetter } = require('./helper');
 const { $function } = require('../elementSearch');
 

--- a/lib/elementWrapper/dropDownWrapper.js
+++ b/lib/elementWrapper/dropDownWrapper.js
@@ -1,5 +1,5 @@
 const DropDown = require('../elements/dropDown');
-const ValueWrapper = require('./valueWrapper');
+const MultiValueWrapper = require('./MultiValueWrapper');
 const { firstElement, getElementGetter } = require('./helper');
 const { $function } = require('../elementSearch');
 
@@ -32,9 +32,9 @@ function getDropDownElementWithLabel(searchElement, label) {
 /**
  * Behaves the same as ValueWrapper + select().
  * Represents HTML [Select](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)
- * @extends {ValueWrapper}
+ * @extends {MultiValueWrapper}
  */
-class DropDownWrapper extends ValueWrapper {
+class DropDownWrapper extends MultiValueWrapper {
   constructor(attrValuePairs, _options, ...args) {
     super('DropDown', 'label', attrValuePairs, _options, ...args);
     this._get = getElementGetter(

--- a/lib/elementWrapper/multiValueWrapper.js
+++ b/lib/elementWrapper/multiValueWrapper.js
@@ -1,0 +1,22 @@
+const ElementWrapper = require('./elementWrapper');
+const { firstElement } = require('./helper');
+
+/**
+ * Behaves the same as ElementWrapper, but for elements that hold multiple values of
+ * specified types (such as a dropdown which supports multiple selections).
+ * @extends {ElementWrapper}
+ */
+class MultiValueWrapper extends ElementWrapper {
+  /**
+   * Read the value of the element
+   *
+   * @returns {Promise<string | string[] | number[]>}
+   * @memberof MultiValueWrapper
+   */
+  async values() {
+    const elem = await firstElement.apply(this);
+    return await elem.values();
+  }
+}
+
+module.exports = MultiValueWrapper;

--- a/lib/elements/dropDown.js
+++ b/lib/elements/dropDown.js
@@ -175,7 +175,7 @@ class DropDown extends Element {
     descEvent.emit('success', 'Selected ' + (values.index || values));
   }
 
-  async value() {
+  async values() {
     function getValue() {
       let selectedValues = [];
       for (let index = 0; index < this.options.length; index++) {

--- a/test/docs-tests/gauge/tests/htmlElementAPI.ts
+++ b/test/docs-tests/gauge/tests/htmlElementAPI.ts
@@ -56,7 +56,7 @@ export default class HtmlElementAPI {
   public async selectDropDownValue(value: string | number, dropDownName: string, fieldValue: any) {
     const box = dropDown(dropDownName);
     await box.select(value);
-    assert.equal(await box.value(), fieldValue);
+    assert.equal(await box.values(), fieldValue);
   }
 
   @Step('Ensure Check Box <checkBoxName> exists')

--- a/test/functional-tests/tests/htmlElementAPI.ts
+++ b/test/functional-tests/tests/htmlElementAPI.ts
@@ -56,7 +56,7 @@ export default class HtmlElementAPI {
   public async selectDropDownValue(value: string | number, dropDownName: string, fieldValue: any) {
     const box = dropDown(dropDownName);
     await box.select(value);
-    assert.equal(await box.value(), fieldValue);
+    assert.equal(await box.values(), fieldValue);
   }
 
   @Step('Ensure Check Box <checkBoxName> exists')

--- a/test/unit-tests/dropDown.test.js
+++ b/test/unit-tests/dropDown.test.js
@@ -162,12 +162,12 @@ describe(test_name, () => {
     it('test select()', async () => {
       await dropDown('Cars').select('Audi');
       await dropDown('Cars').select('mercedes');
-      expect(await dropDown('Cars').value()).to.equal('mercedes');
+      expect(await dropDown('Cars').values()).to.equal('mercedes');
     });
 
     it('test select() with multiple values', async () => {
       await dropDown('Attire').select(['Shirt', 'Blazer']);
-      expect(await dropDown('Attire').value()).to.deep.equal(['shirt', 'blazer']);
+      expect(await dropDown('Attire').values()).to.deep.equal(['shirt', 'blazer']);
     });
 
     it('test options()', async () => {
@@ -192,7 +192,7 @@ describe(test_name, () => {
         expect(await dropDown('Foods').select(['Burger', 'Pasta']));
       } catch (err) {
         expect(err.message).to.equal('Cannot set value Burger on a disabled field');
-        expect(await dropDown('Foods').value()).to.equal('');
+        expect(await dropDown('Foods').values()).to.equal('');
       }
     });
   });
@@ -200,18 +200,18 @@ describe(test_name, () => {
   describe('Select using index', () => {
     it('test select() using index', async () => {
       await dropDown(below('Reason')).select({ index: 1 });
-      expect(await dropDown(below('Reason')).value()).to.equal('9092');
+      expect(await dropDown(below('Reason')).values()).to.equal('9092');
     });
     it('test select() using array of index', async () => {
       await dropDown(below('Feedback')).select({ index: [1, 2] });
-      expect(await dropDown(below('Feedback')).value()).to.deep.equal(['20', '30']);
+      expect(await dropDown(below('Feedback')).values()).to.deep.equal(['20', '30']);
     });
   });
 
   describe('wrapped in label', () => {
     it('test exists()', async () => {
       expect(await dropDown('dropDownWithWrappedInLabel').exists()).to.be.true;
-      expect(await dropDown('dropDownWithWrappedInLabel').value()).to.not.equal('mercedes');
+      expect(await dropDown('dropDownWithWrappedInLabel').values()).to.not.equal('mercedes');
     });
 
     it('test description', async () => {
@@ -283,7 +283,7 @@ describe(test_name, () => {
         id: 'sampleDropDown',
       }).elements();
       await elements[0].select('someValue');
-      expect(await elements[0].value()).to.equal('someValue');
+      expect(await elements[0].values()).to.equal('someValue');
     });
 
     it('test get value of multiple selected elements', async () => {
@@ -291,7 +291,7 @@ describe(test_name, () => {
         id: 'sampleDropDown',
       }).elements();
       await elements[0].select('someValue');
-      expect(await elements[0].value()).to.equal('someValue');
+      expect(await elements[0].values()).to.equal('someValue');
     });
   });
 
@@ -320,11 +320,11 @@ describe(test_name, () => {
   describe('regex based selection', () => {
     it('should select value specified by a regex ', async () => {
       await dropDown('Cars').select(/M.rc.d.s/);
-      expect(await dropDown('Cars').value()).to.equal('mercedes');
+      expect(await dropDown('Cars').values()).to.equal('mercedes');
     });
     it('should select multiple values specified by a regex ', async () => {
       await dropDown('Country').select(/and/);
-      expect(await dropDown('Country').value()).to.deep.equal(['england', 'scotland']);
+      expect(await dropDown('Country').values()).to.deep.equal(['england', 'scotland']);
     });
 
     it('should throw error when there are no items matching regex ', async () => {

--- a/test/unit-tests/elements/dropDown.test.js
+++ b/test/unit-tests/elements/dropDown.test.js
@@ -151,7 +151,7 @@ describe('DropDown', () => {
       let objectId = 28;
       const dropDown = new DropDown(objectId, 'description', runtimeHandler);
       await dropDown.select('28 text 2');
-      expect(await dropDown.value()).to.be.equal('28 value 2');
+      expect(await dropDown.values()).to.be.equal('28 value 2');
     });
   });
 });

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -208,6 +208,10 @@ export interface ValueWrapper extends ElementWrapper {
   value(): Promise<string>;
 }
 
+export interface MultiValueWrapper extends ElementWrapper {
+  values(): Promise<string | string[] | number[]>;
+}
+
 export interface ButtonWrapper extends ElementWrapper {}
 export interface DollarWrapper extends ElementWrapper {}
 export interface ImageWrapper extends ElementWrapper {}
@@ -223,7 +227,7 @@ export interface ColorWrapper extends ValueWrapper {
 export interface FileFieldWrapper extends ValueWrapper {}
 export interface TextBoxWrapper extends ValueWrapper {}
 
-export interface DropDownWrapper extends ValueWrapper {
+export interface DropDownWrapper extends MultiValueWrapper {
   select(value?: string | number | string[] | number[] | { index: number[] }): Promise<void>;
 }
 export interface TimeFieldWrapper extends ValueWrapper {


### PR DESCRIPTION
`DropDownWrapper `previously extended `ValueWrapper `which has a method `value()` returning `Promise<string>`.

With this commit `DropDownWrapper` extends a new `MultiValueWrapper` which has a method `values()` returning `Promise<string | string[] | number[]>`.

The `ValueWrapper` remains as it is for the elements that actually implement that behavior such as `ColorWrapper`, `TextBoxWrapper`, etc.

Related to issue #1652 
