### PR TITLE
build: remove npm trusted publishing hack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          check-latest: 'true'
           registry-url: 'https://registry.npmjs.org'
 
       - name: npm install
@@ -58,6 +59,5 @@ jobs:
           token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Deploy npm
-        run: | # See https://github.com/actions/setup-node/issues/1440
-          unset NODE_AUTH_TOKEN
+        run: |
           npm publish --workspace=taiko --access=public

--- a/.github/workflows/taiko.yml
+++ b/.github/workflows/taiko.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
+          check-latest: 'true'
       - name: install
         run: npm ci
       - name: install browser dependencies
@@ -61,6 +62,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
+          check-latest: 'true'
       - name: install
         run: npm ci
       - name: install browser dependencies
@@ -106,6 +108,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          check-latest: 'true'
       - name: install
         run: npm ci
       - name: install browser dependencies
@@ -153,6 +156,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          check-latest: 'true'
       - name: install
         run: npm ci
       - name: install browser dependencies

--- a/.github/workflows/update_chrome.yml
+++ b/.github/workflows/update_chrome.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          check-latest: 'true'
 
       - name: Setup
         run: |


### PR DESCRIPTION
The workaround/hack seems no longer needed according to upstream, so removing this now, but ensuring we are using latest stable npm release via latest stable node LTS.