### PR TITLE
checkIfElementIsNotCovered shadowroot parent

### DIFF
--- a/lib/actions/pageActionChecks.js
+++ b/lib/actions/pageActionChecks.js
@@ -55,6 +55,7 @@ const checkIfElementIsNotCovered = async (e) => {
     }
     return (
       elem.contains(node) ||
+      (elem.shadowRoot && elem.shadowRoot.contains(node)) ||
       node.contains(elem) ||
       window.getComputedStyle(node).getPropertyValue('opacity') < 0.1 ||
       window.getComputedStyle(elem).getPropertyValue('opacity') < 0.1


### PR DESCRIPTION
elem.contains(node) doesn't work when elem contains a shadow root.