### PR TITLE
Clean up actions and wait for element to be connected before actions

### DIFF
--- a/lib/actions/attach.js
+++ b/lib/actions/attach.js
@@ -1,0 +1,28 @@
+const { isString, isSelector, isElement } = require('../helper');
+const FileFieldWrapper = require('../elementWrapper/fileFieldWrapper');
+const path = require('path');
+const fs = require('fs');
+const { description, waitAndGetActionableElement } = require('./pageActionChecks');
+const { defaultConfig } = require('../config');
+const domHandler = require('../handlers/domHandler');
+const { highlightElement } = require('../elements/elementHelper');
+
+const attach = async (filepath, to) => {
+  let resolvedPath = filepath ? path.resolve(process.cwd(), filepath) : path.resolve(process.cwd());
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`File ${resolvedPath} does not exist.`);
+  }
+  if (isString(to)) {
+    to = new FileFieldWrapper(to);
+  } else if (!isSelector(to) && !isElement(to)) {
+    throw Error('Invalid element passed as parameter');
+  }
+  const element = await waitAndGetActionableElement(to);
+  if (defaultConfig.headful) {
+    await highlightElement(element);
+  }
+  await domHandler.setFileInputFiles(element.get(), resolvedPath);
+  return 'Attached ' + resolvedPath + ' to the ' + description(to, true);
+};
+
+module.exports = { attach };

--- a/lib/actions/clear.js
+++ b/lib/actions/clear.js
@@ -1,0 +1,34 @@
+const { findActiveElement } = require('../elementSearch');
+const { description, waitAndGetActionableElement, checksMap } = require('./pageActionChecks');
+const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
+const { defaultConfig } = require('../config');
+const inputHandler = require('../handlers/inputHandler');
+const runtimeHandler = require('../handlers/runtimeHandler');
+const { highlightElement } = require('../elements/elementHelper');
+
+const _clear = async (elem) => {
+  await runtimeHandler.runtimeCallFunctionOn(
+    function () {
+      document.execCommand('selectall', false, null);
+    },
+    null,
+    { objectId: elem },
+  );
+  await inputHandler.down('Backspace');
+  await inputHandler.up('Backspace');
+};
+
+const clear = async (selector, options) => {
+  selector = selector ? selector : await findActiveElement();
+  const element = await waitAndGetActionableElement(selector, [checksMap.writable]);
+  const desc = !selector ? 'Cleared element on focus' : 'Cleared ' + description(selector, true);
+  await doActionAwaitingNavigation(options, async () => {
+    await _clear(element.get());
+    if (defaultConfig.headful) {
+      await highlightElement(element);
+    }
+  });
+  return desc;
+};
+
+module.exports = { clear };

--- a/lib/actions/clear.js
+++ b/lib/actions/clear.js
@@ -1,4 +1,4 @@
-const { findActiveElement } = require('../elementSearch');
+const { waitAndGetFocusedElement } = require('../elementSearch');
 const { description, waitAndGetActionableElement, checksMap } = require('./pageActionChecks');
 const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
 const { defaultConfig } = require('../config');
