### PR TITLE
Enable web security by default

### DIFF
--- a/lib/browserLauncher.js
+++ b/lib/browserLauncher.js
@@ -275,7 +275,6 @@ async function setChromeBrowserArgs(options) {
     '--use-mock-keychain',
     '--enable-automation',
     '--disable-notifications',
-    '--disable-web-security',
     'about:blank',
   ];
   args = updateArgsFromOptions(args, options);

--- a/lib/handlers/targetHandler.js
+++ b/lib/handlers/targetHandler.js
@@ -154,7 +154,9 @@ const closeTarget = async (targetId) => {
 };
 
 const closeBrowserContext = async (targetId) => {
-  const browserContextId = browserRegistry.get(targetId) ? browserRegistry.get(targetId) : await getBrowserContextIdForTarget(targetId);
+  const browserContextId = browserRegistry.get(targetId)
+    ? browserRegistry.get(targetId)
+    : await getBrowserContextIdForTarget(targetId);
   await browserDebugUrlTarget.disposeBrowserContext({ browserContextId });
   return browserContextId === activeBrowserContextId;
 };

--- a/test/unit-tests/handlers/targetHandler.test.js
+++ b/test/unit-tests/handlers/targetHandler.test.js
@@ -258,24 +258,24 @@ describe('TargetHandler', () => {
     it('should register a browser context id with a target id', async () => {
       let target = { targetId: 'first', type: 'page' };
 
-      targetHandler.__set__('activeBrowserContextId', '4');   
+      targetHandler.__set__('activeBrowserContextId', '4');
       targetHandler.register('one', target);
-      
+
       let browserRegistry = targetHandler.__get__('browserRegistry');
-      
+
       expect(browserRegistry.get(target)).to.be.equal('4');
     });
 
-    it('should unregister the browser context id with the given target', async() => {
+    it('should unregister the browser context id with the given target', async () => {
       let target = { targetId: 'first', type: 'page' };
 
-      targetHandler.__set__('activeBrowserContextId', '4');   
+      targetHandler.__set__('activeBrowserContextId', '4');
       targetHandler.register('one', target);
-      
+
       targetHandler.unregister('one');
 
       let browserRegistry = targetHandler.__get__('browserRegistry');
-      
+
       expect(browserRegistry.get(target)).to.be.undefined;
     });
   });

--- a/test/unit-tests/incognito.test.js
+++ b/test/unit-tests/incognito.test.js
@@ -181,7 +181,7 @@ describe('Browser Context', () => {
   });
 
   describe('close incognito window', () => {
-    it('closeIncognitoWindow should not throw error when the target used to get context id is closed', async() => {
+    it('closeIncognitoWindow should not throw error when the target used to get context id is closed', async () => {
       let exceptionThrown = false;
 
       try {


### PR DESCRIPTION
Fixes: #1822

This will enable CORS restrictions while testing site.
It's better to make this argument explicit to avoid potential
attacks on Taiko script that run on live sites.

Refer: 
The change is in `browserLauncher` however the other files changes were added by the linter.

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>