### PR TITLE
fix(config): Allow navigation and retry timeout to be read from env

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,8 @@
 const defaultConfig = {
-  navigationTimeout: 30000, //Millisecond
+  navigationTimeout: Number(process.env.TAIKO_NAVIGATION_TIMEOUT) || 30000, //Millisecond
   observeTime: 3000, //Millisecond
   retryInterval: 100, //Millisecond
-  retryTimeout: 10000, //Millisecond
+  retryTimeout: Number(process.env.TAIKO_RETRY_TIMEOUT) || 10000, //Millisecond
   noOfElementToMatch: 20,
   observe: false,
   waitForNavigation: true,


### PR DESCRIPTION
This will allow us to read navigation and retry timeout values from environment variables and configurations. This will allow us to set defaults outside of our test setup