### PR TITLE
Fix types and documentation for scrollTo() alignment options

### DIFF
--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -1246,24 +1246,23 @@ async function mouseAction(selector, action, coordinates, options = {}) {
 /**
  * Scrolls the page to the given element.
  * The alignment parameters can be overridden, see below.
- * Tthe possible values reference are available at the https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView.
- *
+ * A reference of the possible values for the alignment parameters is available at https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView.
  *
  * @example
  * await scrollTo('Get Started')
  * @example
  * await scrollTo(link('Get Started'))
  * @example
- * await scrollTo('Get Started',{ alignments: { block: 'center', inline: 'center' }})
+ * await scrollTo('Get Started', { blockAlignment: 'center', inlineAlignment: 'center' })
  *
  * @param {selector|string} selector - A selector of an element to scroll to.
  * @param {Object} options
  * @param {boolean} [options.waitForNavigation=true] - Wait for navigation after the goto. Default navigationTimeout is 30 seconds to override pass `{ navigationTimeout: 10000 }` in `options` parameter.
  * @param {string[]} [options.waitForEvents = []] - Events available to wait for ['DOMContentLoaded', 'loadEventFired', 'networkAlmostIdle', 'networkIdle', 'firstPaint', 'firstContentfulPaint', 'firstMeaningfulPaint', 'targetNavigated']
  * @param {number} [options.navigationTimeout=30000] - Navigation timeout value in milliseconds for navigation after click.
- * @param {number} [options.waitForStart = 100] - time to wait for navigation to start. Accepts value in milliseconds.
- * @param {string} [options.blockAlignment = 'nearest'] - Defines vertical alignment.
- * @param {string} [options.inlineAligment = 'nearest'] - Defines horizontal alignment.
+ * @param {number} [options.waitForStart = 100] - Time to wait for navigation to start. Accepts value in milliseconds.
+ * @param {string} [options.blockAlignment = 'nearest'] - Defines vertical alignment. One of `start`, `center`, `end` or `nearest`.
+ * @param {string} [options.inlineAlignment = 'nearest'] - Defines horizontal alignment. One of `start`, `center`, `end` or `nearest`.
  *
  * @returns {Promise<void>}
  */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Taiko is a Node.js library for automating Chromium based browsers",
   "main": "bin/taiko.js",
   "bin": {

--- a/types/taiko/index.d.ts
+++ b/types/taiko/index.d.ts
@@ -49,6 +49,11 @@ export interface NavigationOptions extends BasicNavigationOptions, EventOptions 
   waitForStart?: number;
 }
 
+export interface ScrollOptions extends NavigationOptions {
+  blockAlignment?: 'start' | 'center' | 'end' | 'nearest';
+  inlineAlignment?: 'start' | 'center' | 'end' | 'nearest';
+}
+
 export interface ReloadOptions extends NavigationOptions {
   ignoreCache?: boolean;
 }
@@ -501,7 +506,7 @@ export function mouseAction(
   options?: ForcedNavigationOptions,
 ): Promise<void>;
 // https://docs.taiko.dev/api/scrollto
-export function scrollTo(selector: SearchElement, options?: NavigationOptions): Promise<void>;
+export function scrollTo(selector: SearchElement, options?: ScrollOptions): Promise<void>;
 // https://docs.taiko.dev/api/scrollright
 export function scrollRight(selector?: SearchElement | number, px?: number): Promise<void>;
 // https://docs.taiko.dev/api/scrollleft


### PR DESCRIPTION
Fixes #2701 See this issue for more details on what this PR fixes. The options themselves do already work, they were just incorrectly documented and the TS type for these options was missing.