### PR TITLE
Set connectedToRemoteBrowser to false for non remote browser

### DIFF
--- a/.github/workflows/taiko.yml
+++ b/.github/workflows/taiko.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node_version: ['20']
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Use NodeJS ${{ matrix.node_version }}
@@ -29,7 +29,7 @@ jobs:
       - name: install
         run: npm install
       - name: install browser dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y  libnss3 \
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         node_version: ['20']
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
       - name: install browser dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -99,7 +99,7 @@ jobs:
   functional-tests-headful:
     needs: unit-tests
     name: FT in linux-headful
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Use NodeJS 20
@@ -144,7 +144,7 @@ jobs:
   docs-tests:
     needs: unit-tests
     name: Docs tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Use NodeJS 20

--- a/lib/taiko.js
+++ b/lib/taiko.js
@@ -111,6 +111,7 @@ module.exports.openBrowser = async (
     defaultConfig.host = currentHost;
     defaultConfig.port = currentPort;
     defaultConfig.browserDebugUrl = browserDebugUrl;
+    defaultConfig.connectedToRemoteBrowser = false;
   }
   await connect_to_cri();
   const description = defaultConfig.device

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taiko",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taiko",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Taiko is a Node.js library for automating Chromium based browsers",
   "main": "bin/taiko.js",
   "bin": {
@@ -36,7 +36,10 @@
     "headless-browser"
   ],
   "lint-staged": {
-    "**/*.{js,ts}": ["npm run lint:fix", "git add"]
+    "**/*.{js,ts}": [
+      "npm run lint:fix",
+      "git add"
+    ]
   },
   "taiko": {
     "browser": {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,7 @@
     "headless-browser"
   ],
   "lint-staged": {
-    "**/*.{js,ts}": [
-      "npm run lint:fix",
-      "git add"
-    ]
+    "**/*.{js,ts}": ["npm run lint:fix", "git add"]
   },
   "taiko": {
     "browser": {


### PR DESCRIPTION
Fixes #2749
If we open a local browser after opening and closing a remote browser, the closeBrowser step hangs.
The `connectedToRemoteBrowser` property was not being reset after connecting to a remote browser.