### PR TITLE
Fix: wait for element to be stable fails on infinite animations (#2711)

### DIFF
--- a/packages/taiko/lib/actions/pageActionChecks.js
+++ b/packages/taiko/lib/actions/pageActionChecks.js
@@ -79,7 +79,10 @@ const checkStable = async (elem) => {
   function waitForElementToBeStable() {
     let elem = this;
     return new Promise((resolve, reject) => {
-      setTimeout(() => reject(false), 10000);
+      setTimeout(
+        () => reject(new Error("Element is not stable: still moving after 10000ms")),
+        10000,
+      );
       let previousRect;
       let currentRect;
       function isInSamePosition(previousRect, currentRect) {
@@ -87,7 +90,7 @@ const checkStable = async (elem) => {
         const leftDiff = Math.abs(previousRect.left - currentRect.left);
         const bottomDiff = Math.abs(previousRect.bottom - currentRect.bottom);
         const rightDiff = Math.abs(previousRect.right - currentRect.right);
-        return topDiff + leftDiff + bottomDiff + rightDiff;
+        return topDiff + leftDiff + bottomDiff + rightDiff === 0;
       }
       (function step() {
         if (elem.nodeType === Node.TEXT_NODE) {
@@ -101,14 +104,14 @@ const checkStable = async (elem) => {
         if (previousRect === undefined) {
           previousRect = currentRect;
           window.requestAnimationFrame(step);
+          return;
         }
 
-        const positionalDiff = isInSamePosition(previousRect, currentRect);
-        if (positionalDiff) {
+        if (isInSamePosition(previousRect, currentRect)) {
+          resolve(true);
+        } else {
           previousRect = currentRect;
           window.requestAnimationFrame(step);
-        } else {
-          resolve(true);
         }
       })();
     });
@@ -123,6 +126,14 @@ const checkStable = async (elem) => {
       awaitPromise: true,
     },
   );
+  if (res.exceptionDetails) {
+    const exceptionDetails = res.exceptionDetails;
+    const message =
+      exceptionDetails.exception && exceptionDetails.exception.description
+        ? exceptionDetails.exception.description
+        : exceptionDetails.text || "Element is not stable";
+    throw new Error(message);
+  }
   return res.result.value;
 };
 

--- a/packages/taiko/lib/actions/pageActionChecks.js
+++ b/packages/taiko/lib/actions/pageActionChecks.js
@@ -80,7 +80,10 @@ const checkStable = async (elem) => {
     let elem = this;
     return new Promise((resolve, reject) => {
       setTimeout(
-        () => reject(new Error("Element is not stable: still moving after 10000ms")),
+        () =>
+          reject(
+            new Error("Element is not stable: still moving after 10000ms"),
+          ),
         10000,
       );
       let previousRect;
@@ -129,9 +132,9 @@ const checkStable = async (elem) => {
   if (res.exceptionDetails) {
     const exceptionDetails = res.exceptionDetails;
     const message =
-      exceptionDetails.exception && exceptionDetails.exception.description
-        ? exceptionDetails.exception.description
-        : exceptionDetails.text || "Element is not stable";
+      exceptionDetails.exception?.description ??
+      exceptionDetails.text ??
+      "Element is not stable";
     throw new Error(message);
   }
   return res.result.value;

--- a/tests/unit-tests/actions/pageActionChecks.test.js
+++ b/tests/unit-tests/actions/pageActionChecks.test.js
@@ -214,4 +214,35 @@ describe("pageActionChecks", () => {
       expect(result.name).to.equal("notActionable1");
     });
   });
+  describe("checkStable", () => {
+    afterEach(() => {
+      pageActionChecks = rewire("taiko/lib/actions/pageActionChecks");
+    });
+    it("should return true when element is stable", async () => {
+      pageActionChecks.__set__("runtimeHandler", {
+        runtimeCallFunctionOn: () => ({
+          result: { value: true },
+        }),
+      });
+      const elem = { get: () => 1 };
+      const result = await pageActionChecks.__get__("checkStable")(elem);
+      expect(result).to.be.true;
+    });
+    it("should throw when element keeps moving and never becomes stable", async () => {
+      pageActionChecks.__set__("runtimeHandler", {
+        runtimeCallFunctionOn: () => ({
+          exceptionDetails: {
+            exception: {
+              description:
+                "Error: Element is not stable: still moving after 10000ms",
+            },
+          },
+        }),
+      });
+      const elem = { get: () => 1 };
+      await expect(
+        pageActionChecks.__get__("checkStable")(elem),
+      ).to.be.rejectedWith("Element is not stable: still moving after 10000ms");
+    });
+  });
 });


### PR DESCRIPTION
Fixes #2711

This PR fixes an issue where actions like click() on elements with infinite CSS animations would not correctly wait for the 10-second timeout and would fail prematurely or proceed unpredictably.

Root Cause
The root cause was a combination of logic flaws in how element stability was checked and how timeouts were communicated back through the Chrome DevTools Protocol (CDP):

isInSamePosition was returning an integer instead of a boolean, confusing the stability logic.

A missing return statement after the initial requestAnimationFrame caused the comparison to happen immediately against the same object.

The 10-second timeout rejected with a primitive false instead of an Error object. In CDP, rejecting with a primitive value swallows the error (resulting in undefined), meaning the Node process never saw the timeout exception.

checkStable was not checking for res.exceptionDetails to propagate the error properly.

Changes Made
Updated isInSamePosition to return a strict boolean (topDiff + leftDiff + bottomDiff + rightDiff === 0).

Added the missing return; statement in waitForElementToBeStable after the first requestAnimationFrame call.

Modified the 10-second timeout to reject with a proper new Error("Element is not stable: still moving after 10000ms").

Added an exceptionDetails check inside checkStable to correctly intercept the timeout error from the browser context and throw it as a standard JavaScript Error in Node.js.