### PR TITLE
Add support for Mac ARM64 Chromium

### DIFF
--- a/lib/browserFetcher.js
+++ b/lib/browserFetcher.js
@@ -29,11 +29,12 @@ const readline = require('readline');
 var url = require('url');
 const ProxyAgent = require('https-proxy-agent');
 const getProxyForUrl = require('proxy-from-env').getProxyForUrl;
-const supportedPlatforms = ['mac', 'linux', 'win32', 'win64'];
+const supportedPlatforms = ['mac', 'mac_arm', 'linux', 'win32', 'win64'];
 const DEFAULT_DOWNLOAD_HOST = 'https://storage.googleapis.com';
 const downloadURLs = {
   linux: '%s/chromium-browser-snapshots/Linux_x64/%d/%s.zip',
   mac: '%s/chromium-browser-snapshots/Mac/%d/%s.zip',
+  mac_arm: '%s/chromium-browser-snapshots/Mac_Arm/%d/%s.zip',
   win32: '%s/chromium-browser-snapshots/Win/%d/%s.zip',
   win64: '%s/chromium-browser-snapshots/Win_x64/%d/%s.zip',
 };
@@ -54,7 +55,7 @@ function archiveName(platform, revision) {
   if (platform === 'linux') {
     return 'chrome-linux';
   }
-  if (platform === 'mac') {
+  if (platform === 'mac' || platform === 'mac_arm') {
     return 'chrome-mac';
   }
   if (platform === 'win32' || platform === 'win64') {
@@ -79,7 +80,7 @@ class BrowserFetcher {
     if (!this._platform) {
       const platform = os.platform();
       if (platform === 'darwin') {
-        this._platform = 'mac';
+        this._platform = os.arch() === 'arm64' ? 'mac_arm' : 'mac';
       } else if (platform === 'linux') {
         this._platform = 'linux';
       } else if (platform === 'win32') {
@@ -180,7 +181,7 @@ class BrowserFetcher {
   revisionInfo(revision) {
     const folderPath = this._getFolderPath(revision);
     let executablePath = '';
-    if (this._platform === 'mac') {
+    if (this._platform === 'mac' || this._platform === 'mac_arm') {
       executablePath = path.join(
         folderPath,
         archiveName(this._platform, revision),


### PR DESCRIPTION
@zabil quick review when you get a moment? I've tested this on my M1 MBP and `npm test` passes.

Also verified the binary image is indeed ARM64 (in case your machine is x86_64):

```console
$ file .local-chromium/mac_arm-1075999/chrome-mac/Chromium.app/Contents/MacOS/Chromium
.local-chromium/mac_arm-1075999/chrome-mac/Chromium.app/Contents/MacOS/Chromium: Mach-O 64-bit executable arm64
```