@@ -19,7 +19,7 @@ const _clear = async (elem) => {
 };
 
 const clear = async (selector, options) => {
-  selector = selector ? selector : await findActiveElement();
+  selector = selector ? selector : await waitAndGetFocusedElement();
   const element = await waitAndGetActionableElement(selector, [checksMap.writable]);
   const desc = !selector ? 'Cleared element on focus' : 'Cleared ' + description(selector, true);
   await doActionAwaitingNavigation(options, async () => {

--- a/lib/actions/clear.js
+++ b/lib/actions/clear.js
@@ -5,6 +5,7 @@ const { defaultConfig } = require('../config');
 const inputHandler = require('../handlers/inputHandler');
 const runtimeHandler = require('../handlers/runtimeHandler');
 const { highlightElement } = require('../elements/elementHelper');
+const { focus } = require('./focus');
 
 const _clear = async (elem) => {
   await runtimeHandler.runtimeCallFunctionOn(
@@ -19,14 +20,15 @@ const _clear = async (elem) => {
 };
 
 const clear = async (selector, options) => {
-  selector = selector ? selector : await waitAndGetFocusedElement();
-  const element = await waitAndGetActionableElement(selector, [checksMap.writable]);
-  const desc = !selector ? 'Cleared element on focus' : 'Cleared ' + description(selector, true);
+  let elements = selector ? selector : await waitAndGetFocusedElement();
+  const element = await waitAndGetActionableElement(elements, [checksMap.writable]);
+  const desc = !selector ? 'Cleared element on focus' : 'Cleared ' + description(element, true);
   await doActionAwaitingNavigation(options, async () => {
-    await _clear(element.get());
+    await focus(element, options);
     if (defaultConfig.headful) {
       await highlightElement(element);
     }
+    await _clear(element.get());
   });
   return desc;
 };

--- a/lib/actions/click.js
+++ b/lib/actions/click.js
@@ -45,7 +45,7 @@ async function click(selector, options = {}, ...args) {
   options.noOfClicks = options.clickCount || 1;
 
   if (isSelector(selector) || isString(selector) || isElement(selector)) {
-    const elementActionabilityChecks = [checksMap.visible, checksMap.disabled, checksMap.covered];
+    const elementActionabilityChecks = [checksMap.covered];
 
     const element = await waitAndGetActionableElement(selector, elementActionabilityChecks, args);
     await checkIfFileType(element);

--- a/lib/actions/focus.js
+++ b/lib/actions/focus.js
@@ -6,7 +6,7 @@ const { highlightElement } = require('../elements/elementHelper');
 const { defaultConfig } = require('../config');
 const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
 
-const focus = async (selector, options, highlight = false) => {
+const focus = async (selector, options = {}, highlight = false) => {
   let elem = selector;
   if (isSelector(selector) || isElement(selector) || isString(selector)) {
     elem = await waitAndGetActionableElement(selector);

--- a/lib/actions/focus.js
+++ b/lib/actions/focus.js
@@ -1,21 +1,30 @@
 const { isSelector, isElement, isString } = require('../helper');
-const { waitAndGetActionableElement } = require('./pageActionChecks');
+const { waitAndGetActionableElement, description } = require('./pageActionChecks');
 const { scrollToElement } = require('./scrollTo');
 const runtimeHandler = require('../handlers/runtimeHandler');
+const { highlightElement } = require('../elements/elementHelper');
+const { defaultConfig } = require('../config');
+const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
 
-const focus = async (selector) => {
+const focus = async (selector, options, highlight = false) => {
   let elem = selector;
   if (isSelector(selector) || isElement(selector) || isString(selector)) {
     elem = await waitAndGetActionableElement(selector);
   }
-  await scrollToElement(elem);
-  await runtimeHandler.runtimeCallFunctionOn(focusElement, null, {
-    objectId: elem.get(),
+  await doActionAwaitingNavigation(options, async () => {
+    await scrollToElement(elem);
+    if (defaultConfig.headful && highlight) {
+      await highlightElement(elem);
+    }
+    await runtimeHandler.runtimeCallFunctionOn(focusElement, null, {
+      objectId: elem.get(),
+    });
+    function focusElement() {
+      this.focus();
+      return true;
+    }
   });
-  function focusElement() {
-    this.focus();
-    return true;
-  }
+  return 'Focussed on the ' + description(selector, true);
 };
 
 module.exports = { focus };

--- a/lib/actions/focus.js
+++ b/lib/actions/focus.js
@@ -1,0 +1,21 @@
+const { isSelector, isElement, isString } = require('../helper');
+const { waitAndGetActionableElement } = require('./pageActionChecks');
+const { scrollToElement } = require('./scrollTo');
+const runtimeHandler = require('../handlers/runtimeHandler');
+
+const focus = async (selector) => {
+  let elem = selector;
+  if (isSelector(selector) || isElement(selector) || isString(selector)) {
+    elem = await waitAndGetActionableElement(selector);
+  }
+  await scrollToElement(elem);
+  await runtimeHandler.runtimeCallFunctionOn(focusElement, null, {
+    objectId: elem.get(),
+  });
+  function focusElement() {
+    this.focus();
+    return true;
+  }
+};
+
+module.exports = { focus };

--- a/lib/actions/highlight.js
+++ b/lib/actions/highlight.js
@@ -1,0 +1,56 @@
+const { description } = require('./pageActionChecks');
+const { handleRelativeSearch } = require('../proximityElementSearch');
+const { findElements } = require('../elementSearch');
+const runtimeHandler = require('../handlers/runtimeHandler');
+
+const clearHighlights = async () => {
+  await runtimeHandler.runtimeEvaluate(
+    `(function () {
+          let _class = 'taiko_highlight_style';
+          let elems = document.getElementsByClassName(_class);
+          Array.from(elems).forEach((e) => e.classList.remove(_class));
+          const searchElements = document.querySelectorAll('*');
+          for (const element of searchElements) {
+            if (element.shadowRoot) {
+              let elems = element.shadowRoot.querySelectorAll('.'+_class);
+              Array.from(elems).forEach((e) => e.classList.remove(_class));
+            }
+          }
+        })()`,
+  );
+  return 'Cleared all highlights for this page.';
+};
+
+const highlight = async (selector, args) => {
+  function highlightNode() {
+    function addTaikoHighlightStyleIfNotPresent(self) {
+      let taikoHighlightStyleID = 'taiko_highlight';
+      const root = self.getRootNode();
+      if (root.getElementById(taikoHighlightStyleID)) {
+        return;
+      }
+      let head =
+        root instanceof ShadowRoot
+          ? root
+          : document.head || document.getElementsByTagName('head')[0];
+      let style = document.createElement('style');
+      let css = '.taiko_highlight_style { outline: 0.5em solid red; }';
+      head.appendChild(style);
+      style.type = 'text/css';
+      style.id = taikoHighlightStyleID;
+      style.appendChild(document.createTextNode(css));
+    }
+    addTaikoHighlightStyleIfNotPresent(this);
+    let _class = 'taiko_highlight_style';
+    if (this.nodeType === Node.TEXT_NODE) {
+      return this.parentElement.classList.add(_class);
+    }
+    this.classList.add(_class);
+  }
+  let elems = await handleRelativeSearch(await findElements(selector), args);
+  await runtimeHandler.runtimeCallFunctionOn(highlightNode, null, { objectId: elems[0].get() });
+
+  return 'Highlighted the ' + description(elems[0], true);
+};
+
+module.exports = { highlight, clearHighlights };

--- a/lib/actions/hover.js
+++ b/lib/actions/hover.js
@@ -1,0 +1,27 @@
+const { description, waitAndGetActionableElement } = require('./pageActionChecks');
+const { scrollToElement } = require('./scrollTo');
+const { defaultConfig } = require('../config');
+const { highlightElement } = require('../elements/elementHelper');
+const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
+const domHandler = require('../handlers/domHandler');
+const inputHandler = require('../handlers/inputHandler');
+
+async function hover(selector, options) {
+  const e = await waitAndGetActionableElement(selector);
+  await scrollToElement(e);
+  if (defaultConfig.headful) {
+    await highlightElement(e);
+  }
+  const { x, y } = await domHandler.boundingBoxCenter(e.get());
+  const option = {
+    x: x,
+    y: y,
+  };
+  await doActionAwaitingNavigation(options, async () => {
+    option.type = 'mouseMoved';
+    return inputHandler.dispatchMouseEvent(option);
+  });
+  return 'Hovered over the ' + description(selector, true);
+}
+
+module.exports = { hover };

--- a/lib/actions/mouseAction.js
+++ b/lib/actions/mouseAction.js
@@ -1,0 +1,51 @@
+const { isSelector, isString } = require('../helper');
+const { scrollToElement } = require('./scrollTo');
+const { waitAndGetActionableElement } = require('./pageActionChecks');
+const { setClickOptions, setNavigationOptions, defaultConfig } = require('../config');
+const domHandler = require('../handlers/domHandler');
+const inputHandler = require('../handlers/inputHandler');
+const overlayHandler = require('../handlers/overlayHandler');
+const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
+
+const mouseAction = async (selector, action, coordinates, options) => {
+  let actions = ['press', 'move', 'release'];
+  if (!actions.includes(selector) && !isSelector(selector) && !isString(selector)) {
+    throw Error('Invalid Selector value passed : ' + selector);
+  }
+  if (!actions.includes(selector)) {
+    const elem = await waitAndGetActionableElement(selector);
+    if (elem == null) {
+      throw Error('Please provide a valid selector, unable to find element');
+    }
+    await scrollToElement(elem);
+    let rect = await domHandler.getBoundingClientRect(elem.get());
+    coordinates.x = coordinates.x + parseInt(rect.left);
+    coordinates.y = coordinates.y + parseInt(rect.top);
+  } else if (actions.includes(selector)) {
+    coordinates = action;
+    action = selector;
+  }
+  options = setNavigationOptions(options);
+  if (defaultConfig.headful) {
+    await overlayHandler.highlightRect({
+      x: coordinates.x,
+      y: coordinates.y,
+      width: 1,
+      height: 1,
+    });
+  }
+  options = setClickOptions(options, coordinates.x, coordinates.y);
+  await doActionAwaitingNavigation(options, async () => {
+    if (action === 'press') {
+      options.type = 'mousePressed';
+    } else if (action === 'move') {
+      options.type = 'mouseMoved';
+    } else if (action === 'release') {
+      options.type = 'mouseReleased';
+    }
+    await inputHandler.dispatchMouseEvent(options);
+  });
+  return 'Performed mouse ' + action + 'action at {' + coordinates.x + ', ' + coordinates.y + '}';
+};
+
+module.exports = { mouseAction };

--- a/lib/actions/pageActionChecks.js
+++ b/lib/actions/pageActionChecks.js
@@ -17,6 +17,10 @@ const checkWritable = async (elem) => {
   return await elem.isWritable();
 };
 
+const checkConnected = async (elem) => {
+  return await elem.isConnected();
+};
+
 const checkIfElementIsNotCovered = async (e) => {
   function isElementAtPointOrChild() {
     function getDirectParent(nodes, elem) {
@@ -68,6 +72,7 @@ const checksMap = {
   disabled: { predicate: checkNotDisabled, error: 'is disabled' },
   covered: { predicate: checkIfElementIsNotCovered, error: 'is covered by other element' },
   writable: { predicate: checkWritable, error: 'is not writable' },
+  connected: { predicate: checkConnected, error: 'is not connected to DOM' },
 };
 
 const checkIfActionable = async (elem, checks) => {
@@ -83,11 +88,10 @@ const checkIfActionable = async (elem, checks) => {
   return { actionable, error };
 };
 
-const waitAndGetActionableElement = async (
-  selector,
-  checks = [checksMap.visible, checksMap.disabled],
-  args = [],
-) => {
+const defaultChecks = [checksMap.visible, checksMap.disabled, checksMap.connected];
+
+const waitAndGetActionableElement = async (selector, checks = defaultChecks, args = []) => {
+  checks = [...new Set([...checks, ...defaultChecks])];
   const elements = await handleRelativeSearch(await findElements(selector), args);
   let elementsLength = elements.length;
   if (elementsLength > defaultConfig.noOfElementToMatch) {

--- a/lib/actions/pageActionChecks.js
+++ b/lib/actions/pageActionChecks.js
@@ -8,8 +8,13 @@ const { scrollToElement } = require('./scrollTo');
 const checkVisible = async (elem) => {
   return await elem.isVisible();
 };
+
 const checkNotDisabled = async (elem) => {
   return !(await elem.isDisabled());
+};
+
+const checkWritable = async (elem) => {
+  return await elem.isWritable();
 };
 
 const checkIfElementIsNotCovered = async (e) => {
@@ -62,6 +67,7 @@ const checksMap = {
   visible: { predicate: checkVisible, error: 'is not visible' },
   disabled: { predicate: checkNotDisabled, error: 'is disabled' },
   covered: { predicate: checkIfElementIsNotCovered, error: 'is covered by other element' },
+  writable: { predicate: checkWritable, error: 'is not writable' },
 };
 
 const checkIfActionable = async (elem, checks) => {

--- a/lib/actions/pageActionChecks.js
+++ b/lib/actions/pageActionChecks.js
@@ -67,12 +67,59 @@ const checkIfElementIsNotCovered = async (e) => {
   return res.result.value;
 };
 
+const checkStable = async (elem) => {
+  function waitForElementToBeStable() {
+    let elem = this;
+    return new Promise((resolve, reject) => {
+      setTimeout(() => reject(false), 10000);
+      let previousRect, currentRect;
+      function isInSamePosition(previousRect, currentRect) {
+        const topDiff = Math.abs(previousRect.top - currentRect.top);
+        const leftDiff = Math.abs(previousRect.left - currentRect.left);
+        const bottomDiff = Math.abs(previousRect.bottom - currentRect.bottom);
+        const rightDiff = Math.abs(previousRect.right - currentRect.right);
+        return topDiff + leftDiff + bottomDiff + rightDiff;
+      }
+      (function step() {
+        if (elem.nodeType === Node.TEXT_NODE) {
+          let range = document.createRange();
+          range.selectNodeContents(elem);
+          currentRect = range.getClientRects()[0];
+          elem = elem.parentElement;
+        } else {
+          currentRect = elem.getBoundingClientRect();
+        }
+        if (previousRect === undefined) {
+          previousRect = currentRect;
+          window.requestAnimationFrame(step);
+        }
+
+        const positionalDiff = isInSamePosition(previousRect, currentRect);
+        if (positionalDiff) {
+          previousRect = currentRect;
+          window.requestAnimationFrame(step);
+        } else {
+          resolve(true);
+        }
+      })();
+    });
+  }
+
+  const objectId = elem.get();
+  const res = await runtimeHandler.runtimeCallFunctionOn(waitForElementToBeStable, null, {
+    objectId: objectId,
+    awaitPromise: true,
+  });
+  return res.result.value;
+};
+
 const checksMap = {
   visible: { predicate: checkVisible, error: 'is not visible' },
   disabled: { predicate: checkNotDisabled, error: 'is disabled' },
   covered: { predicate: checkIfElementIsNotCovered, error: 'is covered by other element' },
   writable: { predicate: checkWritable, error: 'is not writable' },
   connected: { predicate: checkConnected, error: 'is not connected to DOM' },
+  stable: { predicate: checkStable, error: 'is not stable' },
 };
 
 const checkIfActionable = async (elem, checks) => {
@@ -88,7 +135,12 @@ const checkIfActionable = async (elem, checks) => {
   return { actionable, error };
 };
 
-const defaultChecks = [checksMap.visible, checksMap.disabled, checksMap.connected];
+const defaultChecks = [
+  checksMap.visible,
+  checksMap.disabled,
+  checksMap.connected,
+  checksMap.stable,
+];
 
 const waitAndGetActionableElement = async (selector, checks = defaultChecks, args = []) => {
   checks = [...new Set([...checks, ...defaultChecks])];

--- a/lib/actions/scrollTo.js
+++ b/lib/actions/scrollTo.js
@@ -1,4 +1,8 @@
 const runtimeHandler = require('../handlers/runtimeHandler');
+const { findFirstElement } = require('../elementSearch');
+const { defaultConfig, setNavigationOptions } = require('../config');
+const { highlightElement } = require('../elements/elementHelper');
+const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
 
 const scrollToElement = async (element) => {
   function scrollToNode() {
@@ -9,4 +13,37 @@ const scrollToElement = async (element) => {
   await runtimeHandler.runtimeCallFunctionOn(scrollToNode, null, { objectId: element.get() });
 };
 
-module.exports = { scrollToElement };
+const scroll = async (e, px, scrollPage, scrollElement, direction) => {
+  e = e || 100;
+  if (Number.isInteger(e)) {
+    const res = await runtimeHandler.runtimeEvaluate(
+      `(${scrollPage}).apply(null, ${JSON.stringify([e])})`,
+    );
+    if (res.result.subtype == 'error') {
+      throw new Error(res.result.description);
+    }
+    return {
+      description: `Scrolled ${direction} the page by ${e} pixels`,
+    };
+  }
+
+  const element = await findFirstElement(e);
+  if (defaultConfig.headful) {
+    await highlightElement(element);
+  }
+  //TODO: Allow user to set options for scroll
+  const options = setNavigationOptions({});
+  await doActionAwaitingNavigation(options, async () => {
+    const res = await runtimeHandler.runtimeCallFunctionOn(scrollElement, null, {
+      objectId: element.get(),
+      arg: px,
+    });
+    if (res.result.subtype == 'error') {
+      throw new Error(res.result.description);
+    }
+  });
+  const { description } = require('./pageActionChecks');
+  return 'Scrolled ' + direction + description(e, true) + 'by ' + px + ' pixels';
+};
+
+module.exports = { scrollToElement, scroll };

--- a/lib/actions/write.js
+++ b/lib/actions/write.js
@@ -1,0 +1,72 @@
+const keyDefinitions = require('../data/USKeyboardLayout');
+const { defaultConfig } = require('../config');
+const inputHandler = require('../handlers/inputHandler');
+const runtimeHandler = require('../handlers/runtimeHandler');
+const { highlightElement } = require('../elements/elementHelper');
+const { isString, isElement, isSelector } = require('../helper');
+const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
+const { description, waitAndGetActionableElement, checksMap } = require('./pageActionChecks');
+const { findActiveElement } = require('../elementSearch');
+const Element = require('../elements/element');
+const { focus } = require('./focus');
+
+const _write = async (activeElement, text, options) => {
+  if (defaultConfig.headful) {
+    await highlightElement(new Element(activeElement.objectId, '', runtimeHandler));
+  }
+  await focus(activeElement);
+  for (const char of text) {
+    if (keyDefinitions[char]) {
+      await inputHandler.down(char);
+      await inputHandler.up(char);
+      if (options && options.delay) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, options.delay);
+        });
+      }
+    } else {
+      await inputHandler.sendCharacter(char);
+    }
+  }
+};
+
+const write = async (text, into, options) => {
+  if (text == null || text == undefined) {
+    console.warn(`Invalid text value ${text}, setting value to empty ''`);
+    text = '';
+  } else {
+    if (!isString(text)) {
+      text = text.toString();
+    }
+  }
+
+  if (into && !isSelector(into) && !isElement(into) && !isString(into)) {
+    if (!into.delay) {
+      into.delay = options.delay;
+    }
+    options = into;
+    into = undefined;
+  }
+
+  let desc, elems, elementDesc, selector;
+  if (into) {
+    const TextBoxWrapper = require('../elementWrapper/textBoxWrapper');
+    selector = isString(into) ? new TextBoxWrapper(into) : into;
+    elementDesc = description(selector, true);
+  } else {
+    selector = await findActiveElement();
+  }
+  elems = await waitAndGetActionableElement(selector, [checksMap.writable]);
+
+  await doActionAwaitingNavigation(options, async () => {
+    await _write(elems, text, options);
+  });
+
+  const textDesc = (await elems.isPassword()) || options.hideText ? '*****' : text;
+  desc = into
+    ? `Wrote ${textDesc} into the ${elementDesc === '' ? 'focused element' : elementDesc}`
+    : `Wrote ${textDesc} into the focused element.`;
+  return desc;
+};
+
+module.exports = { write };

--- a/lib/actions/write.js
+++ b/lib/actions/write.js
@@ -6,7 +6,7 @@ const { highlightElement } = require('../elements/elementHelper');
 const { isString, isElement, isSelector } = require('../helper');
 const { doActionAwaitingNavigation } = require('../doActionAwaitingNavigation');
 const { description, waitAndGetActionableElement, checksMap } = require('./pageActionChecks');
-const { findActiveElement } = require('../elementSearch');
+const { waitAndGetFocusedElement } = require('../elementSearch');
 const Element = require('../elements/element');
 const { focus } = require('./focus');
 
@@ -54,7 +54,7 @@ const write = async (text, into, options) => {
     selector = isString(into) ? new TextBoxWrapper(into) : into;
     elementDesc = description(selector, true);
   } else {
-    selector = await findActiveElement();
+    selector = await waitAndGetFocusedElement();
   }
   elems = await waitAndGetActionableElement(selector, [checksMap.writable]);
 

--- a/lib/elementSearch.js
+++ b/lib/elementSearch.js
@@ -1,5 +1,5 @@
 const { assertType, isString, waitUntil, isSelector, isElement, isRegex } = require('./helper');
-const { determineRetryInterval, determineRetryTimeout } = require('./config');
+const { determineRetryInterval, determineRetryTimeout, defaultConfig } = require('./config');
 const runtimeHandler = require('./handlers/runtimeHandler');
 const { handleRelativeSearch } = require('./proximityElementSearch');
 const Element = require('./elements/element');
@@ -286,7 +286,28 @@ const findActiveElement = async () => {
 
   const activeElementObjectIds = await runtimeHandler.findElements(getActiveElement);
   const elements = Element.create(activeElementObjectIds, runtimeHandler);
-  return elements[0];
+  return elements;
+};
+
+const waitAndGetFocusedElement = async () => {
+  let activeElement;
+  await waitUntil(
+    async () => {
+      try {
+        activeElement = await findActiveElement();
+        return activeElement.length;
+      } catch (e) {
+        if (e.message.match(/Browser process with pid \d+ exited with/)) {
+          throw e;
+        }
+      }
+    },
+    defaultConfig.retryInterval,
+    defaultConfig.retryTimeout,
+  ).catch(() => {
+    throw new Error('There is no element focused, provide an appropriate selector.');
+  });
+  return activeElement[0];
 };
 
 const getIfExists = (findElements, description, customFuncs = {}) => {
@@ -320,6 +341,6 @@ module.exports = {
   $function,
   findFirstElement,
   findElements,
-  findActiveElement,
+  waitAndGetFocusedElement,
   getIfExists,
 };

--- a/lib/elementSearch.js
+++ b/lib/elementSearch.js
@@ -273,6 +273,22 @@ const findElements = async (selector, tag) => {
   return elements;
 };
 
+const findActiveElement = async () => {
+  const getActiveElement = function () {
+    let activeElement = document.activeElement;
+    const parsedShadowRoots = [];
+    while (activeElement.shadowRoot && !parsedShadowRoots.includes(activeElement.shadowRoot)) {
+      parsedShadowRoots.push(activeElement.shadowRoot);
+      activeElement = activeElement.shadowRoot.activeElement;
+    }
+    return activeElement;
+  };
+
+  const activeElementObjectIds = await runtimeHandler.findElements(getActiveElement);
+  const elements = Element.create(activeElementObjectIds, runtimeHandler);
+  return elements[0];
+};
+
 const getIfExists = (findElements, description, customFuncs = {}) => {
   return async (tag, retryInterval, retryTimeout) => {
     retryInterval = determineRetryInterval(retryInterval);
@@ -304,5 +320,6 @@ module.exports = {
   $function,
   findFirstElement,
   findElements,
+  findActiveElement,
   getIfExists,
 };

--- a/lib/elements/element.js
+++ b/lib/elements/element.js
@@ -37,6 +37,21 @@ class Element {
     return result.result.value;
   }
 
+  static create(objectIds, runtimeHandler) {
+    return objectIds.map((objectId) => new Element(objectId, '', runtimeHandler));
+  }
+
+  async _executeAndGetValue(callback) {
+    const { result } = await this.runtimeHandler.runtimeCallFunctionOn(callback, null, {
+      objectId: this.objectId,
+      returnByValue: true,
+    });
+    if (result.value === undefined) {
+      return false;
+    }
+    return result.value;
+  }
+
   async isVisible() {
     function isHidden() {
       let elem = this;
@@ -50,26 +65,6 @@ class Element {
       returnByValue: true,
     });
     return !result.result.value;
-  }
-
-  static create(objectIds, runtimeHandler) {
-    return objectIds.map((objectId) => new Element(objectId, '', runtimeHandler));
-  }
-
-  async isDisabled() {
-    function isDisabled() {
-      if (this.nodeType === Node.ELEMENT_NODE) {
-        return this.parentElement.disabled || this.disabled;
-      }
-    }
-    const { result } = await this.runtimeHandler.runtimeCallFunctionOn(isDisabled, null, {
-      objectId: this.objectId,
-      returnByValue: true,
-    });
-    if (result.value === undefined) {
-      return false;
-    }
-    return result.value;
   }
 
   async isWritable() {
@@ -99,33 +94,34 @@ class Element {
     }
   }
 
+  async isDisabled() {
+    function isDisabled() {
+      if (this.nodeType === Node.ELEMENT_NODE) {
+        return this.parentElement.disabled || this.disabled;
+      }
+    }
+    return await this._executeAndGetValue(isDisabled);
+  }
+
+  async isConnected() {
+    function isConnected() {
+      return (this.parentElement && this.parentElement.isConnected) || this.isConnected;
+    }
+    return await this._executeAndGetValue(isConnected);
+  }
+
   async isPassword() {
     function isPassword() {
       return this.type === 'password';
     }
-    const { result } = await this.runtimeHandler.runtimeCallFunctionOn(isPassword, null, {
-      objectId: this.objectId,
-      returnByValue: true,
-    });
-    if (result.value === undefined) {
-      return false;
-    }
-    return result.value;
+    return await this._executeAndGetValue(isPassword);
   }
 
   async isDraggable() {
     function isDraggable() {
       return (this.parentElement && this.parentElement.draggable) || this.draggable;
     }
-    const { result } = await this.runtimeHandler.runtimeCallFunctionOn(isDraggable, null, {
-      objectId: this.objectId,
-      returnByValue: true,
-    });
-    if (result.value === undefined) {
-      return false;
-    }
-    return result.value;
+    return await this._executeAndGetValue(isDraggable);
   }
 }
-
 module.exports = Element;

--- a/lib/elements/element.js
+++ b/lib/elements/element.js
@@ -72,6 +72,47 @@ class Element {
     return result.value;
   }
 
+  async isWritable() {
+    function getDetailsForWrittable() {
+      return {
+        tagName: this.tagName,
+        isContentEditable: this.isContentEditable,
+        disabled: this.disabled,
+        type: this.type,
+        readOnly: this.readOnly,
+      };
+    }
+
+    let editable, disabled;
+    const result = await this.runtimeHandler.runtimeCallFunctionOn(getDetailsForWrittable, null, {
+      objectId: this.objectId,
+      returnByValue: true,
+    });
+    const activeElementDetails = result ? result.result.value : undefined;
+    if (activeElementDetails) {
+      editable =
+        !activeElementDetails.readOnly &&
+        (['INPUT', 'TEXTAREA', 'SELECT'].includes(activeElementDetails.tagName) ||
+          activeElementDetails.isContentEditable);
+      disabled = activeElementDetails.disabled;
+      return !(!editable || disabled);
+    }
+  }
+
+  async isPassword() {
+    function isPassword() {
+      return this.type === 'password';
+    }
+    const { result } = await this.runtimeHandler.runtimeCallFunctionOn(isPassword, null, {
+      objectId: this.objectId,
+      returnByValue: true,
+    });
+    if (result.value === undefined) {
+      return false;
+    }
+    return result.value;
+  }
+
   async isDraggable() {
     function isDraggable() {
       return (this.parentElement && this.parentElement.draggable) || this.draggable;

--- a/lib/handlers/runtimeHandler.js
+++ b/lib/handlers/runtimeHandler.js
@@ -161,57 +161,8 @@ const findElements = async (exp, arg) => {
   return objectIds;
 };
 
-const activeElement = async () => {
-  function getActiveElement() {
-    let activeElement = document.activeElement;
-    const parsedShadowRoots = [];
-    while (activeElement.shadowRoot && !parsedShadowRoots.includes(activeElement.shadowRoot)) {
-      parsedShadowRoots.push(activeElement.shadowRoot);
-      activeElement = activeElement.shadowRoot.activeElement;
-    }
-    return activeElement;
-  }
-
-  function getDetails() {
-    return {
-      tagName: this.tagName,
-      isContentEditable: this.isContentEditable,
-      disabled: this.disabled,
-      type: this.type,
-      readOnly: this.readOnly,
-    };
-  }
-
-  let editable, disabled;
-
-  const activeElementObjectIds = await findElements(getActiveElement);
-  for (let activeElementObjectId of activeElementObjectIds) {
-    const result = await runtimeCallFunctionOn(getDetails, null, {
-      objectId: activeElementObjectId,
-      returnByValue: true,
-    });
-    const activeElementDetails = result ? result.result.value : undefined;
-    if (activeElementDetails) {
-      editable =
-        !activeElementDetails.readOnly &&
-        (['INPUT', 'TEXTAREA', 'SELECT'].includes(activeElementDetails.tagName) ||
-          activeElementDetails.isContentEditable);
-      disabled = activeElementDetails.disabled;
-      if (!(!editable || disabled)) {
-        return {
-          notWritable: false,
-          objectId: activeElementObjectId,
-          isPassword: activeElementDetails.type === 'password',
-        };
-      }
-    }
-  }
-  return { notWritable: true };
-};
-
 module.exports = {
   findElements,
-  activeElement,
   runtimeEvaluate,
   runtimeCallFunctionOn,
 };

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1015,13 +1015,8 @@ const { focus } = require('./actions/focus');
 module.exports.focus = async (selector, options = {}) => {
   validate();
   options = setNavigationOptions(options);
-  await doActionAwaitingNavigation(options, async () => {
-    if (defaultConfig.headful) {
-      await highlightElement(await findFirstElement(selector));
-    }
-    await focus(selector);
-  });
-  descEvent.emit('success', 'Focussed on the ' + description(selector, true));
+  const desc = await focus(selector, options, true);
+  descEvent.emit('success', desc);
 };
 
 /**
@@ -1075,7 +1070,7 @@ module.exports.write = async (text, into, options = { delay: 0 }) => {
       for (let elem of elems) {
         try {
           if (!elem.focused) {
-            await focus(elem);
+            await focus(elem, options);
           }
           activeElement = await runtimeHandler.activeElement();
           if (activeElement.notWritable) {
@@ -1158,7 +1153,7 @@ module.exports.clear = async (selector, options = {}) => {
       async () => {
         try {
           if (selector) {
-            await focus(selector);
+            await focus(selector, options);
           }
         } catch (_) {}
         return !(await runtimeHandler.activeElement()).notWritable;

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -24,7 +24,6 @@ const { description } = require('./actions/pageActionChecks');
 const { match, $$xpath, findElements, findFirstElement } = require('./elementSearch');
 const { handleRelativeSearch, RelativeSearchElement } = require('./proximityElementSearch');
 const Element = require('./elements/element');
-const keyDefinitions = require('../lib/data/USKeyboardLayout');
 const { scrollToElement } = require('./actions/scrollTo');
 const {
   setConfig,
@@ -1039,86 +1038,11 @@ module.exports.focus = async (selector, options = {}) => {
  * @returns {Promise<void>}
  */
 module.exports.write = async (text, into, options = { delay: 0 }) => {
-  if (text == null || text == undefined) {
-    console.warn(`Invalid text value ${text}, setting value to empty ''`);
-    text = '';
-  } else {
-    if (!isString(text)) {
-      text = text.toString();
-    }
-  }
   validate();
-  if (into && !isSelector(into) && !isElement(into) && !isString(into)) {
-    if (!into.delay) {
-      into.delay = options.delay;
-    }
-    options = into;
-    into = undefined;
-  }
+  const { write } = require('./actions/write');
   options = setNavigationOptions(options);
-  let desc, elems, activeElement, elementDesc;
-  if (into) {
-    const selector = isString(into) ? textBox(into) : into;
-    elems = await handleRelativeSearch(await findElements(selector), []);
-    elementDesc = description(selector, true);
-  } else {
-    elems = [{ focused: true }];
-  }
-
-  await waitUntil(
-    async () => {
-      for (let elem of elems) {
-        try {
-          if (!elem.focused) {
-            await focus(elem, options);
-          }
-          activeElement = await runtimeHandler.activeElement();
-          if (activeElement.notWritable) {
-            continue;
-          }
-          return true;
-        } catch (e) {
-          if (e.message.match(/Browser process with pid \d+ exited with/)) {
-            throw e;
-          }
-        }
-      }
-      return false;
-    },
-    defaultConfig.retryInterval,
-    defaultConfig.retryTimeout,
-  ).catch(() => {
-    throw new Error('Element focused is not writable');
-  });
-
-  await doActionAwaitingNavigation(options, async () => {
-    await _write(activeElement, text, options);
-  });
-
-  const textDesc = activeElement.isPassword || options.hideText ? '*****' : text;
-  desc = into
-    ? `Wrote ${textDesc} into the ${elementDesc === '' ? 'focused element' : elementDesc}`
-    : `Wrote ${textDesc} into the focused element.`;
+  const desc = await write(text, into, options);
   descEvent.emit('success', desc);
-};
-
-const _write = async (activeElement, text, options) => {
-  if (defaultConfig.headful) {
-    await highlightElement(new Element(activeElement.objectId, '', runtimeHandler));
-  }
-  for (const char of text) {
-    if (keyDefinitions[char]) {
-      await inputHandler.down(char);
-      await inputHandler.up(char);
-      if (options && options.delay) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, options.delay);
-        });
-      }
-    } else {
-      await inputHandler.sendCharacter(char);
-    }
-  }
 };
 
 /**
@@ -1147,47 +1071,9 @@ module.exports.clear = async (selector, options = {}) => {
     selector = undefined;
   }
   options = setNavigationOptions(options);
-  let activeElement = await runtimeHandler.activeElement();
-  if (activeElement.notWritable || selector) {
-    await waitUntil(
-      async () => {
-        try {
-          if (selector) {
-            await focus(selector, options);
-          }
-        } catch (_) {}
-        return !(await runtimeHandler.activeElement()).notWritable;
-      },
-      100,
-      10000,
-    ).catch(() => {
-      throw new Error('Element cannot be cleared');
-    });
-    activeElement = await runtimeHandler.activeElement();
-  }
-  if (activeElement.notWritable) {
-    throw new Error('Element cannot be cleared');
-  }
-  const desc = !selector ? 'Cleared element on focus' : 'Cleared ' + description(selector, true);
-  await doActionAwaitingNavigation(options, async () => {
-    await _clear(activeElement.objectId);
-    if (defaultConfig.headful) {
-      await highlightElement(new Element(activeElement.objectId, '', runtimeHandler));
-    }
-  });
+  const { clear } = require('./actions/clear');
+  const desc = await clear(selector, options);
   descEvent.emit('success', desc);
-};
-
-const _clear = async (elem) => {
-  await runtimeHandler.runtimeCallFunctionOn(
-    function () {
-      document.execCommand('selectall', false, null);
-    },
-    null,
-    { objectId: elem },
-  );
-  await inputHandler.down('Backspace');
-  await inputHandler.up('Backspace');
 };
 
 /**

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1212,47 +1212,9 @@ module.exports.mouseAction = mouseAction;
 
 async function mouseAction(selector, action, coordinates, options = {}) {
   validate();
-  var actions = ['press', 'move', 'release'];
-  if (!actions.includes(selector) && !isSelector(selector) && !isString(selector)) {
-    throw Error('Invalid Selector value passed : ' + selector);
-  }
-  if (!actions.includes(selector)) {
-    const elem = await findFirstElement(selector);
-    if (elem == null) {
-      throw Error('Please provide a valid selector, unable to find element');
-    }
-    await scrollToElement(elem);
-    let rect = await domHandler.getBoundingClientRect(elem.get());
-    coordinates.x = coordinates.x + parseInt(rect.left);
-    coordinates.y = coordinates.y + parseInt(rect.top);
-  } else if (actions.includes(selector)) {
-    coordinates = action;
-    action = selector;
-  }
-  options = setNavigationOptions(options);
-  if (defaultConfig.headful) {
-    await overlayHandler.highlightRect({
-      x: coordinates.x,
-      y: coordinates.y,
-      width: 1,
-      height: 1,
-    });
-  }
-  options = setClickOptions(options, coordinates.x, coordinates.y);
-  await doActionAwaitingNavigation(options, async () => {
-    if (action === 'press') {
-      options.type = 'mousePressed';
-    } else if (action === 'move') {
-      options.type = 'mouseMoved';
-    } else if (action === 'release') {
-      options.type = 'mouseReleased';
-    }
-    await inputHandler.dispatchMouseEvent(options);
-  });
-  descEvent.emit(
-    'success',
-    'Performed mouse ' + action + 'action at {' + coordinates.x + ', ' + coordinates.y + '}',
-  );
+  const { mouseAction } = require('./actions/mouseAction');
+  const desc = mouseAction(selector, action, coordinates, options);
+  descEvent.emit('success', desc);
 }
 
 /**
@@ -1277,44 +1239,9 @@ module.exports.scrollTo = async (selector, options = {}) => {
     await scrollToElement(element);
   });
   if (defaultConfig.headful) {
-    await highlightElement(await findFirstElement(selector));
-  }
-  descEvent.emit('success', 'Scrolled to the ' + description(selector, true));
-};
-
-const scroll = async (e, px, scrollPage, scrollElement, direction) => {
-  e = e || 100;
-  if (Number.isInteger(e)) {
-    const res = await runtimeHandler.runtimeEvaluate(
-      `(${scrollPage}).apply(null, ${JSON.stringify([e])})`,
-    );
-    if (res.result.subtype == 'error') {
-      throw new Error(res.result.description);
-    }
-    return {
-      description: `Scrolled ${direction} the page by ${e} pixels`,
-    };
-  }
-
-  const element = await findFirstElement(e);
-  if (defaultConfig.headful) {
     await highlightElement(element);
   }
-  //TODO: Allow user to set options for scroll
-  const options = setNavigationOptions({});
-  await doActionAwaitingNavigation(options, async () => {
-    const res = await runtimeHandler.runtimeCallFunctionOn(scrollElement, null, {
-      objectId: element.get(),
-      arg: px,
-    });
-    if (res.result.subtype == 'error') {
-      throw new Error(res.result.description);
-    }
-  });
-  descEvent.emit(
-    'success',
-    'Scrolled ' + direction + description(e, true) + 'by ' + px + ' pixels',
-  );
+  descEvent.emit('success', 'Scrolled to the ' + description(selector, true));
 };
 
 /**
@@ -1336,7 +1263,8 @@ const scroll = async (e, px, scrollPage, scrollElement, direction) => {
  */
 module.exports.scrollRight = async (e, px = 100) => {
   validate();
-  return await scroll(
+  const { scroll } = require('./actions/scrollTo');
+  const desc = await scroll(
     e,
     px,
     (px) => window.scrollBy(px, 0),
@@ -1350,6 +1278,7 @@ module.exports.scrollRight = async (e, px = 100) => {
     },
     'right',
   );
+  descEvent.emit('success', desc);
 };
 
 /**
@@ -1371,7 +1300,8 @@ module.exports.scrollRight = async (e, px = 100) => {
  */
 module.exports.scrollLeft = async (e, px = 100) => {
   validate();
-  return await scroll(
+  const { scroll } = require('./actions/scrollTo');
+  const desc = await scroll(
     e,
     px,
     (px) => window.scrollBy(px * -1, 0),
@@ -1385,6 +1315,7 @@ module.exports.scrollLeft = async (e, px = 100) => {
     },
     'left',
   );
+  descEvent.emit('success', desc);
 };
 
 /**
@@ -1406,7 +1337,8 @@ module.exports.scrollLeft = async (e, px = 100) => {
  */
 module.exports.scrollUp = async (e, px = 100) => {
   validate();
-  return await scroll(
+  const { scroll } = require('./actions/scrollTo');
+  const desc = await scroll(
     e,
     px,
     (px) => window.scrollBy(0, px * -1),
@@ -1420,6 +1352,7 @@ module.exports.scrollUp = async (e, px = 100) => {
     },
     'up',
   );
+  descEvent.emit('success', desc);
 };
 
 /**
@@ -1441,7 +1374,8 @@ module.exports.scrollUp = async (e, px = 100) => {
  */
 module.exports.scrollDown = async (e, px = 100) => {
   validate();
-  return await scroll(
+  const { scroll } = require('./actions/scrollTo');
+  const desc = await scroll(
     e,
     px,
     (px) => window.scrollBy(0, px),
@@ -1455,6 +1389,7 @@ module.exports.scrollDown = async (e, px = 100) => {
     },
     'down',
   );
+  descEvent('Success', desc);
 };
 
 /**

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -22,8 +22,7 @@ const browserHandler = require('./handlers/browserHandler');
 const emulationHandler = require('./handlers/emulationHandler');
 const { description } = require('./actions/pageActionChecks');
 const { match, $$xpath, findElements, findFirstElement } = require('./elementSearch');
-const { handleRelativeSearch, RelativeSearchElement } = require('./proximityElementSearch');
-const Element = require('./elements/element');
+const { RelativeSearchElement } = require('./proximityElementSearch');
 const { scrollToElement } = require('./actions/scrollTo');
 const {
   setConfig,
@@ -1089,21 +1088,9 @@ module.exports.clear = async (selector, options = {}) => {
  */
 module.exports.attach = async (filepath, to) => {
   validate();
-  let resolvedPath = filepath ? path.resolve(process.cwd(), filepath) : path.resolve(process.cwd());
-  if (!fs.existsSync(resolvedPath)) {
-    throw new Error(`File ${resolvedPath} does not exist.`);
-  }
-  if (isString(to)) {
-    to = fileField(to);
-  } else if (!isSelector(to) && !isElement(to)) {
-    throw Error('Invalid element passed as parameter');
-  }
-  const element = await findFirstElement(to);
-  if (defaultConfig.headful) {
-    await highlightElement(element);
-  }
-  await domHandler.setFileInputFiles(element.get(), resolvedPath);
-  descEvent.emit('success', 'Attached ' + resolvedPath + ' to the ' + description(to, true));
+  const { attach } = require('./actions/attach');
+  const desc = await attach(filepath, to);
+  descEvent.emit('success', desc);
 };
 
 /**
@@ -1174,35 +1161,9 @@ async function highlight(selector, ...args) {
     console.warn('Highlights are disabled. Please enable highlights.');
     return;
   }
-
-  function highlightNode() {
-    function addTaikoHighlightStyleIfNotPresent(self) {
-      let taikoHighlightStyleID = 'taiko_highlight';
-      const root = self.getRootNode();
-      if (root.getElementById(taikoHighlightStyleID)) {
-        return;
-      }
-      let head =
-        root instanceof ShadowRoot
-          ? root
-          : document.head || document.getElementsByTagName('head')[0];
-      let style = document.createElement('style');
-      let css = '.taiko_highlight_style { outline: 0.5em solid red; }';
-      head.appendChild(style);
-      style.type = 'text/css';
-      style.id = taikoHighlightStyleID;
-      style.appendChild(document.createTextNode(css));
-    }
-    addTaikoHighlightStyleIfNotPresent(this);
-    let _class = 'taiko_highlight_style';
-    if (this.nodeType === Node.TEXT_NODE) {
-      return this.parentElement.classList.add(_class);
-    }
-    this.classList.add(_class);
-  }
-  let elems = await handleRelativeSearch(await findElements(selector), args);
-  await evaluate(elems[0], highlightNode);
-  descEvent.emit('success', 'Highlighted the ' + description(elems[0], true));
+  const { highlight } = require('./actions/highlight');
+  const desc = await highlight(selector, args);
+  descEvent.emit('success', desc);
 }
 
 /**
@@ -1216,20 +1177,9 @@ async function highlight(selector, ...args) {
 
 module.exports.clearHighlights = async () => {
   validate();
-  let elem = (await $$xpath('//*'))[0];
-  await evaluate(elem, function () {
-    let _class = 'taiko_highlight_style';
-    let elems = document.getElementsByClassName(_class);
-    Array.from(elems).forEach((e) => e.classList.remove(_class));
-    const searchElements = document.querySelectorAll('*');
-    for (const element of searchElements) {
-      if (element.shadowRoot) {
-        let elems = element.shadowRoot.querySelectorAll(`.${_class}`);
-        Array.from(elems).forEach((e) => e.classList.remove(_class));
-      }
-    }
-  });
-  descEvent.emit('success', 'Cleared all highlights for this page.');
+  const { clearHighlights } = require('./actions/highlight');
+  const desc = await clearHighlights();
+  descEvent.emit('success', desc);
 };
 
 /**
@@ -2652,12 +2602,6 @@ const dialog = (dialogType, dialogMessage, callback) => {
 const createJsDialogEvent = (message, dType) => {
   let hash = crypto.createHash('md5').update(message.toString()).digest('hex');
   return dType + '_' + hash;
-};
-
-const evaluate = async (selector, func) => {
-  let objectId = (await findFirstElement(selector)).get();
-  let { result } = await runtimeHandler.runtimeCallFunctionOn(func, null, { objectId: objectId });
-  return result || {};
 };
 
 const rectangle = async (selector, callback) => {

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1206,7 +1206,7 @@ module.exports.mouseAction = mouseAction;
 async function mouseAction(selector, action, coordinates, options = {}) {
   validate();
   const { mouseAction } = require('./actions/mouseAction');
-  const desc = mouseAction(selector, action, coordinates, options);
+  const desc = await mouseAction(selector, action, coordinates, options);
   descEvent.emit('success', desc);
 }
 

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -24,19 +24,12 @@ const { description } = require('./actions/pageActionChecks');
 const { match, $$xpath, findElements, findFirstElement } = require('./elementSearch');
 const { RelativeSearchElement } = require('./proximityElementSearch');
 const { scrollToElement } = require('./actions/scrollTo');
-const {
-  setConfig,
-  getConfig,
-  defaultConfig,
-  setNavigationOptions,
-  setClickOptions,
-} = require('./config');
+const { setConfig, getConfig, defaultConfig, setNavigationOptions } = require('./config');
 const fs = require('fs-extra');
 const path = require('path');
 const childProcess = require('child_process');
 const crypto = require('crypto');
 const { eventHandler, eventRegexMap } = require('./eventBus');
-const overlayHandler = require('./handlers/overlayHandler');
 const { highlightElement } = require('./elements/elementHelper');
 const { launchBrowser } = require('./browserLauncher');
 const {
@@ -1389,7 +1382,7 @@ module.exports.scrollDown = async (e, px = 100) => {
     },
     'down',
   );
-  descEvent('Success', desc);
+  descEvent.emit('Success', desc);
 };
 
 /**

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -142,6 +142,13 @@ const _closeBrowser = async () => {
   await closeConnection(promisesToBeResolvedBeforeCloseBrowser);
 };
 
+/**
+ * Gives CRI client object (a wrapper around Chrome DevTools Protocol). Refer https://github.com/cyrus-and/chrome-remote-interface
+ * This is useful while writing plugins or if use some API of [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/).
+ *
+ * @returns {Object}
+ */
+module.exports.client = () => getEventProxy(getClient());
 function getEventProxy(target) {
   if (!target) {
     return target;
@@ -163,14 +170,6 @@ function getEventProxy(target) {
   };
   return new Proxy(target, handler);
 }
-
-/**
- * Gives CRI client object (a wrapper around Chrome DevTools Protocol). Refer https://github.com/cyrus-and/chrome-remote-interface
- * This is useful while writing plugins or if use some API of [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/).
- *
- * @returns {Object}
- */
-module.exports.client = () => getEventProxy(getClient());
 
 /**
  * Allows switching between tabs and windows using URL or page title or Window name.
@@ -995,27 +994,9 @@ module.exports.dragAndDrop = async (source, destination) => {
 module.exports.hover = async (selector, options = {}) => {
   validate();
   options = setNavigationOptions(options);
-  const e = await findFirstElement(selector);
-  await scrollToElement(e);
-  if (defaultConfig.headful) {
-    await highlightElement(e);
-  }
-  const { x, y } = await domHandler.boundingBoxCenter(e.get());
-  const option = {
-    x: x,
-    y: y,
-  };
-  await doActionAwaitingNavigation(options, async () => {
-    Promise.resolve()
-      .then(() => {
-        option.type = 'mouseMoved';
-        return inputHandler.dispatchMouseEvent(option);
-      })
-      .catch((err) => {
-        throw new Error(err);
-      });
-  });
-  descEvent.emit('success', 'Hovered over the ' + description(selector, true));
+  const { hover } = require('./actions/hover');
+  const desc = await hover(selector, options);
+  descEvent.emit('success', desc);
 };
 
 /**
@@ -1030,6 +1011,7 @@ module.exports.hover = async (selector, options = {}) => {
  * @param {Object} options
  * @param {string[]} [options.waitForEvents = ['firstMeaningfulPaint']] - Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint']
  */
+const { focus } = require('./actions/focus');
 module.exports.focus = async (selector, options = {}) => {
   validate();
   options = setNavigationOptions(options);
@@ -1037,7 +1019,7 @@ module.exports.focus = async (selector, options = {}) => {
     if (defaultConfig.headful) {
       await highlightElement(await findFirstElement(selector));
     }
-    await _focus(selector);
+    await focus(selector);
   });
   descEvent.emit('success', 'Focussed on the ' + description(selector, true));
 };
@@ -1093,7 +1075,7 @@ module.exports.write = async (text, into, options = { delay: 0 }) => {
       for (let elem of elems) {
         try {
           if (!elem.focused) {
-            await _focus(elem);
+            await focus(elem);
           }
           activeElement = await runtimeHandler.activeElement();
           if (activeElement.notWritable) {
@@ -1176,7 +1158,7 @@ module.exports.clear = async (selector, options = {}) => {
       async () => {
         try {
           if (selector) {
-            await _focus(selector);
+            await focus(selector);
           }
         } catch (_) {}
         return !(await runtimeHandler.activeElement()).notWritable;
@@ -2759,32 +2741,6 @@ module.exports.getConfig = getConfig;
  * @param {string} [options.highlightOnAction = 'false' ] Option to highlight an element on action.
  */
 module.exports.setConfig = setConfig;
-
-const _focus = async (selector) => {
-  let elems = [selector];
-  if (isSelector(selector) || isElement(selector)) {
-    elems = await handleRelativeSearch(await findElements(selector), []);
-  }
-  let error;
-  for (const elem of elems) {
-    await scrollToElement(elem);
-    const result = await evaluate(elem, focusElement);
-    if (result.subtype != 'error') {
-      return;
-    } else if (result.subtype == 'error') {
-      error = result.description;
-    }
-  }
-  throw new Error(error);
-
-  function focusElement() {
-    if (this.disabled == true) {
-      throw new Error('Element is not focusable');
-    }
-    this.focus();
-    return true;
-  }
-};
 
 const promisesToBeResolvedBeforeCloseBrowser = [];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "taiko",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Taiko is a Node.js library for automating Chromium based browsers",
   "main": "bin/taiko.js",
   "bin": {

--- a/test/unit-tests/actions/pageActionChecks.test.js
+++ b/test/unit-tests/actions/pageActionChecks.test.js
@@ -60,6 +60,7 @@ describe('pageActionChecks', () => {
       const defaultChecks = [
         pageActionChecks.checksMap.visible,
         pageActionChecks.checksMap.disabled,
+        pageActionChecks.checksMap.connected,
       ];
       let actualCheck;
       pageActionChecks.__set__('checkIfActionable', (elem, checks) => {
@@ -72,8 +73,12 @@ describe('pageActionChecks', () => {
       await pageActionChecks.waitAndGetActionableElement('Something');
       expect(actualCheck).to.deep.equal(defaultChecks);
     });
-    it('should call checkActionable with given checks', async () => {
-      const expectedChecks = [pageActionChecks.checksMap.visible];
+    it('should call checkActionable with given checks concatinated with default checks', async () => {
+      const expectedChecks = [
+        pageActionChecks.checksMap.visible,
+        pageActionChecks.checksMap.connected,
+        pageActionChecks.checksMap.disabled,
+      ];
       let actualCheck;
       pageActionChecks.__set__('checkIfActionable', (elem, checks) => {
         actualCheck = checks;
@@ -87,8 +92,18 @@ describe('pageActionChecks', () => {
     });
     it('should return first element that is actionable', async () => {
       pageActionChecks.__set__('findElements', () => [
-        { name: 'notActionable', isVisible: () => true, isDisabled: () => true },
-        { name: 'Actionable', isVisible: () => true, isDisabled: () => false },
+        {
+          name: 'notActionable',
+          isVisible: () => true,
+          isDisabled: () => true,
+          isConnected: () => true,
+        },
+        {
+          name: 'Actionable',
+          isVisible: () => true,
+          isDisabled: () => false,
+          isConnected: () => true,
+        },
       ]);
       const result = await pageActionChecks.waitAndGetActionableElement('Something');
       expect(result.name).to.equal('Actionable');

--- a/test/unit-tests/actions/pageActionChecks.test.js
+++ b/test/unit-tests/actions/pageActionChecks.test.js
@@ -3,6 +3,7 @@ const expect = chai.expect;
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 const rewire = require('rewire');
+const { checksMap } = require('../../../lib/actions/pageActionChecks');
 let pageActionChecks = rewire('../../../lib/actions/pageActionChecks');
 
 describe('pageActionChecks', () => {
@@ -61,6 +62,7 @@ describe('pageActionChecks', () => {
         pageActionChecks.checksMap.visible,
         pageActionChecks.checksMap.disabled,
         pageActionChecks.checksMap.connected,
+        pageActionChecks.checksMap.stable,
       ];
       let actualCheck;
       pageActionChecks.__set__('checkIfActionable', (elem, checks) => {
@@ -78,6 +80,8 @@ describe('pageActionChecks', () => {
         pageActionChecks.checksMap.visible,
         pageActionChecks.checksMap.connected,
         pageActionChecks.checksMap.disabled,
+        pageActionChecks.checksMap.stable,
+        pageActionChecks.checksMap.writable,
       ];
       let actualCheck;
       pageActionChecks.__set__('checkIfActionable', (elem, checks) => {
@@ -87,19 +91,30 @@ describe('pageActionChecks', () => {
       pageActionChecks.__set__('findElements', () => [
         { isVisible: () => true, isDisabled: () => false },
       ]);
-      await pageActionChecks.waitAndGetActionableElement('Something', expectedChecks);
-      expect(actualCheck).to.deep.equal(expectedChecks);
+      await pageActionChecks.waitAndGetActionableElement('Something', [
+        pageActionChecks.checksMap.writable,
+      ]);
+      expect(actualCheck).to.have.members(expectedChecks);
     });
     it('should return first element that is actionable', async () => {
+      pageActionChecks.__set__('runtimeHandler', {
+        runtimeCallFunctionOn: (a, b, c) => {
+          {
+            return { result: { value: true } };
+          }
+        },
+      });
       pageActionChecks.__set__('findElements', () => [
         {
           name: 'notActionable',
+          get: () => 1,
           isVisible: () => true,
           isDisabled: () => true,
           isConnected: () => true,
         },
         {
           name: 'Actionable',
+          get: () => 2,
           isVisible: () => true,
           isDisabled: () => false,
           isConnected: () => true,

--- a/test/unit-tests/focus.test.js
+++ b/test/unit-tests/focus.test.js
@@ -37,7 +37,7 @@ describe(test_name, () => {
 
     it('should throw error if the given element is not focusable', async () => {
       await expect(focus(textBox('unfocusable'))).to.be.eventually.rejectedWith(
-        'Error: Element is not focusable\n',
+        'TextBox with label unfocusable is disabled',
       );
     });
 

--- a/test/unit-tests/write.test.js
+++ b/test/unit-tests/write.test.js
@@ -173,7 +173,7 @@ describe(test_name, () => {
       const input = textBox({ id: 'readonly' });
       const text = 'hello';
       await expect(write(text, into(input))).to.eventually.be.rejectedWith(
-        'Element focused is not writable',
+        'TextBox[id="readonly"]is not writable',
       );
     });
   });


### PR DESCRIPTION
- pull out remaining page actions
- make all actions use `waitAndGetActionableElement` to ensure every action is performed on a stable element
- make isConnected check default for actions