### PR TITLE
ScrollTo type and example improvements

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1246,7 +1246,7 @@ async function mouseAction(selector, action, coordinates, options = {}) {
 /**
  * Scrolls the page to the given element.
  * The alignment parameters can be overridden, see below.
- * Tthe possible values reference are available at the https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView.
+ * The possible values reference are available at the https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView.
  *
  *
  * @example
@@ -1254,7 +1254,7 @@ async function mouseAction(selector, action, coordinates, options = {}) {
  * @example
  * await scrollTo(link('Get Started'))
  * @example
- * await scrollTo('Get Started',{ alignments: { block: 'center', inline: 'center' }})
+ * await scrollTo('Get Started',{ blockAlignment: 'center', inlineAlignment: 'center' })
  *
  * @param {selector|string} selector - A selector of an element to scroll to.
  * @param {Object} options
@@ -1263,7 +1263,7 @@ async function mouseAction(selector, action, coordinates, options = {}) {
  * @param {number} [options.navigationTimeout=30000] - Navigation timeout value in milliseconds for navigation after click.
  * @param {number} [options.waitForStart = 100] - time to wait for navigation to start. Accepts value in milliseconds.
  * @param {string} [options.blockAlignment = 'nearest'] - Defines vertical alignment.
- * @param {string} [options.inlineAligment = 'nearest'] - Defines horizontal alignment.
+ * @param {string} [options.inlineAlignment = 'nearest'] - Defines horizontal alignment.
  *
  * @returns {Promise<void>}
  */

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -60,6 +60,19 @@ export interface ClickOptions extends NavigationOptions, ForceOption {
   elementsToMatch?: number;
 }
 
+export interface ScrollToOptions extends NavigationOptions {
+  /**
+   * Defines vertical alignment.
+   * @default 'nearest'
+   */
+  blockAlignment?: string;
+  /**
+   * Defines horizontal alignment.
+   * @default 'nearest'
+   */
+  inlineAlignment?: string;
+}
+
 export interface GlobalConfigurationOptions {
   navigationTimeout?: number;
   observeTime?: number;
@@ -501,7 +514,7 @@ export function mouseAction(
   options?: ForcedNavigationOptions,
 ): Promise<void>;
 // https://docs.taiko.dev/api/scrollto
-export function scrollTo(selector: SearchElement, options?: NavigationOptions): Promise<void>;
+export function scrollTo(selector: SearchElement, options?: ScrollToOptions): Promise<void>;
 // https://docs.taiko.dev/api/scrollright
 export function scrollRight(selector?: SearchElement | number, px?: number): Promise<void>;
 // https://docs.taiko.dev/api/scrollleft

--- a/types/taiko/test/page-actions.ts
+++ b/types/taiko/test/page-actions.ts
@@ -352,7 +352,12 @@ mouseAction(
 // ------------------------------------------
 scrollTo('Get Started'); // $ExpectType Promise<void>
 scrollTo(link('Get Started')); // $ExpectType Promise<void>
+scrollTo('Get Started', { waitForNavigation: false }); // $ExpectType Promise<void>
+scrollTo('Get Started', { navigationTimeout: 50000 }); // $ExpectType Promise<void>
+scrollTo('Get Started', { waitForStart: 1000 }); // $ExpectType Promise<void>
 scrollTo(link('Get Started'), { waitForEvents: ['firstMeaningfulPaint'] }); // $ExpectType Promise<void>
+scrollTo('Get Started', { blockAlignment: 'center', inlineAlignment: 'center' }); // $ExpectType Promise<void>
+scrollTo('Get Started', { alignments: { block: 'center' } }); // $ExpectError
 
 // ------------------------------------------
 // scrollRight


### PR DESCRIPTION
Follow up to: https://github.com/getgauge/taiko/pull/2066

Adds a type for the options for `scrollTo` and makes some fixes/improvements to the example for it as well.