### PR TITLE
Fix type of ResizeWindowOptions

### DIFF
--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -116,8 +116,8 @@ export interface CookieOptions {
 }
 
 export interface ResizeWindowOptions {
-  height?: string;
-  width?: string;
+  height?: number;
+  width?: number;
 }
 
 export interface CookieDetailOptions extends CookieOptions {


### PR DESCRIPTION
`resizeWindow` API is merged 18 days ago #1793

But the type of this argument is not aligned with [the docs](https://docs.taiko.dev/api/resizewindow/) & [underlaying function](https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-setWindowBounds).

<img width="745" alt="スクリーンショット 2021-02-02 15 11 15" src="https://user-images.githubusercontent.com/856469/106559570-eb15a300-6568-11eb-8943-2b8850564329.png">
