### PR TITLE
Update click.js for relative selectors

### DIFF
--- a/lib/actions/click.js
+++ b/lib/actions/click.js
@@ -49,11 +49,11 @@ async function simulateInputEvents(options) {
 }
 
 async function click(selector, options = {}, ...args) {
-  let allOptions = options;
+  let allOptions = args;
   if (options instanceof RelativeSearchElement) {
     allOptions = [options].concat(args);
   }
-  const clickOptions = setClickOptions(allOptions);
+  const clickOptions = setClickOptions(options);
   clickOptions.noOfClicks = clickOptions.clickCount || 1;
 
   if (isSelector(selector) || isString(selector) || isElement(selector)) {


### PR DESCRIPTION
If a Relative Selector is passed in as the third argument inside of click(), it doesn't actually make it down to waitAndGetActionableElement. 

 We found that `await click(element, options, within(withinElement))`  doesn't search in the "within" element