### PR TITLE
Fix evaluate passing data code snippet

### DIFF
--- a/docs/running_scripts_inside_the_browser.md
+++ b/docs/running_scripts_inside_the_browser.md
@@ -120,8 +120,9 @@ data.
 
 `evaluate` also has an option to receive data from Taiko scripts as follows
 
-      message = { greeting: "Hello"};
+    var message = { args: { greeting: "Hello" } };
       
-      var content = await evaluate($("#data"), 
-      (element, args) => { element.innerText = args.greeting }
-      , message);
+    var content = await evaluate($("#data"), (element, args) => { 
+        element.innerText = args.greeting;
+    }, message);
+


### PR DESCRIPTION
I add 'args' key to message variable because it didn't work. There was missing part.