### PR TITLE
Make changes to support node version 25

### DIFF
--- a/.github/workflows/taiko.yml
+++ b/.github/workflows/taiko.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['20', '22', '24']
+        node_version: ['20', '22', '24', '25']
         os: [ubuntu-22.04, windows-latest]
       fail-fast: false
     steps:
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['20', '22', '24']
+        node_version: ['20', '22', '24', '25']
         os: [ubuntu-22.04, windows-latest]
       fail-fast: false
     steps:
@@ -98,14 +98,18 @@ jobs:
 
   functional-tests-headful:
     needs: unit-tests
-    name: FT in linux-headful
+    name: FT in linux-headful - ${{ matrix.node_version }}
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node_version: ['20', '22', '24', '25']
+      fail-fast: false
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node_version }}
       - name: install
         run: npm ci
       - name: install browser dependencies
@@ -134,25 +138,29 @@ jobs:
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ft-reports-linux-headful
+          name: ft-reports-linux-headful-${{ matrix.node_version }}
           path: tests/functional-tests/reports/html-report
       - name: Upload logs
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ft-logs-linux-headful
+          name: ft-logs-linux-headful-${{ matrix.node_version }}
           path: tests/functional-tests/logs
 
   docs-tests:
     needs: unit-tests
-    name: Docs tests
+    name: Docs tests - ${{ matrix.node_version }}
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node_version: ['20', '22', '24', '25']
+      fail-fast: false
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node_version }}
       - name: install
         run: npm ci
       - name: install browser dependencies
@@ -176,11 +184,11 @@ jobs:
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: docs-tests-reports
+          name: docs-tests-reports-${{ matrix.node_version }}
           path: tests/docs-tests/gauge/reports/html-report
       - name: Upload logs
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: docs-tests-logs
+          name: docs-tests-logs-${{ matrix.node_version }}
           path: tests/docs-tests/gauge/logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,7 @@
       "workspaces": [
         "packages/*",
         "tests"
-      ],
-      "devDependencies": {
-        "husky": "^8.0.3",
-        "lint-staged": "^16.2.7",
-        "mocha": "^10.4.0",
-        "ncp": "^2.0.0",
-        "rewire": "^9.0.1",
-        "sinon": "^15.0.1",
-        "typescript": "^4.9.4"
-      }
+      ]
     },
     "node_modules/@11ty/dependency-tree": {
       "version": "4.0.2",
@@ -846,14 +837,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "license": "MIT",
@@ -862,19 +845,6 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
-      }
-    },
-    "node_modules/@types/chai": {
-      "version": "4.3.20",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/chai-as-promised": {
-      "version": "7.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -1107,22 +1077,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
-      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "license": "MIT",
@@ -1131,19 +1085,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -1404,17 +1345,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001760",
       "funding": [
@@ -1628,56 +1558,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
-      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "license": "ISC",
@@ -1782,18 +1662,6 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/colord": {
-      "version": "2.9.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "license": "MIT",
@@ -1831,17 +1699,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-declaration-sorter": {
-      "version": "6.4.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.9"
-      }
-    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "dev": true,
@@ -1857,18 +1714,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-tree": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "dev": true,
@@ -1878,101 +1723,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cssnano": {
-      "version": "5.1.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-default": "^5.2.14",
-        "lilconfig": "^2.0.3",
-        "yaml": "^1.10.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/cssnano"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "5.2.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-declaration-sorter": "^6.3.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.1",
-        "postcss-convert-values": "^5.1.3",
-        "postcss-discard-comments": "^5.1.2",
-        "postcss-discard-duplicates": "^5.1.0",
-        "postcss-discard-empty": "^5.1.1",
-        "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.7",
-        "postcss-merge-rules": "^5.1.4",
-        "postcss-minify-font-values": "^5.1.0",
-        "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.4",
-        "postcss-minify-selectors": "^5.2.1",
-        "postcss-normalize-charset": "^5.1.0",
-        "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.1",
-        "postcss-normalize-repeat-style": "^5.1.1",
-        "postcss-normalize-string": "^5.1.0",
-        "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.1",
-        "postcss-normalize-url": "^5.1.0",
-        "postcss-normalize-whitespace": "^5.1.1",
-        "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.2",
-        "postcss-reduce-transforms": "^5.1.0",
-        "postcss-svgo": "^5.1.0",
-        "postcss-unique-selectors": "^5.1.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/cssnano-utils": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/csso": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/de-indent": {
@@ -2284,19 +2034,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/errno": {
@@ -2624,13 +2361,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "license": "MIT"
@@ -2879,19 +2609,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-func-name": {
@@ -3318,20 +3035,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "dev": true,
@@ -3515,22 +3218,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-glob": {
@@ -3777,14 +3464,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "license": "MIT"
@@ -3797,57 +3476,6 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/lint-staged": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^14.0.2",
-        "listr2": "^9.0.5",
-        "micromatch": "^4.0.8",
-        "nano-spawn": "^2.0.0",
-        "pidtree": "^0.6.0",
-        "string-argv": "^0.3.2",
-        "yaml": "^2.8.1"
-      },
-      "bin": {
-        "lint-staged": "bin/lint-staged.js"
-      },
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/lint-staged/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/liquidjs": {
@@ -3884,24 +3512,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -3922,20 +3532,10 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
       "dev": true,
       "license": "MIT"
     },
@@ -3992,26 +3592,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^7.0.0",
-        "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/longest-streak": {
@@ -4411,11 +3991,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "dev": true,
-      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -4931,18 +4506,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -4981,19 +4544,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -5203,19 +4753,6 @@
       "version": "2.1.3",
       "license": "MIT"
     },
-    "node_modules/nano-spawn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "funding": [
@@ -5375,22 +4912,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -5676,17 +5197,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pidtree": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/pify": {
       "version": "6.1.0",
       "license": "MIT",
@@ -5743,401 +5253,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/postcss-calc": {
-      "version": "8.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.2"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "5.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-api": "^3.0.0",
-        "colord": "^2.9.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "5.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-merge-longhand": {
-      "version": "5.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "5.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.1.0",
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colord": "^2.9.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "5.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-charset": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "normalize-url": "^6.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "5.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-reduce-initial": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-api": "^3.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-svgo": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "svgo": "^2.7.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/posthtml": {
       "version": "0.16.7",
@@ -6643,23 +5758,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/rewire": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-9.0.1.tgz",
@@ -6670,13 +5768,6 @@
         "eslint": "^9.30",
         "pirates": "^4.0.7"
       }
-    },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/router-ips": {
       "version": "1.0.0",
@@ -6811,19 +5902,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/sinon": {
       "version": "15.2.0",
       "dev": true,
@@ -6860,23 +5938,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/slugify": {
@@ -6952,11 +6013,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -6965,14 +6021,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/string-argv": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -7033,21 +6081,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylehacks": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "dev": true,
@@ -7070,97 +6103,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svgo": {
-      "version": "2.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/svgo/node_modules/css-select": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/svgo/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/domhandler": {
-      "version": "4.3.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/domutils": {
-      "version": "2.8.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/entities": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/taiko": {
@@ -7280,18 +6222,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/uc.micro": {
@@ -7486,11 +6416,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/uvu": {
       "version": "0.5.6",
       "license": "MIT",
@@ -7670,49 +6595,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
@@ -7749,14 +6631,6 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -7913,20 +6787,10 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
-        "@types/chai": "^4.3.4",
-        "@types/chai-as-promised": "^7.1.5",
-        "chai": "^4.3.7",
-        "chai-as-promised": "^7.1.1",
         "clean-css": "^5.3.1",
-        "cssnano": "^5.1.14",
         "eleventy-plugin-toc": "^1.1.5",
         "markdown-it": "^14.1.1",
-        "markdown-it-anchor": "^9.2.0",
-        "mocha": "^10.4.0",
-        "ncp": "^2.0.0",
-        "rewire": "^9.0.1",
-        "sinon": "^15.0.1",
-        "typescript": "^4.9.4"
+        "markdown-it-anchor": "^9.2.0"
       }
     },
     "tests": {
@@ -7937,11 +6801,10 @@
         "taiko": "*"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.4",
-        "@types/chai-as-promised": "^7.1.5",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^10.4.0",
+        "ncp": "^2.0.0",
         "rewire": "^9.0.1",
         "sinon": "^15.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -33,20 +33,5 @@
     "headless-browser"
   ],
   "author": "getgauge",
-  "license": "MIT",
-  "lint-staged": {
-    "**/*.{js,ts}": [
-      "npm run lint:fix",
-      "git add"
-    ]
-  },
-  "devDependencies": {
-    "husky": "^8.0.3",
-    "lint-staged": "^16.2.7",
-    "mocha": "^10.4.0",
-    "ncp": "^2.0.0",
-    "rewire": "^9.0.1",
-    "sinon": "^15.0.1",
-    "typescript": "^4.9.4"
-  }
+  "license": "MIT"
 }

--- a/packages/taiko/.npmignore
+++ b/packages/taiko/.npmignore
@@ -16,3 +16,4 @@ biome.jsonc
 scripts
 netlify*
 _redirects
+test-support/

