### PR TITLE
Fixed the argument type of TimeFieldWrapper's select method

### DIFF
--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -238,7 +238,7 @@ export interface DropDownWrapper extends ValueWrapper {
   select(value?: string | number | string[] | number[] | { index: number[] }): Promise<void>;
 }
 export interface TimeFieldWrapper extends ValueWrapper {
-  select(value?: string | number): Promise<void>;
+  select(value?: Date): Promise<void>;
 }
 export interface RangeWrapper extends ValueWrapper {
   select(value?: string | number): Promise<void>;


### PR DESCRIPTION
Implementing the following code as documented caused a compilation error in Typescript.
https://docs.taiko.dev/api/timefield/
```
await timeField('Birthday:').select(new Date('2020-09-20'))
```
Since line 23 of timeField.js raises an error for any type other than Date, we decided that only Date type arguments should be used for TimeFieldWrapper's select method.
https://github.com/getgauge/taiko/blob/master/lib/elements/timeField.js#L23-L25

Please point out if this fix is wrong.