### PR TITLE
Remove div height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",
+        "@types/chai": "^4.3.0",
+        "@types/chai-as-promised": "^7.1.5",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
         "@typescript-eslint/parser": "^5.9.0",
         "babel-eslint": "^10.0.3",
@@ -800,6 +802,21 @@
         "@types/keyv": "*",
         "@types/node": "*",
         "@types/responselike": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "dev": true
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -16607,6 +16624,21 @@
         "@types/keyv": "*",
         "@types/node": "*",
         "@types/responselike": "*"
+      }
+    },
+    "@types/chai": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
       }
     },
     "@types/http-cache-semantics": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",
+    "@types/chai": "^4.3.0",
+    "@types/chai-as-promised": "^7.1.5",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",
     "babel-eslint": "^10.0.3",

--- a/test/unit-tests/click.test.js
+++ b/test/unit-tests/click.test.js
@@ -50,7 +50,6 @@ describe(test_name, () => {
                     document.getElementById('root').innerText = text
                 }
             </script>
-            <div style="height:1500px"></div>
             <div id="root" style="background:red;"></div>
             <span onclick="displayText('Click works with auto scroll.')">Show Message</span>
             <style>

--- a/test/unit-tests/tap.test.js
+++ b/test/unit-tests/tap.test.js
@@ -50,7 +50,6 @@ describe(test_name, () => {
                     document.getElementById('root').innerText = text
                 }
             </script>
-            <div style="height:1500px"></div>
             <div id="root" style="background:red;"></div>
             <span onclick="displayText('tap works with auto scroll.')">Show Message</span>
             <style>


### PR DESCRIPTION
Tests on github action seem to fail while
asserting on the element as it might be
outside the viewport.

Also adding ts types to get rid of editor warning of missing types.

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>