### PR TITLE
Fixes #2587 Adds the ability to use click modifiers

### DIFF
--- a/lib/actions/click.js
+++ b/lib/actions/click.js
@@ -38,6 +38,7 @@ async function simulateInputEvents(options) {
             y: options.y,
             clickCount: options.clickCount,
             button: options.button,
+            modifiers: options.modifiers,
           });
     });
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -90,6 +90,7 @@ const setClickOptions = (options, x, y) => {
   options.button = options.button || 'left';
   options.clickCount = options.clickCount || 1;
   options.elementsToMatch = options.elementsToMatch || 10;
+  options.modifiers = options.modifiers || 0;
   return options;
 };
 

--- a/test/unit-tests/config.test.js
+++ b/test/unit-tests/config.test.js
@@ -277,6 +277,7 @@ describe('Config tests', () => {
         button: 'left',
         clickCount: 1,
         elementsToMatch: 10,
+        modifiers: 0,
         navigationTimeout: 30000,
         waitForNavigation: true,
         waitForStart: 100,


### PR DESCRIPTION
Adds the ability to do click modifiers such as ctrl+click or alt+click from CDP dispatchMouseEvent:
https://chromedevtools.github.io/devtools-protocol/tot/Input/#method-dispatchMouseEvent