### PR TITLE
Pass proper retry interval/timeout to ElementWrapper.elements

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -2796,7 +2796,7 @@ const waitFor = async (element, time) => {
       throw new Error(`Waiting Failed: Element '${element}' not found within ${timeout} ms`);
     }
   } else if (isSelector(element)) {
-    let foundElements = await element.elements(undefined, defaultConfig.retryInterval, timeout);
+    let foundElements = await element.elements(defaultConfig.retryInterval, timeout);
     if (!foundElements.length) {
       throw new Error(`Waiting Failed: Element '${element}' not found within ${timeout} ms`);
     }

--- a/test/unit-tests/waitFor.test.js
+++ b/test/unit-tests/waitFor.test.js
@@ -27,11 +27,16 @@ describe(test_name, function () {
       '<p id="demo"></p>' +
       '<script>' +
       'function myFunction() {' +
+      'setTimeout(function() {' +
       'document.getElementById("demo").innerHTML = "Wait is Over..!";' +
+      '}, 500)' +
       '}' +
       '</script>';
     filePath = createHtml(innerHtml, test_name);
     await openBrowser(openBrowserArgs);
+  });
+
+  beforeEach(async () => {
     await goto(filePath);
   });
 
@@ -100,6 +105,16 @@ describe(test_name, function () {
       await click('Click me');
       await expect(waitFor(async () => await $('//*[text()="Wait is Over..!"]').exists(0.0))).not.to
         .eventually.be.rejected;
+    });
+
+    it('should wait for given string', async () => {
+      await click('Click me');
+      await expect(waitFor('Wait is Over', 2000)).not.to.eventually.be.rejected;
+    });
+
+    it('should wait for given selector', async () => {
+      await click('Click me');
+      await expect(waitFor(text('Wait is Over'), 2000)).not.to.eventually.be.rejected;
     });
   });
 });


### PR DESCRIPTION
Fixes #1661. This updates the `waitFor` unit test to add some delay to be able to differentiate between `retryInterval` and `retryTimeout`, and a `beforeEach` that makes sure the page is loaded fresh upon each run.