### PR TITLE
Fix beforeunload handler crash during browser closure

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -139,7 +139,7 @@ const connect_to_cri = async (target, options = {}) => {
 
 const closeConnection = async (promisesToBeResolvedBeforeCloseBrowser) => {
   if (_client) {
-    // remove listeners other than JS dialog for beforeUnload on client first to stop executing them when closing
+    pageHandler.setClosingBrowserFlag(true);
     await _client.removeAllListeners();
     pageHandler.addJavascriptDialogOpeningListener();
     if (!defaultConfig.firefox) {
@@ -161,6 +161,7 @@ const closeConnection = async (promisesToBeResolvedBeforeCloseBrowser) => {
     : await closeBrowser();
   await _client.close();
   _client = null;
+  pageHandler.setClosingBrowserFlag(false);
 };
 
 async function reconnect() {

--- a/lib/handlers/pageHandler.js
+++ b/lib/handlers/pageHandler.js
@@ -8,6 +8,7 @@ const { isSameUrl } = require("../util");
 let page;
 let framePromises;
 let frameNavigationPromise;
+let isClosingBrowser = false;
 
 const createdSessionListener = async (client) => {
   let resolve;
@@ -71,6 +72,12 @@ const addJavascriptDialogOpeningListener = () => {
     if (eventName) {
       eventHandler.emit(eventName, data);
       eventRegexMap.delete(eventName);
+    } else if (data.type === "beforeunload" && isClosingBrowser) {
+      page
+        .handleJavaScriptDialog({
+          accept: true,
+        })
+        .catch(() => {});
     } else {
       throw new Error(
         `There is no handler registered for ${data.type} popup displayed on the page ${data.url}.
@@ -258,6 +265,10 @@ const navigateToHistoryEntry = async (entryId) => {
   await page.navigateToHistoryEntry({ entryId });
 };
 
+const setClosingBrowserFlag = (value) => {
+  isClosingBrowser = value;
+};
+
 module.exports = {
   handleNavigation,
   resetPromises,
@@ -268,4 +279,5 @@ module.exports = {
   navigateToHistoryEntry,
   handleJavaScriptDialog,
   getNavigationHistory,
+  setClosingBrowserFlag,
 };


### PR DESCRIPTION
Fixes #2752

  When closing the browser, if a page has a `beforeunload` event handler, Taiko would crash with the error:
  There is no handler registered for beforeunload popup displayed on the page

  This PR adds a flag-based mechanism to automatically accept `beforeunload` dialogs during browser closure, preventing the crash while still allowing explicit beforeunload handling during normal operation.

  ## Changes

  - Added `isClosingBrowser` flag in `pageHandler.js` to track browser closure state
  - Modified `addJavascriptDialogOpeningListener()` to auto-accept beforeunload dialogs when closing
  - Updated `closeConnection()` in `connection.js` to set/reset the flag
  - Used fire-and-forget pattern (no await) to avoid blocking on Windows