### PR TITLE
Fix: evaluate returns empty object when function throws (#2613)

### DIFF
--- a/packages/taiko/lib/taiko.js
+++ b/packages/taiko/lib/taiko.js
@@ -2367,6 +2367,15 @@ module.exports.evaluate = async (selector, callback, options = {}) => {
     });
   });
 
+  if (result && result.exceptionDetails) {
+    const exceptionDetails = result.exceptionDetails;
+    const errorMessage =
+      exceptionDetails.exception && exceptionDetails.exception.description
+        ? exceptionDetails.exception.description
+        : exceptionDetails.text || "Error in evaluate callback";
+    throw new Error(errorMessage);
+  }
+
   if (!_options.silent) {
     descEvent.emit("success", "Evaluated given script");
   }

--- a/packages/taiko/lib/taiko.js
+++ b/packages/taiko/lib/taiko.js
@@ -2370,9 +2370,9 @@ module.exports.evaluate = async (selector, callback, options = {}) => {
   if (result && result.exceptionDetails) {
     const exceptionDetails = result.exceptionDetails;
     const errorMessage =
-      exceptionDetails.exception && exceptionDetails.exception.description
-        ? exceptionDetails.exception.description
-        : exceptionDetails.text || "Error in evaluate callback";
+      exceptionDetails.exception?.description ??
+      exceptionDetails.text ??
+      "Error in evaluate callback";
     throw new Error(errorMessage);
   }
 

--- a/tests/unit-tests/evaluate.test.js
+++ b/tests/unit-tests/evaluate.test.js
@@ -103,6 +103,19 @@ describe(testName, () => {
       expect(actual).to.equal(testName);
     });
 
+    it("should throw when the callback throws an error", async () => {
+      let thrownError;
+      try {
+        await evaluate(() => {
+          return document.querySelector(".doesNotExist").textContent;
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+      expect(thrownError).to.be.an.instanceof(Error);
+      expect(thrownError.message).to.include("TypeError");
+    });
+
     it("should pass args to the callback", async () => {
       const newText = "Updated Item 1 with new item";
       await evaluate(

--- a/tests/unit-tests/evaluate.test.js
+++ b/tests/unit-tests/evaluate.test.js
@@ -104,16 +104,9 @@ describe(testName, () => {
     });
 
     it("should throw when the callback throws an error", async () => {
-      let thrownError;
-      try {
-        await evaluate(() => {
-          return document.querySelector(".doesNotExist").textContent;
-        });
-      } catch (e) {
-        thrownError = e;
-      }
-      expect(thrownError).to.be.an.instanceof(Error);
-      expect(thrownError.message).to.include("TypeError");
+      await expect(
+        evaluate(() => document.querySelector(".doesNotExist").textContent)
+      ).to.be.rejectedWith(Error, /TypeError/);
     });
 
     it("should pass args to the callback", async () => {


### PR DESCRIPTION
Description
This PR fixes the issue where evaluate swallows exceptions thrown inside the browser context and returns an empty object.

Changes:

Checked for result.exceptionDetails in CDP response inside doActionAwaitingNavigation.
If an exception occurred, throw a standard Error in the Node context with the browser's serialized error message.
Also added a unit test to prevent future regressions.

Fixes #2613