### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/frequently_asked_questions.md
+++ b/docs/frequently_asked_questions.md
@@ -141,7 +141,7 @@ performance and reduce flakiness in tests.
 which has heavy image or fonts to loaded.
 * `targetNavigated` - Wait for this event if there is a new tab/window open or close 
 that happens because of an action.
-* `loadEventFired` - Wait for this event if an action triggers a page load which is not instanteneous.
+* `loadEventFired` - Wait for this event if an action triggers a page load which is not instantaneous.
 
 For example
 

--- a/test/types-test-support/generate-types-test.js
+++ b/test/types-test-support/generate-types-test.js
@@ -56,7 +56,7 @@ const util = require('util');
        * Generates a statement that instantiates a const of the specified type and assigns the
        * literal to the const.
        * Dtslint will look as the generated function and produce warnings if the fields in
-       * the literal and in the type declaration are not consinstent.
+       * the literal and in the type declaration are not consistent.
        * The assignment is wrapped in an exported function to avoid irrelevant lint warnings.
        *
        * @param {string} typeName type to be assigned to the constant producing something


### PR DESCRIPTION
There are small typos in:
- docs/frequently_asked_questions.md
- test/types-test-support/generate-types-test.js

Fixes:
- Should read `instantaneous` rather than `instanteneous`.
- Should read `consistent` rather than `consinstent`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md