--- a/packages/taiko/lib/api.json
+++ b/packages/taiko/lib/api.json
@@ -7572,27 +7572,27 @@
     ],
     "loc": {
       "start": {
-        "line": 57,
+        "line": 65,
         "column": 0,
-        "index": 1751
+        "index": 2328
       },
       "end": {
-        "line": 89,
+        "line": 97,
         "column": 3,
-        "index": 3845
+        "index": 4422
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 90,
+          "line": 98,
           "column": 0,
-          "index": 3846
+          "index": 4423
         },
         "end": {
-          "line": 125,
+          "line": 133,
           "column": 2,
-          "index": 5097
+          "index": 5672
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -8032,27 +8032,27 @@
     ],
     "loc": {
       "start": {
-        "line": 127,
+        "line": 135,
         "column": 0,
-        "index": 5099
+        "index": 5674
       },
       "end": {
-        "line": 134,
+        "line": 142,
         "column": 3,
-        "index": 5230
+        "index": 5805
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 135,
+          "line": 143,
           "column": 0,
-          "index": 5231
+          "index": 5806
         },
         "end": {
-          "line": 146,
+          "line": 154,
           "column": 2,
-          "index": 5560
+          "index": 6133
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -8171,27 +8171,27 @@
     ],
     "loc": {
       "start": {
-        "line": 154,
+        "line": 162,
         "column": 0,
-        "index": 5747
+        "index": 6318
       },
       "end": {
-        "line": 161,
+        "line": 169,
         "column": 3,
-        "index": 6033
+        "index": 6604
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 162,
+          "line": 170,
           "column": 0,
-          "index": 6034
+          "index": 6605
         },
         "end": {
-          "line": 162,
+          "line": 170,
           "column": 57,
-          "index": 6091
+          "index": 6662
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -8315,27 +8315,27 @@
     ],
     "loc": {
       "start": {
-        "line": 185,
+        "line": 193,
         "column": 0,
-        "index": 6555
+        "index": 7126
       },
       "end": {
-        "line": 215,
+        "line": 223,
         "column": 3,
-        "index": 7491
+        "index": 8062
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 217,
+          "line": 225,
           "column": 0,
-          "index": 7493
+          "index": 8064
         },
         "end": {
-          "line": 251,
+          "line": 259,
           "column": 2,
-          "index": 8768
+          "index": 9337
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -8558,27 +8558,27 @@
     ],
     "loc": {
       "start": {
-        "line": 253,
+        "line": 261,
         "column": 0,
-        "index": 8770
+        "index": 9339
       },
       "end": {
-        "line": 283,
+        "line": 291,
         "column": 3,
-        "index": 9897
+        "index": 10466
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 284,
+          "line": 292,
           "column": 0,
-          "index": 9898
+          "index": 10467
         },
         "end": {
-          "line": 291,
+          "line": 299,
           "column": 2,
-          "index": 10137
+          "index": 10704
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -8823,27 +8823,27 @@
     ],
     "loc": {
       "start": {
-        "line": 293,
+        "line": 301,
         "column": 0,
-        "index": 10139
+        "index": 10706
       },
       "end": {
-        "line": 312,
+        "line": 320,
         "column": 3,
-        "index": 11014
+        "index": 11581
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 314,
+          "line": 322,
           "column": 0,
-          "index": 11016
+          "index": 11583
         },
         "end": {
-          "line": 321,
+          "line": 329,
           "column": 2,
-          "index": 11256
+          "index": 11821
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -8998,27 +8998,27 @@
     ],
     "loc": {
       "start": {
-        "line": 323,
+        "line": 331,
         "column": 0,
-        "index": 11258
+        "index": 11823
       },
       "end": {
-        "line": 332,
+        "line": 340,
         "column": 3,
-        "index": 11619
+        "index": 12184
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 334,
+          "line": 342,
           "column": 0,
-          "index": 11621
+          "index": 12186
         },
         "end": {
-          "line": 334,
+          "line": 342,
           "column": 45,
-          "index": 11666
+          "index": 12231
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -9167,27 +9167,27 @@
     ],
     "loc": {
       "start": {
-        "line": 341,
+        "line": 349,
         "column": 0,
-        "index": 11852
+        "index": 12415
       },
       "end": {
-        "line": 350,
+        "line": 358,
         "column": 3,
-        "index": 12202
+        "index": 12765
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 351,
+          "line": 359,
           "column": 0,
-          "index": 12203
+          "index": 12766
         },
         "end": {
-          "line": 358,
+          "line": 366,
           "column": 2,
-          "index": 12432
+          "index": 12993
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -9326,27 +9326,27 @@
     ],
     "loc": {
       "start": {
-        "line": 360,
+        "line": 368,
         "column": 0,
-        "index": 12434
+        "index": 12995
       },
       "end": {
-        "line": 365,
+        "line": 373,
         "column": 3,
-        "index": 12727
+        "index": 13288
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 367,
+          "line": 375,
           "column": 0,
-          "index": 12729
+          "index": 13290
         },
         "end": {
-          "line": 370,
+          "line": 378,
           "column": 2,
-          "index": 12900
+          "index": 13459
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -9362,7 +9362,7 @@
       {
         "title": "param",
         "name": "timezoneId",
-        "lineNumber": 367
+        "lineNumber": 375
       }
     ],
     "properties": [],
@@ -9546,27 +9546,27 @@
     ],
     "loc": {
       "start": {
-        "line": 372,
+        "line": 380,
         "column": 0,
-        "index": 12902
+        "index": 13461
       },
       "end": {
-        "line": 389,
+        "line": 397,
         "column": 3,
-        "index": 14163
+        "index": 14722
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 390,
+          "line": 398,
           "column": 0,
-          "index": 14164
+          "index": 14723
         },
         "end": {
-          "line": 422,
+          "line": 430,
           "column": 2,
-          "index": 15189
+          "index": 15746
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -9975,27 +9975,27 @@
     ],
     "loc": {
       "start": {
-        "line": 424,
+        "line": 432,
         "column": 0,
-        "index": 15191
+        "index": 15748
       },
       "end": {
-        "line": 438,
+        "line": 446,
         "column": 3,
-        "index": 16328
+        "index": 16885
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 439,
+          "line": 447,
           "column": 0,
-          "index": 16329
+          "index": 16886
         },
         "end": {
-          "line": 484,
+          "line": 489,
           "column": 2,
-          "index": 17465
+          "index": 18007
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -10296,27 +10296,27 @@
     ],
     "loc": {
       "start": {
-        "line": 485,
+        "line": 490,
         "column": 0,
-        "index": 17466
+        "index": 18008
       },
       "end": {
-        "line": 490,
+        "line": 495,
         "column": 3,
-        "index": 17649
+        "index": 18191
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 491,
+          "line": 496,
           "column": 0,
-          "index": 17650
+          "index": 18192
         },
         "end": {
-          "line": 513,
+          "line": 518,
           "column": 2,
-          "index": 18331
+          "index": 18871
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -10332,7 +10332,7 @@
       {
         "title": "param",
         "name": "arg",
-        "lineNumber": 491
+        "lineNumber": 496
       },
       {
         "title": "param",
@@ -10461,27 +10461,27 @@
     ],
     "loc": {
       "start": {
-        "line": 515,
+        "line": 520,
         "column": 0,
-        "index": 18333
+        "index": 18873
       },
       "end": {
-        "line": 537,
+        "line": 542,
         "column": 3,
-        "index": 19107
+        "index": 19647
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 538,
+          "line": 543,
           "column": 0,
-          "index": 19108
+          "index": 19648
         },
         "end": {
-          "line": 572,
+          "line": 577,
           "column": 2,
-          "index": 20250
+          "index": 20786
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -10509,7 +10509,7 @@
       {
         "title": "param",
         "name": "identifier",
-        "lineNumber": 538
+        "lineNumber": 543
       },
       {
         "title": "param",
@@ -10655,27 +10655,27 @@
     ],
     "loc": {
       "start": {
-        "line": 574,
+        "line": 579,
         "column": 0,
-        "index": 20252
+        "index": 20788
       },
       "end": {
-        "line": 584,
+        "line": 589,
         "column": 3,
-        "index": 20692
+        "index": 21228
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 585,
+          "line": 590,
           "column": 0,
-          "index": 20693
+          "index": 21229
         },
         "end": {
-          "line": 589,
+          "line": 594,
           "column": 2,
-          "index": 20917
+          "index": 21451
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -10849,27 +10849,27 @@
     ],
     "loc": {
       "start": {
-        "line": 591,
+        "line": 596,
         "column": 0,
-        "index": 20919
+        "index": 21453
       },
       "end": {
-        "line": 598,
+        "line": 603,
         "column": 3,
-        "index": 21060
+        "index": 21594
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 599,
+          "line": 604,
           "column": 0,
-          "index": 21061
+          "index": 21595
         },
         "end": {
-          "line": 603,
+          "line": 608,
           "column": 2,
-          "index": 21245
+          "index": 21777
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -11105,27 +11105,27 @@
     ],
     "loc": {
       "start": {
-        "line": 605,
+        "line": 610,
         "column": 0,
-        "index": 21247
+        "index": 21779
       },
       "end": {
-        "line": 625,
+        "line": 630,
         "column": 3,
-        "index": 22379
+        "index": 22911
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 626,
+          "line": 631,
           "column": 0,
-          "index": 22380
+          "index": 22912
         },
         "end": {
-          "line": 640,
+          "line": 645,
           "column": 2,
-          "index": 22881
+          "index": 23411
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -11549,27 +11549,27 @@
     ],
     "loc": {
       "start": {
-        "line": 642,
+        "line": 647,
         "column": 0,
-        "index": 22883
+        "index": 23413
       },
       "end": {
-        "line": 659,
+        "line": 664,
         "column": 3,
-        "index": 23776
+        "index": 24306
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 660,
+          "line": 665,
           "column": 0,
-          "index": 23777
+          "index": 24307
         },
         "end": {
-          "line": 675,
+          "line": 680,
           "column": 2,
-          "index": 24381
+          "index": 24907
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -11798,27 +11798,27 @@
     ],
     "loc": {
       "start": {
-        "line": 677,
+        "line": 682,
         "column": 0,
-        "index": 24383
+        "index": 24909
       },
       "end": {
-        "line": 684,
+        "line": 689,
         "column": 3,
-        "index": 24512
+        "index": 25038
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 685,
+          "line": 690,
           "column": 0,
-          "index": 24513
+          "index": 25039
         },
         "end": {
-          "line": 696,
+          "line": 701,
           "column": 2,
-          "index": 24997
+          "index": 25521
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -11834,7 +11834,7 @@
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 685,
+        "lineNumber": 690,
         "default": "{}"
       }
     ],
@@ -11966,27 +11966,27 @@
     ],
     "loc": {
       "start": {
-        "line": 697,
+        "line": 702,
         "column": 0,
-        "index": 24998
+        "index": 25522
       },
       "end": {
-        "line": 709,
+        "line": 714,
         "column": 3,
-        "index": 25342
+        "index": 25866
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 710,
+          "line": 715,
           "column": 0,
-          "index": 25343
+          "index": 25867
         },
         "end": {
-          "line": 713,
+          "line": 718,
           "column": 2,
-          "index": 25474
+          "index": 25998
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -12188,27 +12188,27 @@
     ],
     "loc": {
       "start": {
-        "line": 715,
+        "line": 720,
         "column": 0,
-        "index": 25476
+        "index": 26000
       },
       "end": {
-        "line": 727,
+        "line": 732,
         "column": 3,
-        "index": 25891
+        "index": 26415
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 728,
+          "line": 733,
           "column": 0,
-          "index": 25892
+          "index": 26416
         },
         "end": {
-          "line": 732,
+          "line": 737,
           "column": 2,
-          "index": 26053
+          "index": 26575
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -12524,27 +12524,27 @@
     ],
     "loc": {
       "start": {
-        "line": 734,
+        "line": 739,
         "column": 0,
-        "index": 26055
+        "index": 26577
       },
       "end": {
-        "line": 764,
+        "line": 769,
         "column": 3,
-        "index": 27578
+        "index": 28100
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 765,
+          "line": 770,
           "column": 0,
-          "index": 27579
+          "index": 28101
         },
         "end": {
-          "line": 780,
+          "line": 785,
           "column": 2,
-          "index": 28100
+          "index": 28620
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -12950,27 +12950,27 @@
     ],
     "loc": {
       "start": {
-        "line": 782,
+        "line": 787,
         "column": 0,
-        "index": 28102
+        "index": 28622
       },
       "end": {
-        "line": 798,
+        "line": 803,
         "column": 3,
-        "index": 29152
+        "index": 29672
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 799,
+          "line": 804,
           "column": 0,
-          "index": 29153
+          "index": 29673
         },
         "end": {
-          "line": 820,
+          "line": 825,
           "column": 2,
-          "index": 29857
+          "index": 30375
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -13332,27 +13332,27 @@
     ],
     "loc": {
       "start": {
-        "line": 822,
+        "line": 827,
         "column": 0,
-        "index": 29859
+        "index": 30377
       },
       "end": {
-        "line": 834,
+        "line": 839,
         "column": 3,
-        "index": 30695
+        "index": 31213
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 835,
+          "line": 840,
           "column": 0,
-          "index": 30696
+          "index": 31214
         },
         "end": {
-          "line": 841,
+          "line": 846,
           "column": 2,
-          "index": 30919
+          "index": 31435
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -13664,27 +13664,27 @@
     ],
     "loc": {
       "start": {
-        "line": 843,
+        "line": 848,
         "column": 0,
-        "index": 30921
+        "index": 31437
       },
       "end": {
-        "line": 855,
+        "line": 860,
         "column": 3,
-        "index": 31766
+        "index": 32282
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 856,
+          "line": 861,
           "column": 0,
-          "index": 31767
+          "index": 32283
         },
         "end": {
-          "line": 862,
+          "line": 867,
           "column": 2,
-          "index": 31996
+          "index": 32510
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -14133,27 +14133,27 @@
     ],
     "loc": {
       "start": {
-        "line": 919,
+        "line": 1023,
         "column": 0,
-        "index": 33387
+        "index": 36267
       },
       "end": {
-        "line": 947,
+        "line": 1051,
         "column": 3,
-        "index": 35530
+        "index": 38410
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 948,
+          "line": 1052,
           "column": 0,
-          "index": 35531
+          "index": 38411
         },
         "end": {
-          "line": 953,
+          "line": 1057,
           "column": 2,
-          "index": 35754
+          "index": 38634
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -14704,27 +14704,27 @@
     ],
     "loc": {
       "start": {
-        "line": 955,
+        "line": 1059,
         "column": 0,
-        "index": 35756
+        "index": 38636
       },
       "end": {
-        "line": 974,
+        "line": 1078,
         "column": 3,
-        "index": 36838
+        "index": 39718
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 975,
+          "line": 1079,
           "column": 0,
-          "index": 36839
+          "index": 39719
         },
         "end": {
-          "line": 981,
+          "line": 1085,
           "column": 2,
-          "index": 37124
+          "index": 40004
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -15058,27 +15058,27 @@
     ],
     "loc": {
       "start": {
-        "line": 983,
+        "line": 1087,
         "column": 0,
-        "index": 37126
+        "index": 40006
       },
       "end": {
-        "line": 998,
+        "line": 1102,
         "column": 3,
-        "index": 38051
+        "index": 40931
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 999,
+          "line": 1103,
           "column": 0,
-          "index": 38052
+          "index": 40932
         },
         "end": {
-          "line": 1005,
+          "line": 1109,
           "column": 2,
-          "index": 38337
+          "index": 41217
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -15411,27 +15411,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1007,
+        "line": 1111,
         "column": 0,
-        "index": 38339
+        "index": 41219
       },
       "end": {
-        "line": 1022,
+        "line": 1126,
         "column": 3,
-        "index": 39209
+        "index": 42089
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1023,
+          "line": 1127,
           "column": 0,
-          "index": 39210
+          "index": 42090
         },
         "end": {
-          "line": 1028,
+          "line": 1132,
           "column": 2,
-          "index": 39461
+          "index": 42341
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -15482,12 +15482,12 @@
       {
         "title": "param",
         "name": "destination",
-        "lineNumber": 1023
+        "lineNumber": 1127
       },
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 1023,
+        "lineNumber": 1127,
         "default": "{}"
       },
       {
@@ -15675,27 +15675,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1030,
+        "line": 1134,
         "column": 0,
-        "index": 39463
+        "index": 42343
       },
       "end": {
-        "line": 1044,
+        "line": 1148,
         "column": 3,
-        "index": 40407
+        "index": 43287
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1045,
+          "line": 1149,
           "column": 0,
-          "index": 40408
+          "index": 43288
         },
         "end": {
-          "line": 1050,
+          "line": 1154,
           "column": 2,
-          "index": 40635
+          "index": 43515
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -15938,27 +15938,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1052,
+        "line": 1156,
         "column": 0,
-        "index": 40637
+        "index": 43517
       },
       "end": {
-        "line": 1064,
+        "line": 1168,
         "column": 3,
-        "index": 41461
+        "index": 44341
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1065,
+          "line": 1169,
           "column": 0,
-          "index": 41462
+          "index": 44342
         },
         "end": {
-          "line": 1070,
+          "line": 1174,
           "column": 2,
-          "index": 41695
+          "index": 44575
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -16300,27 +16300,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1072,
+        "line": 1176,
         "column": 0,
-        "index": 41697
+        "index": 44577
       },
       "end": {
-        "line": 1091,
+        "line": 1195,
         "column": 3,
-        "index": 43044
+        "index": 45924
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1092,
+          "line": 1196,
           "column": 0,
-          "index": 43045
+          "index": 45925
         },
         "end": {
-          "line": 1098,
+          "line": 1202,
           "column": 2,
-          "index": 43315
+          "index": 46195
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -16800,27 +16800,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1100,
+        "line": 1204,
         "column": 0,
-        "index": 43317
+        "index": 46197
       },
       "end": {
-        "line": 1119,
+        "line": 1223,
         "column": 3,
-        "index": 44627
+        "index": 47507
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1120,
+          "line": 1224,
           "column": 0,
-          "index": 44628
+          "index": 47508
         },
         "end": {
-          "line": 1134,
+          "line": 1238,
           "column": 2,
-          "index": 45059
+          "index": 47939
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -17168,27 +17168,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1136,
+        "line": 1240,
         "column": 0,
-        "index": 45061
+        "index": 47941
       },
       "end": {
-        "line": 1149,
+        "line": 1253,
         "column": 3,
-        "index": 45619
+        "index": 48499
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1150,
+          "line": 1254,
           "column": 0,
-          "index": 45620
+          "index": 48500
         },
         "end": {
-          "line": 1155,
+          "line": 1259,
           "column": 2,
-          "index": 45837
+          "index": 48717
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -17274,7 +17274,7 @@
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 1150,
+        "lineNumber": 1254,
         "default": "{}"
       }
     ],
@@ -17493,27 +17493,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1157,
+        "line": 1261,
         "column": 0,
-        "index": 45839
+        "index": 48719
       },
       "end": {
-        "line": 1179,
+        "line": 1283,
         "column": 3,
-        "index": 47160
+        "index": 50040
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1180,
+          "line": 1284,
           "column": 0,
-          "index": 47161
+          "index": 50041
         },
         "end": {
-          "line": 1183,
+          "line": 1287,
           "column": 2,
-          "index": 47303
+          "index": 50183
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -17906,27 +17906,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1203,
+        "line": 1307,
         "column": 0,
-        "index": 47815
+        "index": 50695
       },
       "end": {
-        "line": 1215,
+        "line": 1319,
         "column": 3,
-        "index": 48301
+        "index": 51181
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1216,
+          "line": 1320,
           "column": 0,
-          "index": 48302
+          "index": 51182
         },
         "end": {
-          "line": 1216,
+          "line": 1320,
           "column": 37,
-          "index": 48339
+          "index": 51219
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -18110,27 +18110,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1229,
+        "line": 1333,
         "column": 0,
-        "index": 48673
+        "index": 51553
       },
       "end": {
-        "line": 1236,
+        "line": 1340,
         "column": 3,
-        "index": 48830
+        "index": 51710
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1238,
+          "line": 1342,
           "column": 0,
-          "index": 48832
+          "index": 51712
         },
         "end": {
-          "line": 1243,
+          "line": 1347,
           "column": 2,
-          "index": 49032
+          "index": 51912
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -18354,27 +18354,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1245,
+        "line": 1349,
         "column": 0,
-        "index": 49034
+        "index": 51914
       },
       "end": {
-        "line": 1271,
+        "line": 1375,
         "column": 3,
-        "index": 50577
+        "index": 53457
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1272,
+          "line": 1376,
           "column": 0,
-          "index": 50578
+          "index": 53458
         },
         "end": {
-          "line": 1272,
+          "line": 1376,
           "column": 41,
-          "index": 50619
+          "index": 53499
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -18821,27 +18821,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1281,
+        "line": 1385,
         "column": 0,
-        "index": 50881
+        "index": 53761
       },
       "end": {
-        "line": 1303,
+        "line": 1407,
         "column": 3,
-        "index": 52434
+        "index": 55314
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1304,
+          "line": 1408,
           "column": 0,
-          "index": 52435
+          "index": 55315
         },
         "end": {
-          "line": 1315,
+          "line": 1419,
           "column": 2,
-          "index": 52904
+          "index": 55784
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -19280,27 +19280,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1317,
+        "line": 1421,
         "column": 0,
-        "index": 52906
+        "index": 55786
       },
       "end": {
-        "line": 1333,
+        "line": 1437,
         "column": 3,
-        "index": 53284
+        "index": 56164
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1334,
+          "line": 1438,
           "column": 0,
-          "index": 53285
+          "index": 56165
         },
         "end": {
-          "line": 1355,
+          "line": 1459,
           "column": 2,
-          "index": 53812
+          "index": 56692
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -19512,27 +19512,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1357,
+        "line": 1461,
         "column": 0,
-        "index": 53814
+        "index": 56694
       },
       "end": {
-        "line": 1373,
+        "line": 1477,
         "column": 3,
-        "index": 54187
+        "index": 57067
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1374,
+          "line": 1478,
           "column": 0,
-          "index": 54188
+          "index": 57068
         },
         "end": {
-          "line": 1395,
+          "line": 1499,
           "column": 2,
-          "index": 54718
+          "index": 57598
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -19744,27 +19744,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1397,
+        "line": 1501,
         "column": 0,
-        "index": 54720
+        "index": 57600
       },
       "end": {
-        "line": 1413,
+        "line": 1517,
         "column": 3,
-        "index": 55076
+        "index": 57956
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1414,
+          "line": 1518,
           "column": 0,
-          "index": 55077
+          "index": 57957
         },
         "end": {
-          "line": 1435,
+          "line": 1539,
           "column": 2,
-          "index": 55602
+          "index": 58482
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -19976,27 +19976,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1437,
+        "line": 1541,
         "column": 0,
-        "index": 55604
+        "index": 58484
       },
       "end": {
-        "line": 1453,
+        "line": 1557,
         "column": 3,
-        "index": 55970
+        "index": 58850
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1454,
+          "line": 1558,
           "column": 0,
-          "index": 55971
+          "index": 58851
         },
         "end": {
-          "line": 1475,
+          "line": 1579,
           "column": 2,
-          "index": 56495
+          "index": 59375
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -20242,27 +20242,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1477,
+        "line": 1581,
         "column": 0,
-        "index": 56497
+        "index": 59377
       },
       "end": {
-        "line": 1496,
+        "line": 1600,
         "column": 3,
-        "index": 57274
+        "index": 60154
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1497,
+          "line": 1601,
           "column": 0,
-          "index": 57275
+          "index": 60155
         },
         "end": {
-          "line": 1515,
+          "line": 1619,
           "column": 2,
-          "index": 57941
+          "index": 60821
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -20600,27 +20600,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1517,
+        "line": 1621,
         "column": 0,
-        "index": 57943
+        "index": 60823
       },
       "end": {
-        "line": 1536,
+        "line": 1640,
         "column": 3,
-        "index": 59074
+        "index": 61954
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1537,
+          "line": 1641,
           "column": 0,
-          "index": 59075
+          "index": 61955
         },
         "end": {
-          "line": 1543,
+          "line": 1647,
           "column": 2,
-          "index": 59325
+          "index": 62205
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -20963,27 +20963,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1545,
+        "line": 1649,
         "column": 0,
-        "index": 59327
+        "index": 62207
       },
       "end": {
-        "line": 1564,
+        "line": 1668,
         "column": 3,
-        "index": 60033
+        "index": 62913
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1565,
+          "line": 1669,
           "column": 0,
-          "index": 60034
+          "index": 62914
         },
         "end": {
-          "line": 1569,
+          "line": 1673,
           "column": 2,
-          "index": 60245
+          "index": 63125
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -21014,7 +21014,7 @@
       {
         "title": "param",
         "name": "attrValuePairs",
-        "lineNumber": 1565
+        "lineNumber": 1669
       },
       {
         "title": "param",
@@ -21226,27 +21226,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1571,
+        "line": 1675,
         "column": 0,
-        "index": 60247
+        "index": 63127
       },
       "end": {
-        "line": 1591,
+        "line": 1695,
         "column": 3,
-        "index": 60941
+        "index": 63821
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1592,
+          "line": 1696,
           "column": 0,
-          "index": 60942
+          "index": 63822
         },
         "end": {
-          "line": 1596,
+          "line": 1700,
           "column": 2,
-          "index": 61154
+          "index": 64034
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -21504,27 +21504,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1598,
+        "line": 1702,
         "column": 0,
-        "index": 61156
+        "index": 64036
       },
       "end": {
-        "line": 1617,
+        "line": 1721,
         "column": 3,
-        "index": 61818
+        "index": 64698
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1618,
+          "line": 1722,
           "column": 0,
-          "index": 61819
+          "index": 64699
         },
         "end": {
-          "line": 1622,
+          "line": 1726,
           "column": 2,
-          "index": 62027
+          "index": 64907
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -21790,27 +21790,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1624,
+        "line": 1728,
         "column": 0,
-        "index": 62029
+        "index": 64909
       },
       "end": {
-        "line": 1643,
+        "line": 1747,
         "column": 3,
-        "index": 62765
+        "index": 65645
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1644,
+          "line": 1748,
           "column": 0,
-          "index": 62766
+          "index": 65646
         },
         "end": {
-          "line": 1648,
+          "line": 1752,
           "column": 2,
-          "index": 62990
+          "index": 65870
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -22068,27 +22068,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1650,
+        "line": 1754,
         "column": 0,
-        "index": 62992
+        "index": 65872
       },
       "end": {
-        "line": 1670,
+        "line": 1774,
         "column": 3,
-        "index": 63776
+        "index": 66656
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1671,
+          "line": 1775,
           "column": 0,
-          "index": 63777
+          "index": 66657
         },
         "end": {
-          "line": 1675,
+          "line": 1779,
           "column": 2,
-          "index": 63993
+          "index": 66873
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -22346,27 +22346,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1677,
+        "line": 1781,
         "column": 0,
-        "index": 63995
+        "index": 66875
       },
       "end": {
-        "line": 1696,
+        "line": 1800,
         "column": 3,
-        "index": 64796
+        "index": 67676
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1697,
+          "line": 1801,
           "column": 0,
-          "index": 64797
+          "index": 67677
         },
         "end": {
-          "line": 1697,
+          "line": 1801,
           "column": 37,
-          "index": 64834
+          "index": 67714
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -22626,27 +22626,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1705,
+        "line": 1809,
         "column": 0,
-        "index": 65053
+        "index": 67933
       },
       "end": {
-        "line": 1727,
+        "line": 1831,
         "column": 3,
-        "index": 65958
+        "index": 68838
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1728,
+          "line": 1832,
           "column": 0,
-          "index": 65959
+          "index": 68839
         },
         "end": {
-          "line": 1728,
+          "line": 1832,
           "column": 37,
-          "index": 65996
+          "index": 68876
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -22884,27 +22884,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1736,
+        "line": 1840,
         "column": 0,
-        "index": 66215
+        "index": 69095
       },
       "end": {
-        "line": 1751,
+        "line": 1855,
         "column": 3,
-        "index": 66941
+        "index": 69821
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1752,
+          "line": 1856,
           "column": 0,
-          "index": 66942
+          "index": 69822
         },
         "end": {
-          "line": 1752,
+          "line": 1856,
           "column": 29,
-          "index": 66971
+          "index": 69851
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -23120,27 +23120,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1760,
+        "line": 1864,
         "column": 0,
-        "index": 67174
+        "index": 70054
       },
       "end": {
-        "line": 1778,
+        "line": 1882,
         "column": 3,
-        "index": 67835
+        "index": 70715
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1780,
+          "line": 1884,
           "column": 0,
-          "index": 67837
+          "index": 70717
         },
         "end": {
-          "line": 1780,
+          "line": 1884,
           "column": 29,
-          "index": 67866
+          "index": 70746
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -23387,27 +23387,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1792,
+        "line": 1896,
         "column": 0,
-        "index": 68197
+        "index": 71077
       },
       "end": {
-        "line": 1819,
+        "line": 1923,
         "column": 4,
-        "index": 69311
+        "index": 72191
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1820,
+          "line": 1924,
           "column": 0,
-          "index": 69312
+          "index": 72192
         },
         "end": {
-          "line": 1820,
+          "line": 1924,
           "column": 37,
-          "index": 69349
+          "index": 72229
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -23685,27 +23685,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1849,
+        "line": 1953,
         "column": 0,
-        "index": 70169
+        "index": 73049
       },
       "end": {
-        "line": 1866,
+        "line": 1970,
         "column": 3,
-        "index": 70946
+        "index": 73826
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1867,
+          "line": 1971,
           "column": 0,
-          "index": 70947
+          "index": 73827
         },
         "end": {
-          "line": 1867,
+          "line": 1971,
           "column": 33,
-          "index": 70980
+          "index": 73860
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -23939,27 +23939,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1875,
+        "line": 1979,
         "column": 0,
-        "index": 71200
+        "index": 74080
       },
       "end": {
-        "line": 1900,
+        "line": 2004,
         "column": 3,
-        "index": 72295
+        "index": 75175
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1901,
+          "line": 2005,
           "column": 0,
-          "index": 72296
+          "index": 75176
         },
         "end": {
-          "line": 1901,
+          "line": 2005,
           "column": 35,
-          "index": 72331
+          "index": 75211
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -24185,27 +24185,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1909,
+        "line": 2013,
         "column": 0,
-        "index": 72555
+        "index": 75435
       },
       "end": {
-        "line": 1925,
+        "line": 2029,
         "column": 3,
-        "index": 73226
+        "index": 76106
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1926,
+          "line": 2030,
           "column": 0,
-          "index": 73227
+          "index": 76107
         },
         "end": {
-          "line": 1930,
+          "line": 2034,
           "column": 2,
-          "index": 73460
+          "index": 76340
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -24416,27 +24416,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1932,
+        "line": 2036,
         "column": 0,
-        "index": 73462
+        "index": 76342
       },
       "end": {
-        "line": 1946,
+        "line": 2050,
         "column": 3,
-        "index": 74081
+        "index": 76961
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1947,
+          "line": 2051,
           "column": 0,
-          "index": 74082
+          "index": 76962
         },
         "end": {
-          "line": 1951,
+          "line": 2055,
           "column": 2,
-          "index": 74327
+          "index": 77207
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -24673,27 +24673,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1953,
+        "line": 2057,
         "column": 0,
-        "index": 74329
+        "index": 77209
       },
       "end": {
-        "line": 1976,
+        "line": 2080,
         "column": 3,
-        "index": 75143
+        "index": 78023
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1977,
+          "line": 2081,
           "column": 0,
-          "index": 75144
+          "index": 78024
         },
         "end": {
-          "line": 1977,
+          "line": 2081,
           "column": 27,
-          "index": 75171
+          "index": 78051
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -24927,27 +24927,27 @@
     ],
     "loc": {
       "start": {
-        "line": 1985,
+        "line": 2089,
         "column": 0,
-        "index": 75350
+        "index": 78230
       },
       "end": {
-        "line": 1995,
+        "line": 2099,
         "column": 3,
-        "index": 75661
+        "index": 78541
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 1997,
+          "line": 2101,
           "column": 0,
-          "index": 75663
+          "index": 78543
         },
         "end": {
-          "line": 2009,
+          "line": 2113,
           "column": 2,
-          "index": 76043
+          "index": 78923
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -25117,27 +25117,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2011,
+        "line": 2115,
         "column": 0,
-        "index": 76045
+        "index": 78925
       },
       "end": {
-        "line": 2021,
+        "line": 2125,
         "column": 3,
-        "index": 76358
+        "index": 79238
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2023,
+          "line": 2127,
           "column": 0,
-          "index": 76360
+          "index": 79240
         },
         "end": {
-          "line": 2036,
+          "line": 2140,
           "column": 2,
-          "index": 76760
+          "index": 79640
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -25307,27 +25307,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2038,
+        "line": 2142,
         "column": 0,
-        "index": 76762
+        "index": 79642
       },
       "end": {
-        "line": 2048,
+        "line": 2152,
         "column": 3,
-        "index": 77057
+        "index": 79937
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2050,
+          "line": 2154,
           "column": 0,
-          "index": 77059
+          "index": 79939
         },
         "end": {
-          "line": 2063,
+          "line": 2167,
           "column": 2,
-          "index": 77443
+          "index": 80323
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -25497,27 +25497,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2065,
+        "line": 2169,
         "column": 0,
-        "index": 77445
+        "index": 80325
       },
       "end": {
-        "line": 2075,
+        "line": 2179,
         "column": 3,
-        "index": 77740
+        "index": 80620
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2077,
+          "line": 2181,
           "column": 0,
-          "index": 77742
+          "index": 80622
         },
         "end": {
-          "line": 2090,
+          "line": 2194,
           "column": 2,
-          "index": 78126
+          "index": 81006
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -25687,27 +25687,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2092,
+        "line": 2196,
         "column": 0,
-        "index": 78128
+        "index": 81008
       },
       "end": {
-        "line": 2106,
+        "line": 2210,
         "column": 3,
-        "index": 78655
+        "index": 81535
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2107,
+          "line": 2211,
           "column": 0,
-          "index": 78656
+          "index": 81536
         },
         "end": {
-          "line": 2130,
+          "line": 2234,
           "column": 2,
-          "index": 79376
+          "index": 82256
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -25758,7 +25758,7 @@
       {
         "title": "param",
         "name": "opts",
-        "lineNumber": 2107,
+        "lineNumber": 2211,
         "default": "{offset:30}"
       }
     ],
@@ -25878,27 +25878,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2132,
+        "line": 2236,
         "column": 0,
-        "index": 79378
+        "index": 82258
       },
       "end": {
-        "line": 2143,
+        "line": 2247,
         "column": 3,
-        "index": 79746
+        "index": 82626
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2144,
+          "line": 2248,
           "column": 0,
-          "index": 79747
+          "index": 82627
         },
         "end": {
-          "line": 2166,
+          "line": 2270,
           "column": 2,
-          "index": 80376
+          "index": 83256
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -26061,27 +26061,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2168,
+        "line": 2272,
         "column": 0,
-        "index": 80378
+        "index": 83258
       },
       "end": {
-        "line": 2201,
+        "line": 2305,
         "column": 3,
-        "index": 81460
+        "index": 84340
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2202,
+          "line": 2306,
           "column": 0,
-          "index": 81461
+          "index": 84341
         },
         "end": {
-          "line": 2203,
+          "line": 2307,
           "column": 37,
-          "index": 81544
+          "index": 84424
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -26097,7 +26097,7 @@
       {
         "title": "param",
         "name": "message",
-        "lineNumber": 2202
+        "lineNumber": 2306
       },
       {
         "title": "param",
@@ -26274,27 +26274,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2205,
+        "line": 2309,
         "column": 0,
-        "index": 81546
+        "index": 84426
       },
       "end": {
-        "line": 2239,
+        "line": 2343,
         "column": 3,
-        "index": 82726
+        "index": 85606
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2240,
+          "line": 2344,
           "column": 0,
-          "index": 82727
+          "index": 85607
         },
         "end": {
-          "line": 2241,
+          "line": 2345,
           "column": 38,
-          "index": 82812
+          "index": 85692
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -26310,7 +26310,7 @@
       {
         "title": "param",
         "name": "message",
-        "lineNumber": 2240
+        "lineNumber": 2344
       },
       {
         "title": "param",
@@ -26467,27 +26467,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2243,
+        "line": 2347,
         "column": 0,
-        "index": 82814
+        "index": 85694
       },
       "end": {
-        "line": 2278,
+        "line": 2382,
         "column": 3,
-        "index": 83960
+        "index": 86840
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2279,
+          "line": 2383,
           "column": 0,
-          "index": 83961
+          "index": 86841
         },
         "end": {
-          "line": 2280,
+          "line": 2384,
           "column": 39,
-          "index": 84048
+          "index": 86928
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -26503,7 +26503,7 @@
       {
         "title": "param",
         "name": "message",
-        "lineNumber": 2279
+        "lineNumber": 2383
       },
       {
         "title": "param",
@@ -26642,27 +26642,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2282,
+        "line": 2386,
         "column": 0,
-        "index": 84050
+        "index": 86930
       },
       "end": {
-        "line": 2294,
+        "line": 2398,
         "column": 3,
-        "index": 84441
+        "index": 87321
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2295,
+          "line": 2399,
           "column": 0,
-          "index": 84442
+          "index": 87322
         },
         "end": {
-          "line": 2296,
+          "line": 2400,
           "column": 39,
-          "index": 84525
+          "index": 87405
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -26913,27 +26913,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2298,
+        "line": 2402,
         "column": 0,
-        "index": 84527
+        "index": 87407
       },
       "end": {
-        "line": 2331,
+        "line": 2435,
         "column": 3,
-        "index": 86502
+        "index": 89382
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2332,
+          "line": 2436,
           "column": 0,
-          "index": 86503
+          "index": 89383
         },
         "end": {
-          "line": 2375,
+          "line": 2479,
           "column": 2,
-          "index": 87650
+          "index": 90530
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -27332,27 +27332,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2377,
+        "line": 2481,
         "column": 0,
-        "index": 87652
+        "index": 90532
       },
       "end": {
-        "line": 2385,
+        "line": 2489,
         "column": 3,
-        "index": 87961
+        "index": 90841
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2386,
+          "line": 2490,
           "column": 0,
-          "index": 87962
+          "index": 90842
         },
         "end": {
-          "line": 2386,
+          "line": 2490,
           "column": 37,
-          "index": 87999
+          "index": 90879
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -27368,7 +27368,7 @@
       {
         "title": "param",
         "name": "value",
-        "lineNumber": 2386
+        "lineNumber": 2490
       },
       {
         "title": "param",
@@ -27521,27 +27521,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2388,
+        "line": 2492,
         "column": 0,
-        "index": 88001
+        "index": 90881
       },
       "end": {
-        "line": 2396,
+        "line": 2500,
         "column": 3,
-        "index": 88302
+        "index": 91182
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2397,
+          "line": 2501,
           "column": 0,
-          "index": 88303
+          "index": 91183
         },
         "end": {
-          "line": 2397,
+          "line": 2501,
           "column": 39,
-          "index": 88342
+          "index": 91222
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -27557,7 +27557,7 @@
       {
         "title": "param",
         "name": "value",
-        "lineNumber": 2397
+        "lineNumber": 2501
       },
       {
         "title": "param",
@@ -27709,27 +27709,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2458,
+        "line": 2562,
         "column": 0,
-        "index": 89943
+        "index": 92823
       },
       "end": {
-        "line": 2468,
+        "line": 2572,
         "column": 3,
-        "index": 90255
+        "index": 93135
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2469,
+          "line": 2573,
           "column": 0,
-          "index": 90256
+          "index": 93136
         },
         "end": {
-          "line": 2472,
+          "line": 2576,
           "column": 2,
-          "index": 90409
+          "index": 93289
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -27873,27 +27873,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2474,
+        "line": 2578,
         "column": 0,
-        "index": 90411
+        "index": 93291
       },
       "end": {
-        "line": 2481,
+        "line": 2585,
         "column": 3,
-        "index": 90589
+        "index": 93469
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2482,
+          "line": 2586,
           "column": 0,
-          "index": 90590
+          "index": 93470
         },
         "end": {
-          "line": 2485,
+          "line": 2589,
           "column": 2,
-          "index": 90731
+          "index": 93611
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -28088,27 +28088,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2551,
+        "line": 2655,
         "column": 0,
-        "index": 92589
+        "index": 95469
       },
       "end": {
-        "line": 2572,
+        "line": 2676,
         "column": 3,
-        "index": 94274
+        "index": 97154
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2573,
+          "line": 2677,
           "column": 0,
-          "index": 94275
+          "index": 97155
         },
         "end": {
-          "line": 2573,
+          "line": 2677,
           "column": 37,
-          "index": 94312
+          "index": 97192
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -28799,27 +28799,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2575,
+        "line": 2679,
         "column": 0,
-        "index": 94314
+        "index": 97194
       },
       "end": {
-        "line": 2600,
+        "line": 2704,
         "column": 3,
-        "index": 96606
+        "index": 99486
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2601,
+          "line": 2705,
           "column": 0,
-          "index": 96607
+          "index": 99487
         },
         "end": {
-          "line": 2601,
+          "line": 2705,
           "column": 37,
-          "index": 96644
+          "index": 99524
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -29567,27 +29567,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2804,
+        "line": 2908,
         "column": 0,
-        "index": 100802
+        "index": 103682
       },
       "end": {
-        "line": 2814,
+        "line": 2918,
         "column": 3,
-        "index": 101145
+        "index": 104025
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2815,
+          "line": 2919,
           "column": 0,
-          "index": 101146
+          "index": 104026
         },
         "end": {
-          "line": 2827,
+          "line": 2931,
           "column": 2,
-          "index": 101589
+          "index": 104463
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -29702,27 +29702,27 @@
     ],
     "loc": {
       "start": {
-        "line": 881,
+        "line": 886,
         "column": 0,
-        "index": 32484
+        "index": 32998
       },
       "end": {
-        "line": 891,
+        "line": 896,
         "column": 3,
-        "index": 32753
+        "index": 33267
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 892,
+          "line": 897,
           "column": 0,
-          "index": 32754
+          "index": 33268
         },
         "end": {
-          "line": 898,
+          "line": 903,
           "column": 2,
-          "index": 32937
+          "index": 33449
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -29779,7 +29779,8 @@
     "todos": [],
     "yields": [],
     "name": "currentURL",
-    "kind": "constant",
+    "kind": "function",
+    "async": true,
     "members": {
       "global": [],
       "inner": [],
@@ -29790,7 +29791,7 @@
     "path": [
       {
         "name": "currentURL",
-        "kind": "constant"
+        "kind": "function"
       }
     ],
     "namespace": "currentURL"
@@ -29847,27 +29848,27 @@
     ],
     "loc": {
       "start": {
-        "line": 901,
+        "line": 906,
         "column": 0,
-        "index": 32979
+        "index": 33491
       },
       "end": {
-        "line": 911,
+        "line": 916,
         "column": 3,
-        "index": 33207
+        "index": 33719
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 912,
+          "line": 917,
           "column": 0,
-          "index": 33208
+          "index": 33720
         },
         "end": {
-          "line": 916,
+          "line": 921,
           "column": 2,
-          "index": 33355
+          "index": 33865
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -29924,7 +29925,8 @@
     "todos": [],
     "yields": [],
     "name": "title",
-    "kind": "constant",
+    "kind": "function",
+    "async": true,
     "members": {
       "global": [],
       "inner": [],
@@ -29935,7 +29937,7 @@
     "path": [
       {
         "name": "title",
-        "kind": "constant"
+        "kind": "function"
       }
     ],
     "namespace": "title"
@@ -30027,27 +30029,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2399,
+        "line": 2503,
         "column": 0,
-        "index": 88344
+        "index": 91224
       },
       "end": {
-        "line": 2415,
+        "line": 2519,
         "column": 3,
-        "index": 88839
+        "index": 91719
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2417,
+          "line": 2521,
           "column": 0,
-          "index": 88841
+          "index": 91721
         },
         "end": {
-          "line": 2454,
+          "line": 2558,
           "column": 2,
-          "index": 89906
+          "index": 92786
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -30127,7 +30129,7 @@
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 2417,
+        "lineNumber": 2521,
         "default": "{}"
       },
       {
@@ -30232,27 +30234,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2487,
+        "line": 2591,
         "column": 0,
-        "index": 90733
+        "index": 93613
       },
       "end": {
-        "line": 2501,
+        "line": 2605,
         "column": 3,
-        "index": 91065
+        "index": 93945
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2509,
+          "line": 2613,
           "column": 0,
-          "index": 91269
+          "index": 94149
         },
         "end": {
-          "line": 2522,
+          "line": 2626,
           "column": 2,
-          "index": 91626
+          "index": 94506
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -30328,27 +30330,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2503,
+        "line": 2607,
         "column": 0,
-        "index": 91067
+        "index": 93947
       },
       "end": {
-        "line": 2508,
+        "line": 2612,
         "column": 3,
-        "index": 91268
+        "index": 94148
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2509,
+          "line": 2613,
           "column": 0,
-          "index": 91269
+          "index": 94149
         },
         "end": {
-          "line": 2522,
+          "line": 2626,
           "column": 2,
-          "index": 91626
+          "index": 94506
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -30360,7 +30362,7 @@
       {
         "title": "param",
         "name": "id",
-        "lineNumber": 2509
+        "lineNumber": 2613
       },
       {
         "title": "param",
@@ -30486,27 +30488,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2651,
+        "line": 2755,
         "column": 0,
-        "index": 97915
+        "index": 100795
       },
       "end": {
-        "line": 2665,
+        "line": 2769,
         "column": 3,
-        "index": 98164
+        "index": 101044
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2699,
+          "line": 2803,
           "column": 0,
-          "index": 98856
+          "index": 101736
         },
         "end": {
-          "line": 2699,
+          "line": 2803,
           "column": 21,
-          "index": 98877
+          "index": 101757
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -30661,27 +30663,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2667,
+        "line": 2771,
         "column": 0,
-        "index": 98166
+        "index": 101046
       },
       "end": {
-        "line": 2686,
+        "line": 2790,
         "column": 3,
-        "index": 98648
+        "index": 101528
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2699,
+          "line": 2803,
           "column": 0,
-          "index": 98856
+          "index": 101736
         },
         "end": {
-          "line": 2699,
+          "line": 2803,
           "column": 21,
-          "index": 98877
+          "index": 101757
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
@@ -30839,27 +30841,27 @@
     ],
     "loc": {
       "start": {
-        "line": 2688,
+        "line": 2792,
         "column": 0,
-        "index": 98650
+        "index": 101530
       },
       "end": {
-        "line": 2697,
+        "line": 2801,
         "column": 3,
-        "index": 98854
+        "index": 101734
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2699,
+          "line": 2803,
           "column": 0,
-          "index": 98856
+          "index": 101736
         },
         "end": {
-          "line": 2699,
+          "line": 2803,
           "column": 21,
-          "index": 98877
+          "index": 101757
         }
       },
       "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"

--- a/packages/taiko/lib/browser/browser.js
+++ b/packages/taiko/lib/browser/browser.js
@@ -24,7 +24,6 @@ const { join, basename } = require("node:path");
 const { promisify } = require("node:util");
 const { helper, assert } = require("../helper");
 const { createInterface } = require("node:readline");
-const { parse } = require("node:url");
 const BrowserMetadata = require("./metadata");
 const metadata = new BrowserMetadata();
 
@@ -168,10 +167,11 @@ class Browser {
           return;
         }
         cleanup();
+        const parsedUrl = new URL(match[1]);
         const endpoint = {
-          host: parse(match[1]).hostname,
-          port: parse(match[1]).port,
-          browser: parse(match[1]).href,
+          host: parsedUrl.hostname,
+          port: parsedUrl.port,
+          browser: parsedUrl.href,
         };
         resolve(endpoint);
       }

--- a/packages/taiko/lib/browser/fetcher.js
+++ b/packages/taiko/lib/browser/fetcher.js
@@ -22,7 +22,6 @@ const fs = require("fs-extra");
 const path = require("node:path");
 const extract = require("extract-zip");
 const util = require("node:util");
-const URL = require("node:url");
 const { helper, assert } = require("../helper");
 const ProxyAgent = require("https-proxy-agent");
 const getProxyForUrl = require("proxy-from-env").getProxyForUrl;
@@ -193,13 +192,19 @@ function extractZip(zipPath, folderPath) {
 
 function httpRequest(url, method, response) {
   /** @type {Object} */
-  const options = URL.parse(url);
+  const parsedUrl = new URL(url);
+  const options = {
+    protocol: parsedUrl.protocol,
+    hostname: parsedUrl.hostname,
+    port: parsedUrl.port,
+    path: parsedUrl.pathname + parsedUrl.search,
+  };
   options.method = method;
 
   const proxyURL = getProxyForUrl(url);
   if (proxyURL) {
     /** @type {Object} */
-    const parsedProxyURL = URL.parse(proxyURL);
+    const parsedProxyURL = new URL(proxyURL);
     parsedProxyURL.secureProxy = parsedProxyURL.protocol === "https:";
 
     options.agent = new ProxyAgent(parsedProxyURL);

--- a/packages/taiko/lib/elementSearch.js
+++ b/packages/taiko/lib/elementSearch.js
@@ -79,11 +79,8 @@ function match(text, options = {}, ...args) {
 
       function checkIfRegexMatch(text, searchText, exactMatch) {
         return exactMatch
-          ? isRegex(searchText) &&
-              text &&
-              text.match(searchText) &&
-              text.match(searchText)[0] === text
-          : isRegex(searchText) && text && text.match(searchText);
+          ? isRegex(searchText) && text?.match(searchText)?.[0] === text
+          : isRegex(searchText) && text?.match(searchText);
       }
 
       function normalizeText(text) {

--- a/packages/taiko/lib/handlers/pageHandler.js
+++ b/packages/taiko/lib/handlers/pageHandler.js
@@ -1,8 +1,12 @@
-const { handleUrlRedirection, isElement, isSelector } = require("../helper");
+const {
+  handleUrlRedirection,
+  isElement,
+  isSelector,
+  parseUrl,
+} = require("../helper");
 const { eventHandler, eventRegexMap } = require("../eventBus");
 const { logEvent } = require("../logger");
 const { findElements } = require("../elementSearch");
-const nodeURL = require("node:url");
 const path = require("node:path");
 const { isSameUrl } = require("../util");
 let page;
@@ -146,10 +150,10 @@ const resolveFrameEvent = (p) => {
 };
 
 const normalizeAndHandleRedirection = (urlString) => {
-  let url = nodeURL.parse(urlString);
+  let url = parseUrl(urlString);
   url = handleUrlRedirection(url.href);
   if (url.protocol === "file:") {
-    url.path = path.normalize(url.path);
+    url.path = path.normalize(url.pathname);
   }
   return url.toString();
 };
@@ -158,9 +162,7 @@ const handleNavigation = async (gotoUrl) => {
   let resolveResponse;
   let requestId;
   const response = {};
-  const urlToNavigate = normalizeAndHandleRedirection(
-    nodeURL.parse(gotoUrl).href,
-  );
+  const urlToNavigate = normalizeAndHandleRedirection(parseUrl(gotoUrl).href);
   const handleRequest = (request) => {
     if (
       requestId &&

--- a/packages/taiko/lib/handlers/targetHandler.js
+++ b/packages/taiko/lib/handlers/targetHandler.js
@@ -1,7 +1,12 @@
 const cri = require("chrome-remote-interface");
-const url = require("node:url");
 const path = require("node:path");
-const { handleUrlRedirection, isString, isRegex } = require("../helper");
+const {
+  handleUrlRedirection,
+  isString,
+  isRegex,
+  ensureProtocol,
+  parseUrl,
+} = require("../helper");
 const { eventHandler } = require("../eventBus");
 const { trimCharLeft, escapeHtml } = require("../util");
 const { logEvent } = require("../logger");
@@ -56,7 +61,7 @@ const isMatchingRegex = (target, targetRegex) => {
   if (!isRegex(targetRegex)) {
     return false;
   }
-  const parsedUrl = url.parse(target.url, true);
+  const parsedUrl = new URL(target.url);
   const host = parsedUrl.host ? parsedUrl.host : "";
   const urlPath = path.join(host, trimCharLeft(parsedUrl.pathname, "/"));
   const urlHrefPath = parsedUrl.protocol
@@ -71,11 +76,7 @@ const isMatchingRegex = (target, targetRegex) => {
   );
 };
 
-const prependHttp = (targetUrl) => {
-  return targetUrl && url.parse(targetUrl).host === null
-    ? `http://${targetUrl}`
-    : targetUrl;
-};
+const prependHttp = (targetUrl) => ensureProtocol(targetUrl);
 
 const isMatchingUrl = (target, identifier) => {
   if (!isString(identifier)) {
@@ -83,8 +84,8 @@ const isMatchingUrl = (target, identifier) => {
   }
 
   const _identifier = prependHttp(identifier);
-  const parsedUrl = url.parse(target.url, true);
-  const parsedTargetUrl = url.parse(_identifier, true);
+  const parsedUrl = parseUrl(target.url);
+  const parsedTargetUrl = parseUrl(_identifier);
 
   const host = parsedUrl.host ? parsedUrl.host : "";
   const targetHost = parsedTargetUrl.host ? parsedTargetUrl.host : "";

--- a/packages/taiko/lib/helper.js
+++ b/packages/taiko/lib/helper.js
@@ -174,6 +174,18 @@ const handleUrlRedirection = (url) => {
     : trimmedUrl;
 };
 
+const ensureProtocol = (url) => {
+  if (!url) {
+    return url;
+  }
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(url) ||
+    /^(about|data|file|mailto|ws|wss):/.test(url)
+    ? url
+    : `http://${url}`;
+};
+
+const parseUrl = (url) => new URL(ensureProtocol(url));
+
 const isSelector = (obj) =>
   (obj && Object.hasOwn(obj, "elements") && Object.hasOwn(obj, "exists")) ||
   (obj && Object.hasOwn(obj, "selector"));
@@ -196,6 +208,8 @@ module.exports = {
   xpath,
   waitUntil,
   handleUrlRedirection,
+  ensureProtocol,
+  parseUrl,
   assertType,
   descEvent,
   isSelector,

--- a/packages/taiko/lib/plugins.js
+++ b/packages/taiko/lib/plugins.js
@@ -39,11 +39,11 @@ const getPlugins = () => {
 
 const getExecutablePlugins = () => {
   const pluginsGlobalPath = childProcess
-    .spawnSync("npm", ["root", "-g"], { shell: true })
+    .spawnSync("npm", ["root", "-g"])
     .stdout.toString()
     .trim();
   const pluginsLocalPath = childProcess
-    .spawnSync("npm", ["root"], { shell: true })
+    .spawnSync("npm", ["root"])
     .stdout.toString()
     .trim();
   const globalPlugins = getPluginsInstalledOn(pluginsGlobalPath);

--- a/packages/taiko/lib/repl/repl.js
+++ b/packages/taiko/lib/repl/repl.js
@@ -5,7 +5,6 @@ const { aEval } = require("./awaitEval");
 const { initSearch } = require("./repl-search");
 const { defaultConfig } = require("../config");
 const { removeQuotes, symbols, taikoInstallationLocation } = require("../util");
-const { defineHiddenTestProperty } = require("../testHooks");
 const { EOL } = require("node:os");
 const funcs = {};
 const commands = [];
@@ -194,14 +193,18 @@ ${text}
 `;
 }
 
-defineHiddenTestProperty(module.exports, "__test__", {
-  code,
-  resetState() {
-    commands.length = 0;
-    taikoCommands = [];
-    lastStack = "";
-  },
-});
+// ─── TEST SEAM ─── active only when TAIKO_ENABLE_TEST_HOOKS=1 ───────────────
+if (process.env.TAIKO_ENABLE_TEST_HOOKS) {
+  const { defineHiddenTestProperty } = require("../../test-support/testHooks");
+  defineHiddenTestProperty(module.exports, "__test__", {
+    code,
+    resetState() {
+      commands.length = 0;
+      taikoCommands = [];
+      lastStack = "";
+    },
+  });
+}
 
 function step(withImports = false, actions = commands) {
   const _actions = actions.filter(

--- a/packages/taiko/lib/repl/repl.js
+++ b/packages/taiko/lib/repl/repl.js
@@ -5,6 +5,7 @@ const { aEval } = require("./awaitEval");
 const { initSearch } = require("./repl-search");
 const { defaultConfig } = require("../config");
 const { removeQuotes, symbols, taikoInstallationLocation } = require("../util");
+const { defineHiddenTestProperty } = require("../testHooks");
 const { EOL } = require("node:os");
 const funcs = {};
 const commands = [];
@@ -14,6 +15,8 @@ let lastStack = "";
 let version = "";
 let browserVersion = "";
 let doc = "";
+const isError = (value) =>
+  util.types?.isNativeError?.(value) || value instanceof Error;
 
 module.exports.initialize = async (
   taiko,
@@ -39,7 +42,7 @@ module.exports.initialize = async (
     });
   }
   aEval(repl, (cmd, res) => {
-    if (util.isError(res)) {
+    if (isError(res)) {
       return res;
     }
     commands.push(cmd.trim());
@@ -71,7 +74,7 @@ async function setVersionInfo() {
 }
 
 const writer = (w) => (output) => {
-  if (util.isError(output)) {
+  if (isError(output)) {
     return output.message;
   }
   return w(output);
@@ -162,17 +165,18 @@ function initCommands(taiko, repl, previousSessionFile) {
 }
 
 function code() {
-  if (commands[commands.length - 1].includes("closeBrowser()")) {
-    commands.pop();
-  }
-  const text = commands
+  const lastCommand = commands[commands.length - 1];
+  const sessionCommands = lastCommand?.includes("closeBrowser()")
+    ? commands.slice(0, -1)
+    : commands;
+  const text = sessionCommands
     .map((e) => {
       const _e = e.endsWith(";") ? e : `${e};`;
       return isTaikoFunc(_e) ? `        await ${_e}` : `\t${_e}`;
     })
     .join("\n");
 
-  const cmds = taikoCommands;
+  const cmds = [...taikoCommands];
   if (!cmds.includes("closeBrowser")) {
     cmds.push("closeBrowser");
   }
@@ -189,6 +193,15 @@ ${text}
 })();
 `;
 }
+
+defineHiddenTestProperty(module.exports, "__test__", {
+  code,
+  resetState() {
+    commands.length = 0;
+    taikoCommands = [];
+    lastStack = "";
+  },
+});
 
 function step(withImports = false, actions = commands) {
   const _actions = actions.filter(
@@ -249,7 +262,7 @@ function writeCode(file, previousSessionFile) {
     }
   } catch (error) {
     console.log(`Failed to write to ${file}.`);
-    console.log(error.stacktrace);
+    console.log(error.stack || error.message || error);
   }
 }
 

--- a/packages/taiko/lib/taiko.js
+++ b/packages/taiko/lib/taiko.js
@@ -1,4 +1,5 @@
-const { doActionAwaitingNavigation } = require("./doActionAwaitingNavigation");
+let { doActionAwaitingNavigation } = require("./doActionAwaitingNavigation");
+const helper = require("./helper");
 const {
   wait,
   isString,
@@ -10,13 +11,13 @@ const {
   isSelector,
   isElement,
   isObject,
-} = require("./helper");
+} = helper;
 const inputHandler = require("./handlers/inputHandler");
 const domHandler = require("./handlers/domHandler");
-const networkHandler = require("./handlers/networkHandler");
-const fetchHandler = require("./handlers/fetchHandler");
-const pageHandler = require("./handlers/pageHandler");
-const targetHandler = require("./handlers/targetHandler");
+let networkHandler = require("./handlers/networkHandler");
+let fetchHandler = require("./handlers/fetchHandler");
+let pageHandler = require("./handlers/pageHandler");
+let targetHandler = require("./handlers/targetHandler");
 const runtimeHandler = require("./handlers/runtimeHandler");
 const browserHandler = require("./handlers/browserHandler");
 const emulationHandler = require("./handlers/emulationHandler");
@@ -42,7 +43,7 @@ const crypto = require("node:crypto");
 const { eventHandler, eventRegexMap } = require("./eventBus");
 const { highlightElement } = require("./elements/elementHelper");
 const { launchBrowser } = require("./browser/launcher");
-const {
+let {
   connect_to_cri,
   closeConnection,
   cleanUpListenersOnClient,
@@ -50,9 +51,11 @@ const {
   getClient,
 } = require("./connection");
 const { getPlugins, registerHooks } = require("./plugins");
+const { defineTestHooks } = require("./testHooks");
 let eventHandlerProxy;
+let emitter = descEvent;
 
-module.exports.emitter = descEvent;
+module.exports.emitter = emitter;
 
 /**
  * Launches a browser with a tab. The browser will be closed when the parent node.js process is closed.<br>
@@ -117,7 +120,7 @@ module.exports.openBrowser = async (
   const description = defaultConfig.device
     ? `Browser opened with viewport ${defaultConfig.device}`
     : "Browser opened";
-  descEvent.emit("success", description);
+  emitter.emit("success", description);
 
   if (process.env.TAIKO_EMULATE_NETWORK) {
     await module.exports.emulateNetwork(process.env.TAIKO_EMULATE_NETWORK);
@@ -142,10 +145,10 @@ module.exports.closeBrowser = async () => {
   await waitFor(50); // wait for 50ms to ensure all events are flushed
   await _closeBrowser();
   targetHandler.clearRegister();
-  descEvent.emit("success", "Browser closed");
+  emitter.emit("success", "Browser closed");
 };
 
-const _closeBrowser = async () => {
+let _closeBrowser = async () => {
   fetchHandler.resetInterceptors();
   emulationHandler.resetViewportSettings();
   await closeConnection(promisesToBeResolvedBeforeCloseBrowser);
@@ -247,7 +250,7 @@ module.exports.switchTo = async (arg) => {
   }
   await targetHandler.switchBrowserContext(targetId);
   await connect_to_cri(targetId);
-  descEvent.emit("success", message);
+  emitter.emit("success", message);
 };
 
 /**
@@ -287,7 +290,7 @@ module.exports.intercept = async (requestUrl, option, count) => {
     action: option,
     count,
   });
-  descEvent.emit("success", `Interceptor added for ${requestUrl}`);
+  emitter.emit("success", `Interceptor added for ${requestUrl}`);
 };
 
 /**
@@ -314,7 +317,7 @@ module.exports.intercept = async (requestUrl, option, count) => {
 module.exports.emulateNetwork = async (networkType) => {
   validate();
   await networkHandler.setNetworkEmulation(networkType);
-  descEvent.emit(
+  emitter.emit(
     "success",
     `Set network emulation with values ${JSON.stringify(networkType)}`,
   );
@@ -335,7 +338,7 @@ module.exports.emulateDevice = emulateDevice;
 async function emulateDevice(deviceModel) {
   validate();
   await emulationHandler.emulateDevice(deviceModel);
-  descEvent.emit("success", `Device emulation set to ${deviceModel}`);
+  emitter.emit("success", `Device emulation set to ${deviceModel}`);
 }
 
 /**
@@ -351,7 +354,7 @@ async function emulateDevice(deviceModel) {
 module.exports.setViewPort = async (options) => {
   validate();
   await emulationHandler.setViewport(options);
-  descEvent.emit(
+  emitter.emit(
     "success",
     `ViewPort is set to width ${options.width} and height ${options.height}`,
   );
@@ -366,7 +369,7 @@ module.exports.setViewPort = async (options) => {
 
 module.exports.emulateTimezone = async (timezoneId) => {
   await emulationHandler.setTimeZone(timezoneId);
-  descEvent.emit("success", `Timezone set to ${timezoneId}`);
+  emitter.emit("success", `Timezone set to ${timezoneId}`);
 };
 
 /**
@@ -418,7 +421,7 @@ module.exports.openTab = async (targetUrl, options = {}) => {
   };
 
   await doActionAwaitingNavigation(_options, createNewTarget);
-  descEvent.emit("success", `Opened tab with URL ${finalTargetUrl}`);
+  emitter.emit("success", `Opened tab with URL ${finalTargetUrl}`);
 };
 
 /**
@@ -477,10 +480,7 @@ module.exports.openIncognitoWindow = async (url, options = {}) => {
     });
   }
 
-  descEvent.emit(
-    "success",
-    `Incognito window opened with name ${_options.name}`,
-  );
+  emitter.emit("success", `Incognito window opened with name ${_options.name}`);
 };
 /**
  * Closes the specified browser window.
@@ -509,7 +509,7 @@ module.exports.closeIncognitoWindow = async (arg) => {
     });
     await promiseReconnect;
   }
-  descEvent.emit("success", `Window with name ${arg} closed`);
+  emitter.emit("success", `Window with name ${arg} closed`);
 };
 
 /**
@@ -539,7 +539,7 @@ module.exports.closeTab = async (identifier) => {
   const { matching, others } = await targetHandler.getCriTargets(identifier);
   if (!others.length) {
     await _closeBrowser();
-    descEvent.emit("success", "Closing last target and browser.");
+    emitter.emit("success", "Closing last target and browser.");
     return;
   }
   if (!matching.length) {
@@ -568,7 +568,7 @@ module.exports.closeTab = async (identifier) => {
     targetHandler.unregister(identifier.name);
   }
 
-  descEvent.emit("success", message);
+  emitter.emit("success", message);
 };
 
 /**
@@ -585,7 +585,7 @@ module.exports.closeTab = async (identifier) => {
 module.exports.overridePermissions = async (origin, permissions) => {
   validate();
   await browserHandler.overridePermissions(origin, permissions);
-  descEvent.emit("success", `Override permissions with ${permissions}`);
+  emitter.emit("success", `Override permissions with ${permissions}`);
 };
 
 /**
@@ -599,7 +599,7 @@ module.exports.overridePermissions = async (origin, permissions) => {
 module.exports.clearPermissionOverrides = async () => {
   validate();
   await browserHandler.clearPermissionOverrides();
-  descEvent.emit("success", "Cleared permission overrides");
+  emitter.emit("success", "Cleared permission overrides");
 };
 
 /**
@@ -636,7 +636,7 @@ module.exports.setCookie = async (name, value, options = {}) => {
   if (!res.success) {
     throw new Error(`Unable to set ${name} cookie`);
   }
-  descEvent.emit("success", `${name} cookie set successfully`);
+  emitter.emit("success", `${name} cookie set successfully`);
 };
 
 /**
@@ -661,7 +661,7 @@ module.exports.deleteCookies = async (cookieName, options = {}) => {
   validate();
   if (!cookieName || !cookieName.trim()) {
     await networkHandler.clearBrowserCookies();
-    descEvent.emit("success", "Browser cookies deleted successfully");
+    emitter.emit("success", "Browser cookies deleted successfully");
   } else {
     if (options.url === undefined && options.domain === undefined) {
       throw new Error(
@@ -670,7 +670,7 @@ module.exports.deleteCookies = async (cookieName, options = {}) => {
     }
     options.name = cookieName;
     await networkHandler.deleteCookies(options);
-    descEvent.emit("success", `"${cookieName}" cookie deleted successfully`);
+    emitter.emit("success", `"${cookieName}" cookie deleted successfully`);
   }
 };
 
@@ -689,7 +689,7 @@ module.exports.resizeWindow = async (options = {}) => {
   }
   const [{ targetId }] = await targetHandler.getFirstAvailablePageTarget();
   await browserHandler.setWindowBounds(targetId, options.height, options.width);
-  descEvent.emit(
+  emitter.emit(
     "success",
     `Window resized to height ${options.height} and width ${options.width}`,
   );
@@ -728,7 +728,7 @@ module.exports.getCookies = async (options = {}) => {
 module.exports.setLocation = async (options) => {
   validate();
   await emulationHandler.setLocation(options);
-  descEvent.emit("success", "Geolocation set");
+  emitter.emit("success", "Geolocation set");
 };
 
 /**
@@ -775,7 +775,7 @@ module.exports.goto = async (
   await doActionAwaitingNavigation(setNavigationOptions(options), async () => {
     response = await pageHandler.handleNavigation(_url);
   });
-  descEvent.emit("success", `Navigated to URL ${_url}`);
+  emitter.emit("success", `Navigated to URL ${_url}`);
   return response;
 };
 
@@ -816,7 +816,7 @@ module.exports.reload = async (
   const windowLocation = (
     await runtimeHandler.runtimeEvaluate("window.location.toString()")
   ).result.value;
-  descEvent.emit("success", `${windowLocation}reloaded`);
+  emitter.emit("success", `${windowLocation}reloaded`);
 };
 
 /**
@@ -837,7 +837,7 @@ module.exports.goBack = async (
 ) => {
   validate();
   await _go(-1, options);
-  descEvent.emit("success", "Performed clicking on browser back button");
+  emitter.emit("success", "Performed clicking on browser back button");
 };
 
 /**
@@ -858,7 +858,7 @@ module.exports.goForward = async (
 ) => {
   validate();
   await _go(+1, options);
-  descEvent.emit("success", "Performed clicking on browser forward button");
+  emitter.emit("success", "Performed clicking on browser forward button");
 };
 
 const _go = async (delta, options) => {
@@ -889,7 +889,7 @@ const _go = async (delta, options) => {
  *
  * @returns {Promise<string>} - The URL of the current window.
  */
-const currentURL = async () => {
+let currentURL = async () => {
   validate();
   const locationObj = await runtimeHandler.runtimeEvaluate(
     "window.location.toString()",
@@ -909,12 +909,107 @@ module.exports.currentURL = currentURL;
  *
  * @returns {Promise<string>} - The title of the current page.
  */
-const title = async () => {
+let title = async () => {
   validate();
   const result = await runtimeHandler.runtimeEvaluate("document.title");
   return result.result.value;
 };
 module.exports.title = title;
+
+const createTestAccessors = () => ({
+  doActionAwaitingNavigation: {
+    get: () => doActionAwaitingNavigation,
+    set: (value) => {
+      doActionAwaitingNavigation = value;
+    },
+  },
+  networkHandler: {
+    get: () => networkHandler,
+    set: (value) => {
+      networkHandler = value;
+    },
+  },
+  fetchHandler: {
+    get: () => fetchHandler,
+    set: (value) => {
+      fetchHandler = value;
+    },
+  },
+  pageHandler: {
+    get: () => pageHandler,
+    set: (value) => {
+      pageHandler = value;
+    },
+  },
+  targetHandler: {
+    get: () => targetHandler,
+    set: (value) => {
+      targetHandler = value;
+    },
+  },
+  connect_to_cri: {
+    get: () => connect_to_cri,
+    set: (value) => {
+      connect_to_cri = value;
+    },
+  },
+  cleanUpListenersOnClient: {
+    get: () => cleanUpListenersOnClient,
+    set: (value) => {
+      cleanUpListenersOnClient = value;
+    },
+  },
+  validate: {
+    get: () => validate,
+    set: (value) => {
+      validate = value;
+    },
+  },
+  descEvent: {
+    get: () => emitter,
+    set: (value) => {
+      emitter = value;
+      module.exports.emitter = value;
+    },
+  },
+  _closeBrowser: {
+    get: () => _closeBrowser,
+    set: (value) => {
+      _closeBrowser = value;
+    },
+  },
+  currentURL: {
+    get: () => currentURL,
+    set: (value) => {
+      currentURL = value;
+      module.exports.currentURL = value;
+    },
+  },
+  title: {
+    get: () => title,
+    set: (value) => {
+      title = value;
+      module.exports.title = value;
+    },
+  },
+});
+
+const createTestDefaults = () => ({
+  doActionAwaitingNavigation,
+  networkHandler,
+  fetchHandler,
+  pageHandler,
+  targetHandler,
+  connect_to_cri,
+  cleanUpListenersOnClient,
+  validate,
+  descEvent: emitter,
+  _closeBrowser,
+  currentURL,
+  title,
+});
+
+defineTestHooks(module.exports, createTestAccessors(), createTestDefaults());
 
 /**
  * Fetches an element with the given selector, scrolls it into view if needed, and then clicks in the center of the element. If there's no element matching selector, the method throws an error.
@@ -2816,12 +2911,12 @@ module.exports.clearIntercept = (requestUrl) => {
   if (requestUrl) {
     const success = fetchHandler.resetInterceptor(requestUrl);
     if (success) {
-      descEvent.emit("success", `Intercepts reset for url ${requestUrl}`);
+      emitter.emit("success", `Intercepts reset for url ${requestUrl}`);
     } else {
-      descEvent.emit("success", `Intercepts not found for url ${requestUrl}`);
+      emitter.emit("success", `Intercepts not found for url ${requestUrl}`);
     }
   } else {
     fetchHandler.resetInterceptors();
-    descEvent.emit("success", "Intercepts reset for all url");
+    emitter.emit("success", "Intercepts reset for all url");
   }
 };

--- a/packages/taiko/lib/taiko.js
+++ b/packages/taiko/lib/taiko.js
@@ -1,3 +1,4 @@
+// @injectable — reassignable by test seam; see if (TAIKO_ENABLE_TEST_HOOKS) block below
 let { doActionAwaitingNavigation } = require("./doActionAwaitingNavigation");
 const helper = require("./helper");
 const {
@@ -14,9 +15,13 @@ const {
 } = helper;
 const inputHandler = require("./handlers/inputHandler");
 const domHandler = require("./handlers/domHandler");
+// @injectable — reassignable by test seam; see if (TAIKO_ENABLE_TEST_HOOKS) block below
 let networkHandler = require("./handlers/networkHandler");
+// @injectable — reassignable by test seam; see if (TAIKO_ENABLE_TEST_HOOKS) block below
 let fetchHandler = require("./handlers/fetchHandler");
+// @injectable — reassignable by test seam; see if (TAIKO_ENABLE_TEST_HOOKS) block below
 let pageHandler = require("./handlers/pageHandler");
+// @injectable — reassignable by test seam; see if (TAIKO_ENABLE_TEST_HOOKS) block below
 let targetHandler = require("./handlers/targetHandler");
 const runtimeHandler = require("./handlers/runtimeHandler");
 const browserHandler = require("./handlers/browserHandler");
@@ -43,6 +48,7 @@ const crypto = require("node:crypto");
 const { eventHandler, eventRegexMap } = require("./eventBus");
 const { highlightElement } = require("./elements/elementHelper");
 const { launchBrowser } = require("./browser/launcher");
+// @injectable — connect_to_cri, cleanUpListenersOnClient, validate are reassignable by test seam
 let {
   connect_to_cri,
   closeConnection,
@@ -51,7 +57,6 @@ let {
   getClient,
 } = require("./connection");
 const { getPlugins, registerHooks } = require("./plugins");
-const { defineTestHooks } = require("./testHooks");
 let eventHandlerProxy;
 let emitter = descEvent;
 
@@ -916,100 +921,104 @@ let title = async () => {
 };
 module.exports.title = title;
 
-const createTestAccessors = () => ({
-  doActionAwaitingNavigation: {
-    get: () => doActionAwaitingNavigation,
-    set: (value) => {
-      doActionAwaitingNavigation = value;
+// ─── TEST SEAM ─── active only when TAIKO_ENABLE_TEST_HOOKS=1 ───────────────
+// createTestAccessors and createTestDefaults MUST live in this file because
+// they close over module-private variables. See test-support/testHooks.js.
+if (process.env.TAIKO_ENABLE_TEST_HOOKS) {
+  const { defineTestHooks } = require("../test-support/testHooks");
+  const createTestAccessors = () => ({
+    doActionAwaitingNavigation: {
+      get: () => doActionAwaitingNavigation,
+      set: (value) => {
+        doActionAwaitingNavigation = value;
+      },
     },
-  },
-  networkHandler: {
-    get: () => networkHandler,
-    set: (value) => {
-      networkHandler = value;
+    networkHandler: {
+      get: () => networkHandler,
+      set: (value) => {
+        networkHandler = value;
+      },
     },
-  },
-  fetchHandler: {
-    get: () => fetchHandler,
-    set: (value) => {
-      fetchHandler = value;
+    fetchHandler: {
+      get: () => fetchHandler,
+      set: (value) => {
+        fetchHandler = value;
+      },
     },
-  },
-  pageHandler: {
-    get: () => pageHandler,
-    set: (value) => {
-      pageHandler = value;
+    pageHandler: {
+      get: () => pageHandler,
+      set: (value) => {
+        pageHandler = value;
+      },
     },
-  },
-  targetHandler: {
-    get: () => targetHandler,
-    set: (value) => {
-      targetHandler = value;
+    targetHandler: {
+      get: () => targetHandler,
+      set: (value) => {
+        targetHandler = value;
+      },
     },
-  },
-  connect_to_cri: {
-    get: () => connect_to_cri,
-    set: (value) => {
-      connect_to_cri = value;
+    connect_to_cri: {
+      get: () => connect_to_cri,
+      set: (value) => {
+        connect_to_cri = value;
+      },
     },
-  },
-  cleanUpListenersOnClient: {
-    get: () => cleanUpListenersOnClient,
-    set: (value) => {
-      cleanUpListenersOnClient = value;
+    cleanUpListenersOnClient: {
+      get: () => cleanUpListenersOnClient,
+      set: (value) => {
+        cleanUpListenersOnClient = value;
+      },
     },
-  },
-  validate: {
-    get: () => validate,
-    set: (value) => {
-      validate = value;
+    validate: {
+      get: () => validate,
+      set: (value) => {
+        validate = value;
+      },
     },
-  },
-  descEvent: {
-    get: () => emitter,
-    set: (value) => {
-      emitter = value;
-      module.exports.emitter = value;
+    descEvent: {
+      get: () => emitter,
+      set: (value) => {
+        emitter = value;
+        module.exports.emitter = value;
+      },
     },
-  },
-  _closeBrowser: {
-    get: () => _closeBrowser,
-    set: (value) => {
-      _closeBrowser = value;
+    _closeBrowser: {
+      get: () => _closeBrowser,
+      set: (value) => {
+        _closeBrowser = value;
+      },
     },
-  },
-  currentURL: {
-    get: () => currentURL,
-    set: (value) => {
-      currentURL = value;
-      module.exports.currentURL = value;
+    currentURL: {
+      get: () => currentURL,
+      set: (value) => {
+        currentURL = value;
+        module.exports.currentURL = value;
+      },
     },
-  },
-  title: {
-    get: () => title,
-    set: (value) => {
-      title = value;
-      module.exports.title = value;
+    title: {
+      get: () => title,
+      set: (value) => {
+        title = value;
+        module.exports.title = value;
+      },
     },
-  },
-});
-
-const createTestDefaults = () => ({
-  doActionAwaitingNavigation,
-  networkHandler,
-  fetchHandler,
-  pageHandler,
-  targetHandler,
-  connect_to_cri,
-  cleanUpListenersOnClient,
-  validate,
-  descEvent: emitter,
-  _closeBrowser,
-  currentURL,
-  title,
-});
-
-defineTestHooks(module.exports, createTestAccessors(), createTestDefaults());
+  });
+  const createTestDefaults = () => ({
+    doActionAwaitingNavigation,
+    networkHandler,
+    fetchHandler,
+    pageHandler,
+    targetHandler,
+    connect_to_cri,
+    cleanUpListenersOnClient,
+    validate,
+    descEvent: emitter,
+    _closeBrowser,
+    currentURL,
+    title,
+  });
+  defineTestHooks(module.exports, createTestAccessors(), createTestDefaults());
+}
 
 /**
  * Fetches an element with the given selector, scrolls it into view if needed, and then clicks in the center of the element. If there's no element matching selector, the method throws an error.

--- a/packages/taiko/lib/testHooks.js
+++ b/packages/taiko/lib/testHooks.js
@@ -1,0 +1,42 @@
+const defineTestHooks = (target, accessors, defaults) => {
+  Object.defineProperties(target, {
+    __set__: {
+      enumerable: false,
+      value: (key, value) => {
+        if (!Object.hasOwn(accessors, key)) {
+          throw new Error(`Unsupported test override: ${key}`);
+        }
+        accessors[key].set(value);
+      },
+    },
+    __get__: {
+      enumerable: false,
+      value: (key) => {
+        if (!Object.hasOwn(accessors, key)) {
+          throw new Error(`Unsupported test lookup: ${key}`);
+        }
+        return accessors[key].get();
+      },
+    },
+    __reset__: {
+      enumerable: false,
+      value: () => {
+        for (const [key, value] of Object.entries(defaults)) {
+          accessors[key].set(value);
+        }
+      },
+    },
+  });
+};
+
+const defineHiddenTestProperty = (target, key, value) => {
+  Object.defineProperty(target, key, {
+    enumerable: false,
+    value,
+  });
+};
+
+module.exports = {
+  defineTestHooks,
+  defineHiddenTestProperty,
+};

--- a/packages/taiko/lib/util.js
+++ b/packages/taiko/lib/util.js
@@ -1,9 +1,9 @@
 const isWin = require("node:os").platform() === "win32";
 const Module = require("node:module");
-const nodeURL = require("node:url");
 const path = require("node:path");
-const { spawnSync } = require("node:child_process");
-const { readFileSync, existsSync, realpathSync } = require("node:fs");
+let { spawnSync } = require("node:child_process");
+let { readFileSync, existsSync, realpathSync } = require("node:fs");
+const { defineTestHooks } = require("./testHooks");
 
 module.exports.removeQuotes = (textWithQuotes, textWithoutQuotes) => {
   return textWithQuotes
@@ -43,13 +43,13 @@ module.exports.isSameUrl = (url1, url2) => {
   if (url1 === url2) {
     return true;
   }
-  const parsedUrl1 = nodeURL.parse(url1);
-  const parsedUrl2 = nodeURL.parse(url2);
+  const parsedUrl1 = new URL(url1);
+  const parsedUrl2 = new URL(url2);
   if (
     parsedUrl1.protocol === "file:" &&
     parsedUrl2.protocol === "file:" &&
-    path.relative(parsedUrl1.path, parsedUrl2.path) === "" &&
-    parsedUrl1.query === parsedUrl2.query &&
+    path.relative(parsedUrl1.pathname, parsedUrl2.pathname) === "" &&
+    parsedUrl1.search === parsedUrl2.search &&
     parsedUrl1.hash === parsedUrl2.hash
   ) {
     return true;
@@ -93,3 +93,32 @@ module.exports.taikoInstallationLocation = () => {
   }
   return installLocation;
 };
+
+const createTestAccessors = () => ({
+  spawnSync: {
+    get: () => spawnSync,
+    set: (value) => {
+      spawnSync = value;
+    },
+  },
+  readFileSync: {
+    get: () => readFileSync,
+    set: (value) => {
+      readFileSync = value;
+    },
+  },
+  existsSync: {
+    get: () => existsSync,
+    set: (value) => {
+      existsSync = value;
+    },
+  },
+});
+
+const createTestDefaults = () => ({
+  spawnSync,
+  readFileSync,
+  existsSync,
+});
+
+defineTestHooks(module.exports, createTestAccessors(), createTestDefaults());

--- a/packages/taiko/lib/util.js
+++ b/packages/taiko/lib/util.js
@@ -1,9 +1,11 @@
 const isWin = require("node:os").platform() === "win32";
 const Module = require("node:module");
 const path = require("node:path");
+// @injectable — reassignable by test seam; see if (TAIKO_ENABLE_TEST_HOOKS) block below
 let { spawnSync } = require("node:child_process");
-let { readFileSync, existsSync, realpathSync } = require("node:fs");
-const { defineTestHooks } = require("./testHooks");
+const { realpathSync } = require("node:fs");
+// @injectable — reassignable by test seam; see if (TAIKO_ENABLE_TEST_HOOKS) block below
+let { readFileSync, existsSync } = require("node:fs");
 
 module.exports.removeQuotes = (textWithQuotes, textWithoutQuotes) => {
   return textWithQuotes
@@ -94,31 +96,35 @@ module.exports.taikoInstallationLocation = () => {
   return installLocation;
 };
 
-const createTestAccessors = () => ({
-  spawnSync: {
-    get: () => spawnSync,
-    set: (value) => {
-      spawnSync = value;
+// ─── TEST SEAM ─── active only when TAIKO_ENABLE_TEST_HOOKS=1 ───────────────
+// createTestAccessors and createTestDefaults MUST live in this file because
+// they close over module-private variables. See test-support/testHooks.js.
+if (process.env.TAIKO_ENABLE_TEST_HOOKS) {
+  const { defineTestHooks } = require("../test-support/testHooks");
+  const createTestAccessors = () => ({
+    spawnSync: {
+      get: () => spawnSync,
+      set: (value) => {
+        spawnSync = value;
+      },
     },
-  },
-  readFileSync: {
-    get: () => readFileSync,
-    set: (value) => {
-      readFileSync = value;
+    readFileSync: {
+      get: () => readFileSync,
+      set: (value) => {
+        readFileSync = value;
+      },
     },
-  },
-  existsSync: {
-    get: () => existsSync,
-    set: (value) => {
-      existsSync = value;
+    existsSync: {
+      get: () => existsSync,
+      set: (value) => {
+        existsSync = value;
+      },
     },
-  },
-});
-
-const createTestDefaults = () => ({
-  spawnSync,
-  readFileSync,
-  existsSync,
-});
-
-defineTestHooks(module.exports, createTestAccessors(), createTestDefaults());
+  });
+  const createTestDefaults = () => ({
+    spawnSync,
+    readFileSync,
+    existsSync,
+  });
+  defineTestHooks(module.exports, createTestAccessors(), createTestDefaults());
+}

--- a/packages/taiko/package.json
+++ b/packages/taiko/package.json
@@ -27,12 +27,6 @@
     "headless-testing",
     "headless-browser"
   ],
-  "lint-staged": {
-    "**/*.{js,ts}": [
-      "npm run lint:fix",
-      "git add"
-    ]
-  },
   "taiko": {
     "browser": {
       "version": "140.0.7339.82",
@@ -63,12 +57,6 @@
       }
     }
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged && npm run test:api",
-      "pre-push": "npm test"
-    }
-  },
   "author": "getgauge",
   "license": "MIT",
   "dependencies": {
@@ -88,19 +76,9 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.1.2",
-    "@types/chai": "^4.3.4",
-    "@types/chai-as-promised": "^7.1.5",
-    "chai": "^4.3.7",
-    "chai-as-promised": "^7.1.1",
     "clean-css": "^5.3.1",
-    "cssnano": "^5.1.14",
     "eleventy-plugin-toc": "^1.1.5",
     "markdown-it": "^14.1.1",
-    "markdown-it-anchor": "^9.2.0",
-    "mocha": "^10.4.0",
-    "ncp": "^2.0.0",
-    "rewire": "^9.0.1",
-    "sinon": "^15.0.1",
-    "typescript": "^4.9.4"
+    "markdown-it-anchor": "^9.2.0"
   }
 }

--- a/packages/taiko/test-support/testHooks.js
+++ b/packages/taiko/test-support/testHooks.js
@@ -1,3 +1,14 @@
+/**
+ * TEST SEAM UTILITIES — not shipped in production (excluded via .npmignore).
+ *
+ * This module is only loaded when TAIKO_ENABLE_TEST_HOOKS=1.
+ * It is required from within production modules (taiko.js, util.js, repl.js)
+ * because the injected variables are module-private and closures must live
+ * in the same module scope. The require() calls are guarded by
+ * process.env.TAIKO_ENABLE_TEST_HOOKS so this file is never loaded in
+ * production environments.
+ */
+
 const defineTestHooks = (target, accessors, defaults) => {
   Object.defineProperties(target, {
     __set__: {

--- a/tests/functional-tests/package-lock.json
+++ b/tests/functional-tests/package-lock.json
@@ -19,6 +19,23 @@
         "the-internet-express": "git+https://github.com/getgauge-contrib/the-internet-express.git"
       }
     },
+    "..": {
+      "name": "taiko-tests",
+      "version": "1.4.7",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "taiko": "*"
+      },
+      "devDependencies": {
+        "chai": "^4.3.7",
+        "chai-as-promised": "^7.1.1",
+        "mocha": "^10.4.0",
+        "ncp": "^2.0.0",
+        "rewire": "^9.0.1",
+        "sinon": "^15.0.1"
+      }
+    },
     "../..": {
       "name": "taiko-workspace",
       "version": "1.4.8",
@@ -26,26 +43,53 @@
       "workspaces": [
         "packages/*",
         "tests"
-      ],
+      ]
+    },
+    "../../packages/examples": {
+      "name": "taiko-examples",
+      "version": "0.7.0",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "taiko": "*"
+      },
       "devDependencies": {
-        "@11ty/eleventy": "^2.0.1",
-        "@biomejs/biome": "^1.8.3",
-        "husky": "^8.0.3",
-        "lint-staged": "^16.2.7",
-        "markdown-it": "^13.0.1",
-        "markdown-it-anchor": "^8.6.6",
-        "mocha": "^10.4.0",
-        "ncp": "^2.0.0",
-        "rewire": "^9.0.1",
-        "sinon": "^15.0.1",
-        "typescript": "^4.9.4"
->>>>>>> 60fd1c9 (Update gitignore)
+        "chai": "^4.2.0"
+      }
+    },
+    "../../packages/taiko": {
+      "version": "1.4.8",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "chrome-remote-interface": "^0.33.0",
+        "commander": "^9.5.0",
+        "debug": "^4.3.4",
+        "devtools-protocol": "0.0.1082910",
+        "documentation": "^14.0.1",
+        "extract-zip": "^2.0.1",
+        "fs-extra": "^11.1.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-reachable": "^5.2.1",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "recast": "^0.23.1"
+      },
+      "bin": {
+        "taiko": "bin/taiko.js"
+      },
+      "devDependencies": {
+        "@11ty/eleventy": "^3.1.2",
+        "clean-css": "^5.3.1",
+        "eleventy-plugin-toc": "^1.1.5",
+        "markdown-it": "^14.1.1",
+        "markdown-it-anchor": "^9.2.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.24.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -53,9 +97,7 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.24.5",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -63,14 +105,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.24.5",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -79,14 +116,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.24.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
+        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -94,8 +130,6 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -105,25 +139,23 @@
       }
     },
     "node_modules/@getgauge/cli": {
-      "version": "1.6.25",
-      "resolved": "https://registry.npmjs.org/@getgauge/cli/-/cli-1.6.25.tgz",
-      "integrity": "sha512-F43+KyptWQL4PLoky4FZmQkB3RpAawnAlWiR0C8zua8o7JH5Z8rnKYkke6ATKMp0Yml3Lts2SqqgJwE1cWopbw==",
+      "version": "1.6.30",
+      "resolved": "https://registry.npmjs.org/@getgauge/cli/-/cli-1.6.30.tgz",
+      "integrity": "sha512-zipyAAbOkhyboj3L+fjt84t8tw9dCJFqKTjLnsiuuFk4s2AXIa9Zx/PZ1i++uRpjq4lJrOBwT2qZaiJPCvvKxQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "adm-zip": "^0.5.16"
+        "adm-zip": "^0.5.17"
       },
       "bin": {
         "gauge": "bin/gauge"
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.10.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.8.0",
+        "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -131,14 +163,12 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
-      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "version": "0.7.13",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.5.3",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -150,23 +180,17 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.4.15",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -175,8 +199,6 @@
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
-      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -185,32 +207,22 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -219,71 +231,51 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "version": "1.0.11",
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
-      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -296,8 +288,6 @@
     },
     "node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -308,33 +298,16 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.2",
       "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk/node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -342,8 +315,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -351,8 +322,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -366,42 +335,30 @@
     },
     "node_modules/append-field": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/assert-never": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
-      "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
+      "version": "1.2.1",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",
-      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
-      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -413,8 +370,6 @@
     },
     "node_modules/body-parser": {
       "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha512-YQyoqQG3sO8iCmf8+hyVpgHHOv0/hCEFiS4zTGUwTA1HjAFX66wRcNQrVCeJq9pgESMRvUAOvSil5MJlmccuKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -435,15 +390,11 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/busboy": {
       "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
-      "integrity": "sha512-InWFDomvlkEj+xWLBfU3AvnbVYqeTWmQopiW0tWWEy5yehYm2YkGEc59sUmw/4ty5Zj/b0WHGs1LgecuBSBGrg==",
       "dev": true,
       "dependencies": {
         "dicer": "0.2.5",
@@ -455,37 +406,22 @@
     },
     "node_modules/bytes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+    "node_modules/call-bind": {
+      "version": "1.0.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -496,8 +432,6 @@
     },
     "node_modules/character-parser": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -506,8 +440,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -520,8 +452,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -532,14 +462,10 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "engines": [
         "node >= 0.8"
@@ -554,15 +480,11 @@
     },
     "node_modules/concat-stream/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -577,8 +499,6 @@
     },
     "node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -587,8 +507,6 @@
     },
     "node_modules/constantinople": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
-      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -598,8 +516,6 @@
     },
     "node_modules/content-disposition": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -608,8 +524,6 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -617,9 +531,7 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "0.4.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -627,13 +539,11 @@
       }
     },
     "node_modules/cookie-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
-      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "version": "1.4.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cookie": "0.7.2",
+        "cookie": "0.4.1",
         "cookie-signature": "1.0.6"
       },
       "engines": {
@@ -642,38 +552,44 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -682,15 +598,11 @@
     },
     "node_modules/destroy": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dicer": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-      "integrity": "sha512-FDvbtnq7dzlPz0wyYlOExifDEZcu8h+rErEXgfxqmLfRfC/kJidEFh4+effJRO3P0xmfqyPbSMG0LveNRfTKVg==",
       "dev": true,
       "dependencies": {
         "readable-stream": "1.1.x",
@@ -701,9 +613,7 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "version": "4.0.2",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -711,43 +621,20 @@
     },
     "node_modules/doctypes": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -755,42 +642,26 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "version": "3.1.2",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -798,15 +669,11 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -815,8 +682,6 @@
     },
     "node_modules/express": {
       "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -857,8 +722,6 @@
     },
     "node_modules/express/node_modules/cookie": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -867,8 +730,6 @@
     },
     "node_modules/finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -886,8 +747,6 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -896,8 +755,6 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -906,8 +763,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -915,9 +770,7 @@
       }
     },
     "node_modules/gauge-ts": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/gauge-ts/-/gauge-ts-0.3.6.tgz",
-      "integrity": "sha512-IUWZj7q2Ta82l5BWvoCAEzzVLIZetcSqrGnBdvwgG7FVeyIQV8LlOzyHztv2zrpnaBtuYz2dSZEYc1qTmhYXhw==",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.9",
@@ -929,30 +782,21 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "version": "1.2.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -961,30 +805,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/google-protobuf": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
-      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "version": "3.21.2",
       "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.3",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -995,9 +843,7 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "version": "1.0.3",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1009,8 +855,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1025,8 +869,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1038,8 +880,6 @@
     },
     "node_modules/http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1054,8 +894,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1067,15 +905,11 @@
     },
     "node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1083,16 +917,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.13.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1100,8 +929,6 @@
     },
     "node_modules/is-expression": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
-      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1111,8 +938,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1120,22 +945,16 @@
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "version": "1.1.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1146,22 +965,16 @@
     },
     "node_modules/isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jstransformer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1171,36 +984,18 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "version": "5.2.3",
       "license": "Apache-2.0"
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "license": "ISC"
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1209,15 +1004,11 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1226,8 +1017,6 @@
     },
     "node_modules/mime": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1236,8 +1025,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1246,8 +1033,6 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1259,8 +1044,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1269,8 +1052,6 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1282,16 +1063,11 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/multer": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.4.tgz",
-      "integrity": "sha512-2wY2+xD4udX612aMqMcB8Ws2Voq6NIUPEtD1be6m411T4uDH/VtL9i//xvcyFlTVfRdaBsk7hV5tgrGQqhuBiw==",
-      "deprecated": "Multer 1.x is affected by CVE-2022-24434. This is fixed in v1.4.4-lts.1 which drops support for versions of Node.js before 6. Please upgrade to at least Node.js 6 and version 1.4.4-lts.1 of Multer. If you need support for older versions of Node.js, we are open to accepting patches that would fix the CVE on the main 1.x release line, whilst maintaining compatibility with Node.js 0.10.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1310,8 +1086,6 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1320,8 +1094,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1330,8 +1102,6 @@
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1343,8 +1113,6 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1353,29 +1121,21 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/promise": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1383,9 +1143,7 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.3.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1408,8 +1166,6 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1421,13 +1177,11 @@
       }
     },
     "node_modules/pug": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
-      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
+      "version": "3.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "pug-code-gen": "^3.0.3",
+        "pug-code-gen": "^3.0.2",
         "pug-filters": "^4.0.0",
         "pug-lexer": "^5.0.1",
         "pug-linker": "^4.0.0",
@@ -1439,8 +1193,6 @@
     },
     "node_modules/pug-attrs": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
-      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1450,9 +1202,7 @@
       }
     },
     "node_modules/pug-code-gen": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
-      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
+      "version": "3.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1460,23 +1210,19 @@
         "doctypes": "^1.1.0",
         "js-stringify": "^1.0.2",
         "pug-attrs": "^3.0.0",
-        "pug-error": "^2.1.0",
-        "pug-runtime": "^3.0.1",
+        "pug-error": "^2.0.0",
+        "pug-runtime": "^3.0.0",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
       }
     },
     "node_modules/pug-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
-      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
+      "version": "2.0.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
-      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1489,8 +1235,6 @@
     },
     "node_modules/pug-lexer": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
-      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1501,8 +1245,6 @@
     },
     "node_modules/pug-linker": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
-      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1512,8 +1254,6 @@
     },
     "node_modules/pug-load": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
-      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1523,8 +1263,6 @@
     },
     "node_modules/pug-parser": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
-      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1534,15 +1272,11 @@
     },
     "node_modules/pug-runtime": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
-      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pug-strip-comments": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
-      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1551,15 +1285,11 @@
     },
     "node_modules/pug-walk": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
-      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1568,8 +1298,6 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1578,8 +1306,6 @@
     },
     "node_modules/raw-body": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1594,8 +1320,6 @@
     },
     "node_modules/readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1607,29 +1331,22 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.8",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1637,22 +1354,16 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/send": {
       "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1676,8 +1387,6 @@
     },
     "node_modules/serve-static": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1690,17 +1399,29 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/statuses": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1709,8 +1430,6 @@
     },
     "node_modules/streamsearch": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -1718,15 +1437,11 @@
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -1739,8 +1454,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1751,8 +1464,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1779,17 +1490,21 @@
         "pug": "^3.0.1"
       }
     },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/token-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
-      "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -1830,9 +1545,7 @@
       }
     },
     "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.11.3",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1843,8 +1556,6 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1857,15 +1568,11 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.4.5",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1876,15 +1583,13 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1893,15 +1598,11 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1910,8 +1611,6 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -1919,14 +1618,10 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1935,8 +1630,6 @@
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1945,8 +1638,6 @@
     },
     "node_modules/with": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
-      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1961,8 +1652,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -1978,8 +1667,6 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1988,8 +1675,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -1997,8 +1682,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -2015,8 +1698,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2024,8 +1705,6 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,11 +15,10 @@
     "taiko": "*"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.4",
-    "@types/chai-as-promised": "^7.1.5",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "mocha": "^10.4.0",
+    "ncp": "^2.0.0",
     "rewire": "^9.0.1",
     "sinon": "^15.0.1"
   },

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "scripts": {
     "test:api": "node unit-tests/taiko-test.js",
-    "test:unit:silent": "node ../node_modules/mocha/bin/mocha.js 'unit-tests/**/*.test.js' --timeout 9000 -R dot --trace-warnings --exit",
-    "test:unit": "node ../node_modules/mocha/bin/mocha.js 'unit-tests/**/*.test.js' --timeout 9000 --trace-warnings --exit",
+    "test:unit:silent": "node ../node_modules/mocha/bin/mocha.js 'unit-tests/**/*.test.js' --require unit-tests/setup.js --timeout 9000 -R dot --trace-warnings --exit",
+    "test:unit": "node ../node_modules/mocha/bin/mocha.js 'unit-tests/**/*.test.js' --require unit-tests/setup.js --timeout 9000 --trace-warnings --exit",
     "test": "npm run test:api && npm run test:unit:silent",
     "test-functional": "npm install && cd functional-tests && npm install && npm test",
     "test-docs": "cd docs-tests && node prepare.js && eleventy && cd ./gauge && npm ci && npm test"

--- a/tests/unit-tests/browserLauncher.test.js
+++ b/tests/unit-tests/browserLauncher.test.js
@@ -1,9 +1,24 @@
 const chai = require("chai");
 const expect = chai.expect;
 const rewire = require("rewire");
+const { once } = require("node:events");
 const { openBrowserArgs } = require("./test-util");
 const { openBrowser, closeBrowser } = require("taiko");
 const { eventHandler } = require("taiko/lib/eventBus");
+
+const waitForEvent = (emitter, eventName, timeout = 1000) => {
+  let timeoutId;
+  return Promise.race([
+    once(emitter, eventName),
+    new Promise((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new Error(`Timed out waiting for ${eventName}`));
+      }, timeout);
+    }),
+  ]).finally(() => {
+    clearTimeout(timeoutId);
+  });
+};
 
 describe("OpenBrowser", () => {
   let browserLauncher;
@@ -45,19 +60,15 @@ describe("OpenBrowser", () => {
     });
 
     it("should emit browserCrashed event when chrome process crashes", async () => {
-      let browserCrashedEmitted = false;
-      eventHandler.on("browserCrashed", () => {
-        browserCrashedEmitted = true;
-      });
+      const browserCrashed = waitForEvent(eventHandler, "browserCrashed");
       browserProcess.kill("SIGKILL");
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
-      expect(browserCrashedEmitted).to.be.true;
+      await browserCrashed;
     });
 
     it("should allow to open a browser after chrome process crashes", async () => {
+      const browserExit = waitForEvent(browserProcess, "exit");
       browserProcess.kill("SIGKILL");
+      await browserExit;
       await openBrowser(openBrowserArgs);
       await closeBrowser();
     });

--- a/tests/unit-tests/clearIntercept.test.js
+++ b/tests/unit-tests/clearIntercept.test.js
@@ -1,16 +1,16 @@
 const expect = require("chai").expect;
 const { EventEmitter } = require("node:events");
-const rewire = require("rewire");
 
 describe("clearIntercept", () => {
   let validateEmitterEvent;
   let taiko;
   before(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   after(() => {
-    rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   beforeEach(() => {

--- a/tests/unit-tests/closeTab.test.js
+++ b/tests/unit-tests/closeTab.test.js
@@ -1,6 +1,5 @@
 const expect = require("chai").expect;
 const { EventEmitter } = require("node:events");
-const rewire = require("rewire");
 
 describe("closeTab", () => {
   let _targets = { matching: [], others: [] };
@@ -24,7 +23,8 @@ describe("closeTab", () => {
     });
 
   before(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
     const targetRegistry = new Map();
     const mockHandler = {
       closeTarget: () => {},
@@ -64,11 +64,10 @@ describe("closeTab", () => {
       currentTarget = target;
       return currentTarget;
     });
-    taiko.__set__("dom", { getDocument: async () => {} });
   });
 
   after(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   beforeEach(() => {

--- a/tests/unit-tests/cookies.test.js
+++ b/tests/unit-tests/cookies.test.js
@@ -1,6 +1,5 @@
 const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
-const rewire = require("rewire");
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 const test_name = "cookies";
@@ -8,12 +7,13 @@ const test_name = "cookies";
 describe(test_name, () => {
   let taiko;
   before(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
     taiko.__set__("validate", () => {});
   });
 
   after(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   it("setCookie should throw error if url or domain is not specified", async () => {

--- a/tests/unit-tests/goBack.test.js
+++ b/tests/unit-tests/goBack.test.js
@@ -1,5 +1,4 @@
 const { expect } = require("chai");
-const rewire = require("rewire");
 
 const test_name = "goBack";
 
@@ -13,14 +12,15 @@ describe(test_name, () => {
       actualOptions = options;
       await cb();
     };
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
     taiko.__set__("doActionAwaitingNavigation", mockWrapper);
     taiko.__set__("validate", () => {});
   });
 
   after(async () => {
     actualOptions = null;
-    taiko = rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   describe("to about blank page", () => {

--- a/tests/unit-tests/goto.test.js
+++ b/tests/unit-tests/goto.test.js
@@ -1,4 +1,3 @@
-const rewire = require("rewire");
 const expect = require("chai").expect;
 const test_name = "Goto";
 
@@ -11,7 +10,8 @@ describe(test_name, () => {
   let validateCalled = false;
 
   before(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
     const mockWrapper = async (options, cb) => {
       actualOptions = options;
       await cb();
@@ -46,7 +46,7 @@ describe(test_name, () => {
   });
 
   after(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   afterEach(() => {

--- a/tests/unit-tests/goto.test.js
+++ b/tests/unit-tests/goto.test.js
@@ -62,40 +62,45 @@ describe(test_name, () => {
     expect(validateCalled).to.be.true;
   });
 
-  it("should not alter the url if protocol is given", async () => {
-    let expectedUrl = "https://example.com";
-    await taiko.goto(expectedUrl);
-    expect(actualUrl).to.equal(expectedUrl);
+  const urlTransformCases = [
+    {
+      label: "https protocol untouched",
+      input: "https://example.com",
+      expected: "https://example.com",
+    },
+    {
+      label: "file protocol untouched",
+      input: "file://example.com",
+      expected: "file://example.com",
+    },
+    {
+      label: "chrome-extension protocol untouched",
+      input: "chrome-extension://gjaerjgaerjeoareapoj/internalPage.html",
+      expected: "chrome-extension://gjaerjgaerjeoareapoj/internalPage.html",
+    },
+    {
+      label: "adds http:// when no protocol given",
+      input: "example.com",
+      expected: "http://example.com",
+    },
+    {
+      label: 'does not add http:// for "about:*" urls',
+      input: "about:randomString",
+      expected: "about:randomString",
+    },
+    {
+      label: "adds http:// for url with port specified",
+      input: "localhost:8080",
+      expected: "http://localhost:8080",
+    },
+  ];
 
-    expectedUrl = "file://example.com";
-    await taiko.goto(expectedUrl);
-    expect(actualUrl).to.equal(expectedUrl);
-
-    expectedUrl = "chrome-extension://gjaerjgaerjeoareapoj/internalPage.html";
-    await taiko.goto(expectedUrl);
-    expect(actualUrl).to.equal(expectedUrl);
-  });
-
-  it("should add protocol http:// if not given", async () => {
-    const urlWithoutProtocol = "example.com";
-    const expectedUrl = `http://${urlWithoutProtocol}`;
-    await taiko.goto(urlWithoutProtocol);
-    expect(actualUrl).to.equal(expectedUrl);
-  });
-
-  it('should not add protocol http:// if url is "about:*"', async () => {
-    const aboutBlank = "about:randomString";
-    const expectedUrl = aboutBlank;
-    await taiko.goto(aboutBlank);
-    expect(actualUrl).to.equal(expectedUrl);
-  });
-
-  it("should add protocol http:// for url with port specified", async () => {
-    const urlWithPort = "localhost:8080";
-    const expectedUrl = `http://${urlWithPort}`;
-    await taiko.goto(urlWithPort);
-    expect(actualUrl).to.equal(expectedUrl);
-  });
+  for (const { label, input, expected } of urlTransformCases) {
+    it(`URL: ${label}`, async () => {
+      await taiko.goto(input);
+      expect(actualUrl, `navigated URL for input "${input}"`).to.equal(expected);
+    });
+  }
 
   it("should configure provided headers for the domain", async () => {
     const options = {

--- a/tests/unit-tests/openBrowser.test.js
+++ b/tests/unit-tests/openBrowser.test.js
@@ -1,36 +1,49 @@
 const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
 const expect = chai.expect;
 
+chai.use(chaiAsPromised);
+
 const { openBrowserArgs } = require("./test-util");
+
 describe("OpenBrowser", () => {
   let taiko;
   let openBrowser;
   let closeBrowser;
+
   before(() => {
     taiko = require("taiko/lib/taiko");
     taiko.__reset__();
     openBrowser = taiko.openBrowser;
     closeBrowser = taiko.closeBrowser;
   });
+
   after(() => {
     taiko.__reset__();
   });
-  describe("throws an error", () => {
-    it("openBrowser should throw an error when options parameter is string", async () =>
-      await openBrowser("someString").catch((error) =>
-        expect(error).to.be.an.instanceOf(Error),
-      ));
-    it("openBrowser should throw an error when options parameter is array", async () =>
-      await openBrowser([]).catch((error) =>
-        expect(error).to.be.an.instanceOf(Error),
-      ));
 
-    it("openBrowser should throw error, when it is called before closeBrowser is called", async () => {
+  describe("throws an error", () => {
+    it("openBrowser should throw an error when options parameter is string", async () => {
+      await expect(openBrowser("someString")).to.eventually.be.rejectedWith(Error);
+    });
+
+    it("openBrowser should throw an error when options parameter is array", async () => {
+      await expect(openBrowser([])).to.eventually.be.rejectedWith(Error);
+    });
+  });
+
+  describe("when browser is already open", () => {
+    afterEach(async () => {
+      try {
+        await closeBrowser();
+      } catch (_) {
+        // ignore — browser may not have opened successfully
+      }
+    });
+
+    it("openBrowser should throw error when called before closeBrowser", async () => {
       await openBrowser(openBrowserArgs);
-      await openBrowser(openBrowserArgs).catch((error) =>
-        expect(error).to.be.an.instanceOf(Error),
-      );
-      await closeBrowser();
+      await expect(openBrowser(openBrowserArgs)).to.eventually.be.rejectedWith(Error);
     });
   });
 });

--- a/tests/unit-tests/openBrowser.test.js
+++ b/tests/unit-tests/openBrowser.test.js
@@ -1,6 +1,5 @@
 const chai = require("chai");
 const expect = chai.expect;
-const rewire = require("rewire");
 
 const { openBrowserArgs } = require("./test-util");
 describe("OpenBrowser", () => {
@@ -8,12 +7,13 @@ describe("OpenBrowser", () => {
   let openBrowser;
   let closeBrowser;
   before(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
     openBrowser = taiko.openBrowser;
     closeBrowser = taiko.closeBrowser;
   });
   after(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
   describe("throws an error", () => {
     it("openBrowser should throw an error when options parameter is string", async () =>

--- a/tests/unit-tests/openTab.test.js
+++ b/tests/unit-tests/openTab.test.js
@@ -1,6 +1,5 @@
 const expect = require("chai").expect;
 const { EventEmitter } = require("node:events");
-const rewire = require("rewire");
 const { fail } = require("node:assert");
 
 describe("openTab", () => {
@@ -11,7 +10,8 @@ describe("openTab", () => {
   const target = "TARGET";
 
   before(async () => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
 
     const mockConnectToCri = (tgt) => {
       actualTarget = tgt;
@@ -47,7 +47,7 @@ describe("openTab", () => {
   });
 
   after(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   afterEach(() => {

--- a/tests/unit-tests/repl.test.js
+++ b/tests/unit-tests/repl.test.js
@@ -1,0 +1,145 @@
+const chai = require("chai");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const repl = require("node:repl");
+const { PassThrough } = require("node:stream");
+
+const expect = chai.expect;
+const taikoRepl = require("taiko/lib/repl/repl");
+
+const waitForRepl = (delay = 50) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+
+async function createReplSession() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const logs = [];
+  let renderedOutput = "";
+  const originalStart = repl.start;
+  const originalLog = console.log;
+
+  output.on("data", (chunk) => {
+    renderedOutput += chunk.toString();
+  });
+
+  repl.start = (options) =>
+    originalStart({ ...options, input, output, terminal: false });
+  console.log = (...args) => {
+    logs.push(args.join(" "));
+  };
+
+  const fakeTaiko = {
+    emitter: { on() {} },
+    metadata: { Helpers: [] },
+    client: () => null,
+    openBrowser: async () => {},
+    goto: async () => {},
+    write: async () => {},
+    press: async () => {},
+    closeBrowser: async () => {},
+  };
+
+  const session = await taikoRepl.initialize(fakeTaiko);
+  await waitForRepl();
+
+  return {
+    input,
+    logs,
+    session,
+    renderedOutput: () => renderedOutput,
+    restore: () => {
+      repl.start = originalStart;
+      console.log = originalLog;
+    },
+  };
+}
+
+async function runCommands(input, commands) {
+  for (const command of commands) {
+    input.write(`${command}\n`);
+    await waitForRepl();
+  }
+}
+
+describe("repl", function () {
+  this.timeout(5000);
+
+  let replSession;
+
+  afterEach(async () => {
+    if (replSession) {
+      replSession.session.close();
+      await waitForRepl();
+      replSession.restore();
+      replSession = null;
+    }
+  });
+
+  describe(".code", () => {
+    it("should print generated code when commands were recorded", async () => {
+      replSession = await createReplSession();
+
+      await runCommands(replSession.input, [
+        'openBrowser()',
+        'goto("search.brave.com")',
+        'write("Hello World")',
+        'press("Enter")',
+        "closeBrowser()",
+        ".code",
+      ]);
+
+      await waitForRepl(100);
+
+      const output = replSession.logs.join("\n");
+      expect(output).to.contain(
+        "const { openBrowser, goto, write, press, closeBrowser } = require('taiko');",
+      );
+      expect(output).to.contain('await goto("search.brave.com");');
+      expect(output).to.contain('await write("Hello World");');
+      expect(output).to.contain('await press("Enter");');
+      expect(output).to.contain("await closeBrowser();");
+    });
+
+    it("should print generated code when no commands were recorded", async () => {
+      taikoRepl.__test__.resetState();
+      const output = taikoRepl.__test__.code();
+      expect(output).to.contain(
+        "const { closeBrowser } = require('taiko');",
+      );
+      expect(output).to.contain("await closeBrowser();");
+    });
+
+    it("should save generated code to the given file", async () => {
+      replSession = await createReplSession();
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "taiko-repl-"));
+      const filePath = path.join(tempDir, "session.js");
+
+      try {
+        await runCommands(replSession.input, [
+          "openBrowser()",
+          'goto("search.brave.com")',
+          'write("Hello World")',
+          'press("Enter")',
+          "closeBrowser()",
+          `.code ${filePath}`,
+        ]);
+
+        await waitForRepl(100);
+
+        expect(fs.existsSync(filePath)).to.equal(true);
+
+        const savedCode = fs.readFileSync(filePath, "utf8");
+        expect(savedCode).to.contain(
+          "const { openBrowser, goto, write, press, closeBrowser } = require('taiko');",
+        );
+        expect(savedCode).to.contain('await goto("search.brave.com");');
+        expect(savedCode).to.contain("await closeBrowser();");
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/tests/unit-tests/setup.js
+++ b/tests/unit-tests/setup.js
@@ -1,0 +1,4 @@
+// Must run before any production module is required. CommonJS caches modules
+// after the first require(), so TAIKO_ENABLE_TEST_HOOKS must be set before
+// any require('taiko/lib/taiko') or require('taiko/lib/util') occurs.
+process.env.TAIKO_ENABLE_TEST_HOOKS = "1";

--- a/tests/unit-tests/switchTo.test.js
+++ b/tests/unit-tests/switchTo.test.js
@@ -5,18 +5,17 @@ const chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
 
 describe("switchTo", () => {
-  let argument;
   let taiko;
   let registeredTarget;
+  let baseTargetHandler;
 
   before(async () => {
     taiko = require("taiko/lib/taiko");
     taiko.__reset__();
     const targetRegistry = new Map();
     taiko.__set__("validate", () => {});
-    taiko.__set__("targetHandler", {
-      getCriTargets: (arg) => {
-        argument = arg;
+    baseTargetHandler = {
+      getCriTargets: () => {
         return { matching: [] };
       },
       register: (name, target) => {
@@ -27,7 +26,8 @@ describe("switchTo", () => {
         return registeredTarget ?? targetRegistry.get(name);
       },
       switchBrowserContext: () => {},
-    });
+    };
+    taiko.__set__("targetHandler", baseTargetHandler);
     taiko.__set__("connect_to_cri", () => {
       return registeredTarget;
     });
@@ -37,33 +37,53 @@ describe("switchTo", () => {
     taiko.__reset__();
   });
 
-  it("should throw error if no url specified", async () => {
-    await expect(taiko.switchTo()).to.eventually.rejectedWith(
-      'The "targetUrl" argument must be of type string, regex or identifier. Received type undefined',
-    );
+  afterEach(() => {
+    // Restore the baseline targetHandler in case a test overrode it
+    taiko.__set__("targetHandler", baseTargetHandler);
   });
 
-  it("should throw error if url is empty", async () => {
-    await expect(taiko.switchTo("")).to.eventually.rejectedWith(
-      "Cannot switch to tab or window as the targetUrl is empty. Please use a valid string, regex or identifier",
-    );
-  });
+  const invalidInputCases = [
+    {
+      label: "no url specified",
+      input: undefined,
+      expectedMsg:
+        'The "targetUrl" argument must be of type string, regex or identifier. Received type undefined',
+    },
+    {
+      label: "empty string",
+      input: "",
+      expectedMsg:
+        "Cannot switch to tab or window as the targetUrl is empty. Please use a valid string, regex or identifier",
+    },
+    {
+      label: "whitespace-only string",
+      input: "  ",
+      expectedMsg:
+        "Cannot switch to tab or window as the targetUrl is empty. Please use a valid string, regex or identifier",
+    },
+  ];
 
-  it("should throw error if url is only spaces", async () => {
-    await expect(taiko.switchTo("  ")).to.eventually.rejectedWith(
-      "Cannot switch to tab or window as the targetUrl is empty. Please use a valid string, regex or identifier",
-    );
-  });
+  for (const { label, input, expectedMsg } of invalidInputCases) {
+    it(`should throw error when ${label}`, async () => {
+      await expect(taiko.switchTo(input)).to.eventually.be.rejectedWith(
+        expectedMsg,
+      );
+    });
+  }
 
   it("should accept regex and call targetHandler with RegExp", async () => {
-    await expect(
-      taiko.switchTo(/http(s):\/\/www.google.com/),
-    ).to.eventually.rejectedWith(
-      "No tab(s) matching /http(s):\\/\\/www.google.com/ found",
-    );
-    await expect(argument).to.deep.equal(
-      new RegExp(/http(s):\/\/www.google.com/),
-    );
+    let capturedArg;
+    taiko.__set__("targetHandler", {
+      getCriTargets: (arg) => {
+        capturedArg = arg;
+        return { matching: [] };
+      },
+      register: () => {},
+      switchBrowserContext: () => {},
+    });
+    const pattern = /http(s):\/\/www.google.com/;
+    await taiko.switchTo(pattern).catch(() => {});
+    expect(capturedArg, "targetHandler should be called with the regex").to.deep.equal(pattern);
   });
 
   it("should accept window identifier", async () => {

--- a/tests/unit-tests/switchTo.test.js
+++ b/tests/unit-tests/switchTo.test.js
@@ -1,7 +1,6 @@
 const chai = require("chai");
 const expect = require("chai").expect;
 const chaiAsPromised = require("chai-as-promised");
-const rewire = require("rewire");
 
 chai.use(chaiAsPromised);
 
@@ -11,23 +10,31 @@ describe("switchTo", () => {
   let registeredTarget;
 
   before(async () => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko = require("taiko/lib/taiko");
+    taiko.__reset__();
+    const targetRegistry = new Map();
     taiko.__set__("validate", () => {});
-    taiko.__set__("targetHandler.getCriTargets", (arg) => {
-      argument = arg;
-      return { matching: [] };
+    taiko.__set__("targetHandler", {
+      getCriTargets: (arg) => {
+        argument = arg;
+        return { matching: [] };
+      },
+      register: (name, target) => {
+        if (name && target) {
+          targetRegistry.set(name, target);
+          return;
+        }
+        return registeredTarget ?? targetRegistry.get(name);
+      },
+      switchBrowserContext: () => {},
     });
-    taiko.__set__("targetHandler.register", () => {
-      return registeredTarget;
-    });
-    taiko.__set__("targetHandler.switchBrowserContext", () => {});
     taiko.__set__("connect_to_cri", () => {
       return registeredTarget;
     });
   });
 
   after(() => {
-    taiko = rewire("taiko/lib/taiko");
+    taiko.__reset__();
   });
 
   it("should throw error if no url specified", async () => {

--- a/tests/unit-tests/util.test.js
+++ b/tests/unit-tests/util.test.js
@@ -1,6 +1,5 @@
 const chai = require("chai");
 const path = require("node:path");
-const rewire = require("rewire");
 const expect = chai.expect;
 const test_name = "util";
 
@@ -10,13 +9,14 @@ describe(test_name, () => {
   let escapeHtml;
   let taikoInstallationLocation;
   before(() => {
-    util = rewire("taiko/lib/util");
+    util = require("taiko/lib/util");
+    util.__reset__();
     trimCharLeft = util.trimCharLeft;
     escapeHtml = util.escapeHtml;
     taikoInstallationLocation = util.taikoInstallationLocation;
   });
   after(() => {
-    util = rewire("taiko/lib/util");
+    util.__reset__();
   });
   describe("trim Char()", () => {
     it("should trim the char specified from the string", async () => {


### PR DESCRIPTION
## Summary

- Improves Taiko’s compatibility with newer Node.js versions, including Node.js 25.
- Cleans up warning-producing behavior so running Taiko feels less noisy and more predictable.
- Makes URL handling more consistent so common navigation and tab-switching cases behave more reliably.
- Strengthens the test setup to reduce flaky failures and make the suite more dependable across environments.
- Expands CI coverage so the project is validated on more Node.js versions.
- Cleans up package and dependency setup to make the repository easier to maintain.

Without this change on node 25 we have the following warnings

```
⋊> ~/p/taiko on fix/taiko-security-warning  node --trace-deprecation packages/taiko/bin/taiko.js                                                                                                                                                                                                                     15:25:03

Version: 1.4.8 (Chromium: 140.0.7339.82)
Type .api for help and .exit to quit

> openBrowser()
(node:54165) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
    at urlParse (node:url:137:13)
    at Interface.onLine (/Users/zabilcm/projects/taiko/packages/taiko/lib/browser/browser.js:172:17)
    at Interface.emit (node:events:508:20)
    at Interface.emit (node:domain:552:15)
    at [_onLine] [as _onLine] (node:internal/readline/interface:465:12)
    at [_normalWrite] [as _normalWrite] (node:internal/readline/interface:647:22)
    at Socket.ondata (node:internal/readline/interface:263:23)
    at Socket.emit (node:events:508:20)
    at Socket.emit (node:domain:552:15)
    at addChunk (node:internal/streams/readable:564:12)
 ✔ Browser opened
> 
```

## Why this change

- Newer Node.js versions exposed warnings and test issues that made the project harder to run cleanly.
- Some test failures were caused by timing and setup behavior rather than real product problems.
- The repository had some dependency and configuration clutter that was no longer needed.

## What changed

- Updated internal handling around URLs and related browser interactions to avoid warning-prone behavior.
- Added safer test-only support so testing can be done cleanly without affecting production builds.
- Improved REPL-related test coverage and behavior.
- Updated browser crash tests to wait for the actual event instead of relying on fixed timing.
- Added Node.js 25 to CI and extended test coverage across the workflow.
- Removed unused or misplaced package configuration and refreshed generated files.

## Result

- Cleaner runs on newer Node.js versions.
- More reliable automated tests.
- Better confidence in cross-version support.
- Simpler repository maintenance.

 Fix #2767 