### PR TITLE
Cache proxomity element Rect

### DIFF
--- a/lib/proximityElementSearch.js
+++ b/lib/proximityElementSearch.js
@@ -16,6 +16,8 @@ const isRelativeSearch = (args) => args.every((a) => a instanceof RelativeSearch
 
 const getMatchingNode = async (elements, args) => {
   const matchingNodes = [];
+  let proximity = false;
+  let elementRect;
   for (const element of elements) {
     if (!(await element.isVisible())) {
       continue;
@@ -24,12 +26,14 @@ const getMatchingNode = async (elements, args) => {
     let valid = true;
     let dist = 0;
     for (const arg of args) {
-      const relativeNode = await arg.validNodes(objectId);
-      if (relativeNode === undefined) {
+      const relativeNode = await arg.validNodes(objectId, proximity, elementRect);
+      if (relativeNode.matchingNode === undefined) {
         valid = false;
         break;
       }
-      dist += relativeNode.dist;
+      dist += relativeNode.matchingNode.dist;
+      proximity = !!relativeNode.elementRect;
+      elementRect = relativeNode.elementRect;
     }
     if (valid) {
       matchingNodes.push({ element: element, dist: dist });
@@ -52,11 +56,13 @@ class RelativeSearchElement {
     this.desc = desc;
   }
 
-  async validNodes(objectId) {
+  async validNodes(objectId, foundPromixityNode = false, elementRect) {
     let matchingNode,
       minDiff = Infinity;
-    const results = await this.findProximityElementRects();
-    for (const result of results) {
+    if (!foundPromixityNode) {
+      elementRect = await this.findProximityElementRects();
+    }
+    for (const result of elementRect) {
       if (await this.condition(objectId, result.result)) {
         const diff = await domHandler.getPositionalDifference(objectId, result.elem);
         if (diff < minDiff) {
@@ -65,7 +71,7 @@ class RelativeSearchElement {
         }
       }
     }
-    return matchingNode;
+    return { matchingNode, elementRect };
   }
 
   toString() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Taiko is a Node.js library for automating Chromium based browsers",
   "main": "bin/taiko.js",
   "bin": {


### PR DESCRIPTION
Optimize proximity selector search by caching the calculated bounding rects of given proximity elements.

For Ex: 

```
$('.class-multiple-elements', toRightOf(text('Hello')))
```

`.class-multiple-elements',` returns 200 elements and `toRightOf` was calculated for ever element which impacted the performance. 