### PR TITLE
Do not pop up first run dialog on chrome

### DIFF
--- a/lib/browserLauncher.js
+++ b/lib/browserLauncher.js
@@ -275,6 +275,7 @@ async function setChromeBrowserArgs(options) {
     '--use-mock-keychain',
     '--enable-automation',
     '--disable-notifications',
+    '--no-first-run',
     'about:blank',
   ];
   args = updateArgsFromOptions(args, options);


### PR DESCRIPTION
When launching chrome for the first time it opens
up an initialization dialog box that breaks the
openBrowser api

For more reference
https://github.com/getgauge/taiko/discussions/2061

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>