### PR TITLE
Update click.js for relative selectors

### DIFF
--- a/lib/actions/click.js
+++ b/lib/actions/click.js
@@ -49,11 +49,11 @@ async function simulateInputEvents(options) {
 }
 
 async function click(selector, options = {}, ...args) {
-  let allOptions = options;
+  let allOptions = args;
   if (options instanceof RelativeSearchElement) {
     allOptions = [options].concat(args);
   }
-  const clickOptions = setClickOptions(allOptions);
+  const clickOptions = setClickOptions(options);
   clickOptions.noOfClicks = clickOptions.clickCount || 1;
 
   if (isSelector(selector) || isString(selector) || isElement(selector)) {

--- a/test/unit-tests/click.test.js
+++ b/test/unit-tests/click.test.js
@@ -156,9 +156,16 @@ describe(test_name, () => {
 
   describe("With proximity selector and Options Object", () => {
     it("should click", async () => {
-      await click("Click with proximity", {waitForNavigation: true}, below("Proximity marker"));
-      expect(await text("Click works with proximity selector and Options Object.").exists()).to.be
-        .true;
+      await click(
+        "Click with proximity", 
+        { waitForNavigation: true }, 
+        below("Proximity marker"),
+      );
+      expect(
+        await text(
+          "Click works with proximity selector and Options Object."
+        ).exists()
+      ).to.be.true;
     });
   });
 

--- a/test/unit-tests/click.test.js
+++ b/test/unit-tests/click.test.js
@@ -154,6 +154,14 @@ describe(test_name, () => {
     });
   });
 
+  describe("With proximity selector and Options Object", () => {
+    it("should click", async () => {
+      await click("Click with proximity", {waitForNavigation: true}, below("Proximity marker"));
+      expect(await text("Click works with proximity selector and Options Object.").exists()).to.be
+        .true;
+    });
+  });
+
   describe("Text accross element", () => {
     it("should click", async () => {
       await click("Text accross elements");

--- a/test/unit-tests/click.test.js
+++ b/test/unit-tests/click.test.js
@@ -157,14 +157,14 @@ describe(test_name, () => {
   describe("With proximity selector and Options Object", () => {
     it("should click", async () => {
       await click(
-        "Click with proximity", 
-        { waitForNavigation: true }, 
+        "Click with proximity",
+        { waitForNavigation: true },
         below("Proximity marker"),
       );
       expect(
         await text(
-          "Click works with proximity selector and Options Object."
-        ).exists()
+          "Click works with proximity selector and Options Object.",
+        ).exists(),
       ).to.be.true;
     });
   });

--- a/test/unit-tests/click.test.js
+++ b/test/unit-tests/click.test.js
@@ -48,6 +48,7 @@ describe(test_name, () => {
             <input onclick="displayText('Click works with text as value.')" value="Text as value"/><br/>
             <input onclick="displayText('Click works with text as type.')" type="Text as type"/><br/>
             <span onclick="displayText('Click works with proximity selector.')">Click with proximity</span>
+            <span onclick="displayText('Click works with proximity selector and options object.')">Click with proximity and options object</span>
             <div onclick="displayText('Click works with text accross element.')">
                 Text <span>accross</span> elements
             </div>
@@ -154,16 +155,16 @@ describe(test_name, () => {
     });
   });
 
-  describe("With proximity selector and Options Object", () => {
+  describe("With proximity selector and options object", () => {
     it("should click", async () => {
       await click(
-        "Click with proximity",
+        "Click with proximity and options object",
         { waitForNavigation: true },
         below("Proximity marker"),
       );
       expect(
         await text(
-          "Click works with proximity selector and Options Object.",
+          "Click works with proximity selector and options object.",
         ).exists(),
       ).to.be.true;
     });


### PR DESCRIPTION
If a Relative Selector is passed in as the third argument inside of click(), it doesn't actually make it down to waitAndGetActionableElement. 

 We found that `await click(element, options, within(withinElement))`  doesn't search in the "within" element with the Biome Migration changes

Signed-off-by: DCoomer <deshuncoomer@gmail.com>