### PR TITLE
debug: capture taiko:intercept logs on Windows to diagnose navigation hang

### DIFF
--- a/.github/workflows/taiko.yml
+++ b/.github/workflows/taiko.yml
@@ -48,13 +48,9 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: npm run test:unit:silent
 
-      - name: Run unit tests (windows, with retry)
+      - name: Run unit tests (windows)
         if: matrix.os == 'windows-latest'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 10
-          max_attempts: 2
-          command: npm run test:unit:silent
+        run: npm run test:unit:silent
 
   functional-tests:
     needs: unit-tests
@@ -94,13 +90,11 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: npm run test-functional
 
-      - name: functional-tests (windows, with retry)
+      - name: functional-tests (windows)
         if: matrix.os == 'windows-latest'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 2
-          command: npm run test-functional
+        env:
+          DEBUG: taiko:intercept
+        run: npm run test-functional
 
       - name: Upload html report
         uses: actions/upload-artifact@v6

--- a/packages/taiko/lib/handlers/fetchHandler.js
+++ b/packages/taiko/lib/handlers/fetchHandler.js
@@ -86,7 +86,11 @@ const handleInterceptor = (p) => {
     return;
   }
   interceptor.count = interceptor.count - 1;
-  logIntercept("matched interceptor url=%s action=%s", interceptor.requestUrl, typeof interceptor.action);
+  logIntercept(
+    "matched interceptor url=%s action=%s",
+    interceptor.requestUrl,
+    typeof interceptor.action,
+  );
 
   switch (true) {
     //Blocks matching url
@@ -113,13 +117,22 @@ const handleInterceptor = (p) => {
         interceptor.action = `http://${interceptor.action}`;
       }
       options.url = interceptor.action;
-      logIntercept("calling continueRequest (redirect) for url=%s -> %s", p.request.url, interceptor.action);
+      logIntercept(
+        "calling continueRequest (redirect) for url=%s -> %s",
+        p.request.url,
+        interceptor.action,
+      );
       fetch.continueRequest(options).catch(() => warnInterceptFailed(p));
       break;
     //Mocks response with given object
     case isObject(interceptor.action):
       options = mockResponse(interceptor.action, options);
-      logIntercept("calling fulfillRequest (object) for url=%s responseCode=%d bodyLen=%d", p.request.url, options.responseCode, options.body ? options.body.length : 0);
+      logIntercept(
+        "calling fulfillRequest (object) for url=%s responseCode=%d bodyLen=%d",
+        p.request.url,
+        options.responseCode,
+        options.body ? options.body.length : 0,
+      );
       fetch.fulfillRequest(options).catch(() => warnInterceptFailed(p));
       break;
     //Continue default request if none of the above matches
@@ -255,7 +268,11 @@ const getMatchingInterceptor = (interceptor, url) => {
 
 const addInterceptor = async (requestWithAction) => {
   interceptors.push(requestWithAction);
-  logIntercept("interceptor added url=%s totalInterceptors=%d", requestWithAction.requestUrl, interceptors.length);
+  logIntercept(
+    "interceptor added url=%s totalInterceptors=%d",
+    requestWithAction.requestUrl,
+    interceptors.length,
+  );
   if (!userEnabledIntercept) {
     userEnabledIntercept = true;
     await enableFetchIntercept();

--- a/packages/taiko/lib/handlers/fetchHandler.js
+++ b/packages/taiko/lib/handlers/fetchHandler.js
@@ -1,5 +1,6 @@
 const { isFunction, isString, isObject } = require("../helper");
 const { eventHandler } = require("../eventBus");
+const { logIntercept } = require("../logger");
 const headersMap = new Map();
 const defaultErrorReason = "Failed";
 let fetch;
@@ -72,16 +73,20 @@ const filterInterceptorsAndWarnIfNeeded = (requestUrl) => {
 
 const warnInterceptFailed = (p) => {
   console.warn(`WARNING: Could not intercept request ${p.request.url}`);
+  logIntercept("fulfillRequest/continueRequest failed for url=%s", p.request.url);
 };
 
 const handleInterceptor = (p) => {
+  logIntercept("requestPaused url=%s", p.request.url);
   let options = addExtraHeadersToRequest(p);
   const interceptor = filterInterceptorsAndWarnIfNeeded(p.request.url);
   if (!interceptor) {
+    logIntercept("no matching interceptor, continuing request");
     fetch.continueRequest(options).catch(() => {});
     return;
   }
   interceptor.count = interceptor.count - 1;
+  logIntercept("matched interceptor url=%s action=%s", interceptor.requestUrl, typeof interceptor.action);
 
   switch (true) {
     //Blocks matching url
@@ -94,6 +99,7 @@ const handleInterceptor = (p) => {
       p.continue = (override) => overrideRequest(p, override, options);
       p.respond = (mock) => {
         options = mockResponse(mock, options);
+        logIntercept("calling fulfillRequest (callback) for url=%s", p.request.url);
         fetch.fulfillRequest(options).catch(() => warnInterceptFailed(p));
       };
       interceptor.action(p);
@@ -107,11 +113,13 @@ const handleInterceptor = (p) => {
         interceptor.action = `http://${interceptor.action}`;
       }
       options.url = interceptor.action;
+      logIntercept("calling continueRequest (redirect) for url=%s -> %s", p.request.url, interceptor.action);
       fetch.continueRequest(options).catch(() => warnInterceptFailed(p));
       break;
     //Mocks response with given object
     case isObject(interceptor.action):
       options = mockResponse(interceptor.action, options);
+      logIntercept("calling fulfillRequest (object) for url=%s responseCode=%d bodyLen=%d", p.request.url, options.responseCode, options.body ? options.body.length : 0);
       fetch.fulfillRequest(options).catch(() => warnInterceptFailed(p));
       break;
     //Continue default request if none of the above matches
@@ -247,6 +255,7 @@ const getMatchingInterceptor = (interceptor, url) => {
 
 const addInterceptor = async (requestWithAction) => {
   interceptors.push(requestWithAction);
+  logIntercept("interceptor added url=%s totalInterceptors=%d", requestWithAction.requestUrl, interceptors.length);
   if (!userEnabledIntercept) {
     userEnabledIntercept = true;
     await enableFetchIntercept();

--- a/packages/taiko/lib/handlers/fetchHandler.js
+++ b/packages/taiko/lib/handlers/fetchHandler.js
@@ -73,7 +73,10 @@ const filterInterceptorsAndWarnIfNeeded = (requestUrl) => {
 
 const warnInterceptFailed = (p) => {
   console.warn(`WARNING: Could not intercept request ${p.request.url}`);
-  logIntercept("fulfillRequest/continueRequest failed for url=%s", p.request.url);
+  logIntercept(
+    "fulfillRequest/continueRequest failed for url=%s",
+    p.request.url,
+  );
 };
 
 const handleInterceptor = (p) => {
@@ -103,7 +106,10 @@ const handleInterceptor = (p) => {
       p.continue = (override) => overrideRequest(p, override, options);
       p.respond = (mock) => {
         options = mockResponse(mock, options);
-        logIntercept("calling fulfillRequest (callback) for url=%s", p.request.url);
+        logIntercept(
+          "calling fulfillRequest (callback) for url=%s",
+          p.request.url,
+        );
         fetch.fulfillRequest(options).catch(() => warnInterceptFailed(p));
       };
       interceptor.action(p);

--- a/packages/taiko/lib/logger.js
+++ b/packages/taiko/lib/logger.js
@@ -1,8 +1,10 @@
 const debug = require("debug");
 const logEvent = debug("taiko:event");
 const logQuery = debug("taiko:query");
+const logIntercept = debug("taiko:intercept");
 
 module.exports = {
   logEvent,
   logQuery,
+  logIntercept,
 };


### PR DESCRIPTION
## Problem

The Windows CI job `FTs - NodeJS 22 & windows-latest` is consistently failing at `intercept.spec:38`:

```
Failed Step: Navigate to "https://localhost/employees/2/address"
Error Message: Navigation took more than 60000ms. Please increase the navigationTimeout.
```

Both retry attempts fail, so this is not random flakiness. The root cause is unknown — we don't know whether:

- **Scenario A**: `Fetch.requestPaused` fires but `fulfillRequest` fails silently (request stays paused → navigation hangs)
- **Scenario B**: `Fetch.requestPaused` never fires at all (Chrome bypasses the intercept for HTTPS on Windows)

## Changes

### `packages/taiko/lib/logger.js`
Adds a `taiko:intercept` debug namespace (uses the existing `debug` package — zero overhead when `DEBUG` is unset).

### `packages/taiko/lib/handlers/fetchHandler.js`
Adds `logIntercept` calls at every key point in the intercept lifecycle:
- When an interceptor is registered (`addInterceptor`)
- When `requestPaused` fires (with the request URL)
- When no matching interceptor is found
- When a matching interceptor is found (with type)
- When `fulfillRequest`/`continueRequest` is called (with response details)
- When those CDP calls fail

### `.github/workflows/taiko.yml`
- Enables `DEBUG=taiko:intercept` on the Windows functional-test step so the logs appear inline in the CI job output on failure
- **Removes** the `nick-fields/retry` workaround from both unit-tests and functional-tests on Windows — retries were hiding the failure signal

## How to read the output

After this PR, the failing CI run will show one of:

**Scenario A** (requestPaused fires, fulfillRequest fails):
```
taiko:intercept requestPaused url=https://localhost/employees/2/address
taiko:intercept matched interceptor url=... action=object
taiko:intercept calling fulfillRequest (object) for url=...
taiko:intercept fulfillRequest/continueRequest failed for url=...
```

**Scenario B** (requestPaused never fires):
```
taiko:intercept requestPaused url=https://localhost/employees/1/address   ← appears
taiko:intercept requestPaused url=https://localhost/employees/1/address   ← appears (second nav)
                                                                          ← nothing for /2/address
```

This PR is diagnostic only — no behaviour change.