### PR TITLE
Fix taiko version info display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Taiko
-##### [Docs](https://docs.taiko.dev) | [API reference](https://docs.taiko.dev/api/reference) 
+##### [Docs](https://docs.taiko.dev) | [API reference](https://docs.taiko.dev/api/reference)
 
 A Node.js library for testing modern web applications
 
@@ -48,7 +48,7 @@ This installs Taiko and the latest version of Chromium browser. We are all set t
 Taiko comes with a Recorder that’s a REPL for writing test scripts. You can use Taiko’s JavaScript API to control the browser from the REPL. To launch the REPL type taiko in your favorite terminal application
 
     $ taiko
-    Version: 0.8.0 (Chromium:76.0.3803.0)
+    Version: 1.4.0 (Chromium: 126.0.6468.0)
     Type .api for help and .exit to quit
     >
 
@@ -107,7 +107,7 @@ By default Taiko runs the script in headless mode, that means it does not launch
 Taiko’s REPL also documents all the API’s. To view all available API’s use the special command `.api`
 
     $ taiko
-    Version: 0.8.0 (Chromium:76.0.3803.0)
+    Version: 1.4.0 (Chromium: 126.0.6468.0)
     Type .api for help and .exit to quit
     > .api
     Browser actions
@@ -191,12 +191,12 @@ Learn more about [Gauge](https://docs.gauge.org)!
 ### Experimental Firefox Support
 
 #### To launch taiko with firefox:
-- Download and install [firefox nightly](https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly) 
+- Download and install [firefox nightly](https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly)
 - Set `TAIKO_BROWSER_PATH` to firefox nightly's executable.
 
 Example: `TAIKO_BROWSER_PATH="/Applications/Firefoxnightly.app/Contents/MacOS/firefox" taiko`
 
-#### Known Issues for now:  
+#### Known Issues for now:
 - Highlighting element on action is set to false as overlay domain is not supported
 - openTab/closeTab does not work as expected since `New` is not available in firefox yet
 - Autofocus on first input field does not happen

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -142,7 +142,7 @@ if (isTaikoRunner(processArgv[1])) {
     )
     .option('--plugin <plugin1,plugin2...>', 'Load the taiko plugin.', setPluginNameInEnv)
     .option('--no-log', 'Disable log output of taiko', setDisableLogout)
-    .action(function(_, fileName, cmd) {
+    .action(function (_, fileName, cmd) {
       taiko = require('../lib/taiko');
       if (fileName) {
         validate(fileName);

--- a/bin/taiko.js
+++ b/bin/taiko.js
@@ -18,7 +18,11 @@ function printVersion() {
     if (packageJson._resolved && packageJson._resolved.includes('#')) {
       hash = packageJson._resolved.split('#')[1];
     }
-    return `Version: ${packageJson.version} (Chromium: ${packageJson.taiko.chromium_version}) ${hash}`;
+
+    const taikoVersion = packageJson.version;
+    const browserVersion = packageJson.taiko.browser.version;
+
+    return `Version: ${taikoVersion} (Chromium: ${browserVersion}) ${hash}`;
   } catch (error) {
     return 'Could not find the package.json file to read version information';
   }
@@ -138,7 +142,7 @@ if (isTaikoRunner(processArgv[1])) {
     )
     .option('--plugin <plugin1,plugin2...>', 'Load the taiko plugin.', setPluginNameInEnv)
     .option('--no-log', 'Disable log output of taiko', setDisableLogout)
-    .action(function (_, fileName, cmd) {
+    .action(function(_, fileName, cmd) {
       taiko = require('../lib/taiko');
       if (fileName) {
         validate(fileName);

--- a/lib/repl/repl.js
+++ b/lib/repl/repl.js
@@ -57,11 +57,13 @@ async function setVersionInfo() {
     version = require('../../package.json').version;
     doc = require('../api.json');
     if (!browserPath) {
-      browserVersion = `Chromium: ${require('../../package.json').taiko.chromium_version}`;
+      browserVersion = `Chromium: ${require('../../package.json').taiko.browser.version}`;
     } else {
       browserVersion = browserPath;
     }
-  } catch (_) {}
+  } catch (_) {
+    // ignore
+  }
   displayTaiko(browserPath);
 }
 
@@ -264,7 +266,7 @@ function initTaiko(taiko, repl) {
 function addFunctionToRepl(target, repl) {
   for (let func in target) {
     if (target[func].constructor.name === 'AsyncFunction') {
-      repl.context[func] = async function () {
+      repl.context[func] = async function() {
         try {
           lastStack = '';
           let args = await Promise.all(Object.values(arguments));
@@ -280,7 +282,7 @@ function addFunctionToRepl(target, repl) {
         }
       };
     } else if (target[func].constructor.name === 'Function') {
-      repl.context[func] = function () {
+      repl.context[func] = function() {
         if (!taikoCommands.includes(func)) {
           taikoCommands.push(func);
         }
@@ -305,7 +307,7 @@ function warnIfBrowserPathIsNotAFile(browserPath) {
     if (!fs.existsSync(browserPath) || !fs.statSync(browserPath).isFile()) {
       console.log(
         `Warning: Please check if TAIKO_BROWSER_PATH (${browserPath})\n` +
-          'points to a valid browser executable file.\n',
+        'points to a valid browser executable file.\n',
       );
     }
   } catch (e) {
@@ -342,8 +344,7 @@ function displayUsageFor(name) {
   if (e.returns) {
     e.returns.map((e) => {
       console.log(
-        `Returns: ${type(e.type)} ${
-          e.description.type ? desc(e.description) : e.description
+        `Returns: ${type(e.type)} ${e.description.type ? desc(e.description) : e.description
         }${EOL}`,
       );
     });

--- a/lib/repl/repl.js
+++ b/lib/repl/repl.js
@@ -266,7 +266,7 @@ function initTaiko(taiko, repl) {
 function addFunctionToRepl(target, repl) {
   for (let func in target) {
     if (target[func].constructor.name === 'AsyncFunction') {
-      repl.context[func] = async function() {
+      repl.context[func] = async function () {
         try {
           lastStack = '';
           let args = await Promise.all(Object.values(arguments));
@@ -282,7 +282,7 @@ function addFunctionToRepl(target, repl) {
         }
       };
     } else if (target[func].constructor.name === 'Function') {
-      repl.context[func] = function() {
+      repl.context[func] = function () {
         if (!taikoCommands.includes(func)) {
           taikoCommands.push(func);
         }
@@ -307,7 +307,7 @@ function warnIfBrowserPathIsNotAFile(browserPath) {
     if (!fs.existsSync(browserPath) || !fs.statSync(browserPath).isFile()) {
       console.log(
         `Warning: Please check if TAIKO_BROWSER_PATH (${browserPath})\n` +
-        'points to a valid browser executable file.\n',
+          'points to a valid browser executable file.\n',
       );
     }
   } catch (e) {
@@ -344,7 +344,8 @@ function displayUsageFor(name) {
   if (e.returns) {
     e.returns.map((e) => {
       console.log(
-        `Returns: ${type(e.type)} ${e.description.type ? desc(e.description) : e.description
+        `Returns: ${type(e.type)} ${
+          e.description.type ? desc(e.description) : e.description
         }${EOL}`,
       );
     });


### PR DESCRIPTION
Fix regression in version info display

Before

```
$ taiko
Version: 1.4.0 (Chromium: undefined)
Type .api for help and .exit to quit
```

After

```
$ taiko
Version: 1.4.0 (Chromium: 126.0.6468.0)
Type .api for help and .exit to quit
```