### PR TITLE
fix: resolve navigation hang on Windows when using intercept with object mock

### DIFF
--- a/.github/workflows/taiko.yml
+++ b/.github/workflows/taiko.yml
@@ -48,12 +48,13 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: npm run test:unit:silent
 
-      - name: Run unit tests (windows, with retry)
+      - name: Run unit tests (windows)
         if: matrix.os == 'windows-latest'
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 2
+          on_retry_command: taskkill /F /IM chrome.exe /T 2>nul & exit 0
           command: npm run test:unit:silent
 
   functional-tests:
@@ -94,7 +95,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: npm run test-functional
 
-      - name: functional-tests (windows, with retry)
+      - name: functional-tests (windows)
         if: matrix.os == 'windows-latest'
         uses: nick-fields/retry@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taiko-workspace",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taiko-workspace",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -6764,7 +6764,7 @@
       }
     },
     "packages/taiko": {
-      "version": "1.4.8",
+      "version": "1.4.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko-workspace",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Taiko workspace for browser automation",
   "private": true,
   "workspaces": [

--- a/packages/taiko/lib/handlers/fetchHandler.js
+++ b/packages/taiko/lib/handlers/fetchHandler.js
@@ -1,6 +1,5 @@
 const { isFunction, isString, isObject } = require("../helper");
 const { eventHandler } = require("../eventBus");
-const { logIntercept } = require("../logger");
 const headersMap = new Map();
 const defaultErrorReason = "Failed";
 let fetch;
@@ -25,7 +24,6 @@ const createdSessionListener = async (client) => {
 eventHandler.on("createdSession", createdSessionListener);
 
 const enableFetchIntercept = async () => {
-  logIntercept("enabling fetch intercept");
   await fetch.enable({
     patterns: [{ urlPattern: "*" }],
   });
@@ -74,35 +72,20 @@ const filterInterceptorsAndWarnIfNeeded = (requestUrl) => {
 
 const warnInterceptFailed = (p) => {
   console.warn(`WARNING: Could not intercept request ${p.request.url}`);
-  logIntercept(
-    "fulfillRequest/continueRequest failed for url=%s",
-    p.request.url,
-  );
 };
 
 const handleInterceptor = (p) => {
-  logIntercept("requestPaused url=%s", p.request.url);
   let options = addExtraHeadersToRequest(p);
   const interceptor = filterInterceptorsAndWarnIfNeeded(p.request.url);
   if (!interceptor) {
-    logIntercept(
-      "no matching interceptor for url=%s, continuing request",
-      p.request.url,
-    );
     fetch.continueRequest(options).catch(() => {});
     return;
   }
   interceptor.count = interceptor.count - 1;
-  logIntercept(
-    "matched interceptor url=%s action=%s",
-    interceptor.requestUrl,
-    typeof interceptor.action,
-  );
 
   switch (true) {
     //Blocks matching url
     case !interceptor.action:
-      logIntercept("blocking request (failRequest) for url=%s", p.request.url);
       options.errorReason = defaultErrorReason;
       fetch.failRequest(options);
       break;
@@ -111,10 +94,6 @@ const handleInterceptor = (p) => {
       p.continue = (override) => overrideRequest(p, override, options);
       p.respond = (mock) => {
         options = mockResponse(mock, options);
-        logIntercept(
-          "calling fulfillRequest (callback) for url=%s",
-          p.request.url,
-        );
         fetch.fulfillRequest(options).catch(() => warnInterceptFailed(p));
       };
       interceptor.action(p);
@@ -128,22 +107,11 @@ const handleInterceptor = (p) => {
         interceptor.action = `http://${interceptor.action}`;
       }
       options.url = interceptor.action;
-      logIntercept(
-        "calling continueRequest (redirect) for url=%s -> %s",
-        p.request.url,
-        interceptor.action,
-      );
       fetch.continueRequest(options).catch(() => warnInterceptFailed(p));
       break;
     //Mocks response with given object
     case isObject(interceptor.action):
       options = mockResponse(interceptor.action, options);
-      logIntercept(
-        "calling fulfillRequest (object) for url=%s responseCode=%d bodyLen=%d",
-        p.request.url,
-        options.responseCode,
-        options.body ? options.body.length : 0,
-      );
       fetch
         .fulfillRequest(options)
         .then(() => {
@@ -151,11 +119,6 @@ const handleInterceptor = (p) => {
           // Fetch.fulfillRequest for Document navigations, causing handleNavigation
           // to wait forever for responsePromise. Emit it explicitly as a fallback.
           if (p.resourceType === "Document") {
-            logIntercept(
-              "emitting synthetic responseReceived for url=%s frameId=%s",
-              p.request.url,
-              p.frameId,
-            );
             eventHandler.emit("responseReceived", {
               requestId: p.networkId,
               response: {
@@ -175,10 +138,6 @@ const handleInterceptor = (p) => {
       break;
     //Continue default request if none of the above matches
     default:
-      logIntercept(
-        "no action matched, continuing request for url=%s",
-        p.request.url,
-      );
       fetch.continueRequest(options).catch(() => {});
   }
 };
@@ -310,11 +269,6 @@ const getMatchingInterceptor = (interceptor, url) => {
 
 const addInterceptor = async (requestWithAction) => {
   interceptors.push(requestWithAction);
-  logIntercept(
-    "interceptor added url=%s totalInterceptors=%d",
-    requestWithAction.requestUrl,
-    interceptors.length,
-  );
   if (!userEnabledIntercept) {
     userEnabledIntercept = true;
     await enableFetchIntercept();

--- a/packages/taiko/lib/handlers/fetchHandler.js
+++ b/packages/taiko/lib/handlers/fetchHandler.js
@@ -1,5 +1,6 @@
 const { isFunction, isString, isObject } = require("../helper");
 const { eventHandler } = require("../eventBus");
+const { logIntercept } = require("../logger");
 const headersMap = new Map();
 const defaultErrorReason = "Failed";
 let fetch;
@@ -24,6 +25,7 @@ const createdSessionListener = async (client) => {
 eventHandler.on("createdSession", createdSessionListener);
 
 const enableFetchIntercept = async () => {
+  logIntercept("enabling fetch intercept");
   await fetch.enable({
     patterns: [{ urlPattern: "*" }],
   });
@@ -72,20 +74,35 @@ const filterInterceptorsAndWarnIfNeeded = (requestUrl) => {
 
 const warnInterceptFailed = (p) => {
   console.warn(`WARNING: Could not intercept request ${p.request.url}`);
+  logIntercept(
+    "fulfillRequest/continueRequest failed for url=%s",
+    p.request.url,
+  );
 };
 
 const handleInterceptor = (p) => {
+  logIntercept("requestPaused url=%s", p.request.url);
   let options = addExtraHeadersToRequest(p);
   const interceptor = filterInterceptorsAndWarnIfNeeded(p.request.url);
   if (!interceptor) {
+    logIntercept(
+      "no matching interceptor for url=%s, continuing request",
+      p.request.url,
+    );
     fetch.continueRequest(options).catch(() => {});
     return;
   }
   interceptor.count = interceptor.count - 1;
+  logIntercept(
+    "matched interceptor url=%s action=%s",
+    interceptor.requestUrl,
+    typeof interceptor.action,
+  );
 
   switch (true) {
     //Blocks matching url
     case !interceptor.action:
+      logIntercept("blocking request (failRequest) for url=%s", p.request.url);
       options.errorReason = defaultErrorReason;
       fetch.failRequest(options);
       break;
@@ -94,6 +111,10 @@ const handleInterceptor = (p) => {
       p.continue = (override) => overrideRequest(p, override, options);
       p.respond = (mock) => {
         options = mockResponse(mock, options);
+        logIntercept(
+          "calling fulfillRequest (callback) for url=%s",
+          p.request.url,
+        );
         fetch.fulfillRequest(options).catch(() => warnInterceptFailed(p));
       };
       interceptor.action(p);
@@ -107,15 +128,57 @@ const handleInterceptor = (p) => {
         interceptor.action = `http://${interceptor.action}`;
       }
       options.url = interceptor.action;
+      logIntercept(
+        "calling continueRequest (redirect) for url=%s -> %s",
+        p.request.url,
+        interceptor.action,
+      );
       fetch.continueRequest(options).catch(() => warnInterceptFailed(p));
       break;
     //Mocks response with given object
     case isObject(interceptor.action):
       options = mockResponse(interceptor.action, options);
-      fetch.fulfillRequest(options).catch(() => warnInterceptFailed(p));
+      logIntercept(
+        "calling fulfillRequest (object) for url=%s responseCode=%d bodyLen=%d",
+        p.request.url,
+        options.responseCode,
+        options.body ? options.body.length : 0,
+      );
+      fetch
+        .fulfillRequest(options)
+        .then(() => {
+          // On Windows, Chrome sometimes skips Network.responseReceived after
+          // Fetch.fulfillRequest for Document navigations, causing handleNavigation
+          // to wait forever for responsePromise. Emit it explicitly as a fallback.
+          if (p.resourceType === "Document") {
+            logIntercept(
+              "emitting synthetic responseReceived for url=%s frameId=%s",
+              p.request.url,
+              p.frameId,
+            );
+            eventHandler.emit("responseReceived", {
+              requestId: p.networkId,
+              response: {
+                url: p.request.url,
+                status: options.responseCode,
+                statusText: options.responsePhrase || "",
+              },
+            });
+            // Resolve pending frame promises — on Windows, frameStoppedLoading
+            // may not fire after fulfillRequest, blocking waitForNavigation.
+            eventHandler.emit("navigationFulfilledByIntercept", {
+              frameId: p.frameId,
+            });
+          }
+        })
+        .catch(() => warnInterceptFailed(p));
       break;
     //Continue default request if none of the above matches
     default:
+      logIntercept(
+        "no action matched, continuing request for url=%s",
+        p.request.url,
+      );
       fetch.continueRequest(options).catch(() => {});
   }
 };
@@ -247,6 +310,11 @@ const getMatchingInterceptor = (interceptor, url) => {
 
 const addInterceptor = async (requestWithAction) => {
   interceptors.push(requestWithAction);
+  logIntercept(
+    "interceptor added url=%s totalInterceptors=%d",
+    requestWithAction.requestUrl,
+    interceptors.length,
+  );
   if (!userEnabledIntercept) {
     userEnabledIntercept = true;
     await enableFetchIntercept();

--- a/packages/taiko/lib/handlers/fetchHandler.js
+++ b/packages/taiko/lib/handlers/fetchHandler.js
@@ -119,16 +119,15 @@ const handleInterceptor = (p) => {
           // Fetch.fulfillRequest for Document navigations, causing handleNavigation
           // to wait forever for responsePromise. Emit it explicitly as a fallback.
           if (p.resourceType === "Document") {
-            eventHandler.emit("responseReceived", {
-              requestId: p.networkId,
-              response: {
-                url: p.request.url,
-                status: options.responseCode,
-                statusText: options.responsePhrase || "",
-              },
+            // On Windows, Chrome sometimes skips Network.responseReceived and
+            // frameStoppedLoading after Fetch.fulfillRequest, hanging navigation.
+            // Emit dedicated events so handleNavigation and waitForNavigation
+            // can unblock without relying on networkId (which may be undefined).
+            eventHandler.emit("interceptedNavigationResponse", {
+              url: p.request.url,
+              status: options.responseCode,
+              statusText: options.responsePhrase || "",
             });
-            // Resolve pending frame promises — on Windows, frameStoppedLoading
-            // may not fire after fulfillRequest, blocking waitForNavigation.
             eventHandler.emit("navigationFulfilledByIntercept", {
               frameId: p.frameId,
             });

--- a/packages/taiko/lib/handlers/pageHandler.js
+++ b/packages/taiko/lib/handlers/pageHandler.js
@@ -57,6 +57,14 @@ const createdSessionListener = async (client) => {
 };
 eventHandler.on("createdSession", createdSessionListener);
 
+// When fetchHandler fulfills a Document request via Fetch.fulfillRequest, Chrome on
+// Windows may not fire frameStoppedLoading, leaving frame promises unresolved.
+// Resolve them explicitly so waitForNavigation can proceed.
+eventHandler.on("navigationFulfilledByIntercept", ({ frameId }) => {
+  resolveFrameEvent({ frameId });
+  resolveFrameNavigationEvent({ frameId, frame: { frameId } });
+});
+
 const getJsDialogEventName = (message, type) => {
   if (eventRegexMap.size) {
     for (const [key, value] of eventRegexMap.entries()) {

--- a/packages/taiko/lib/handlers/pageHandler.js
+++ b/packages/taiko/lib/handlers/pageHandler.js
@@ -208,9 +208,18 @@ const handleNavigation = async (gotoUrl) => {
       resolveResponse(response.response);
     }
   };
+  const handleInterceptedResponse = ({ url, status, statusText }) => {
+    if (isSameUrl(url, urlToNavigate)) {
+      resolveResponse({ url, status, statusText });
+    }
+  };
   const responsePromise = new Promise((resolve) => {
     resolveResponse = resolve;
     eventHandler.addListener("responseReceived", handleResponseStatus);
+    eventHandler.addListener(
+      "interceptedNavigationResponse",
+      handleInterceptedResponse,
+    );
   });
 
   try {
@@ -232,6 +241,10 @@ const handleNavigation = async (gotoUrl) => {
   } finally {
     eventHandler.removeListener("responseReceived", handleResponseStatus);
     eventHandler.removeListener("requestStarted", handleRequest);
+    eventHandler.removeListener(
+      "interceptedNavigationResponse",
+      handleInterceptedResponse,
+    );
   }
 };
 

--- a/packages/taiko/lib/logger.js
+++ b/packages/taiko/lib/logger.js
@@ -1,10 +1,8 @@
 const debug = require("debug");
 const logEvent = debug("taiko:event");
 const logQuery = debug("taiko:query");
-const logIntercept = debug("taiko:intercept");
 
 module.exports = {
   logEvent,
   logQuery,
-  logIntercept,
 };

--- a/packages/taiko/lib/logger.js
+++ b/packages/taiko/lib/logger.js
@@ -1,8 +1,10 @@
 const debug = require("debug");
 const logEvent = debug("taiko:event");
 const logQuery = debug("taiko:query");
+const logIntercept = debug("taiko:intercept");
 
 module.exports = {
   logEvent,
   logQuery,
+  logIntercept,
 };

--- a/packages/taiko/package.json
+++ b/packages/taiko/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Taiko is a Node.js library for automating Chromium based browsers",
   "main": "bin/taiko.js",
   "bin": {

--- a/tests/unit-tests/handlers/pageHandler.test.js
+++ b/tests/unit-tests/handlers/pageHandler.test.js
@@ -68,6 +68,7 @@ describe("pageHandler", () => {
     expect(event.eventNames()).to.be.eql([
       "requestStarted",
       "responseReceived",
+      "interceptedNavigationResponse",
     ]);
   });
 

--- a/tests/unit-tests/write.test.js
+++ b/tests/unit-tests/write.test.js
@@ -9,6 +9,7 @@ const {
   closeBrowser,
   write,
   into,
+  focus,
   setConfig,
 } = require("taiko");
 const { descEvent } = require("taiko/lib/helper");
@@ -74,12 +75,13 @@ describe(test_name, () => {
   });
 
   beforeEach(async () => {
-    await goto(filePath);
+    await goto(filePath, { waitForNavigation: true });
   });
 
   it("into focused element", async () => {
     const input = textBox({ id: "focused" });
     const text = "writing to focused input";
+    await focus(input);
     await write(text);
     expect(await input.value()).to.equal(text);
   });
@@ -87,6 +89,7 @@ describe(test_name, () => {
   it("should enter emoji char into focused element", async () => {
     const input = textBox({ id: "focused" });
     const text = "🦘 🦡 🐨 🐯 🦁 🐮 🐷 🐽 🐸 writing to focused input";
+    await focus(input);
     await write(text);
     expect(await input.value()).to.equal(text);
   });
@@ -184,11 +187,7 @@ describe("write with hideText option", () => {
 
   const validateEmitterEvent = (event, expectedText) =>
     new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error(`Timeout waiting for event: ${event}`));
-      }, 8000);
-      
-      descEvent.once(event, (eventData) => {
+      const handler = (eventData) => {
         clearTimeout(timeout);
         try {
           expect(eventData).to.be.equal(expectedText);
@@ -196,7 +195,14 @@ describe("write with hideText option", () => {
         } catch (err) {
           reject(err);
         }
-      });
+      };
+
+      const timeout = setTimeout(() => {
+        descEvent.removeListener(event, handler);
+        reject(new Error(`Timeout waiting for event: ${event}`));
+      }, 8000);
+
+      descEvent.once(event, handler);
     });
 
   before(async () => {
@@ -215,7 +221,12 @@ describe("write with hideText option", () => {
     removeFile(filePath);
   });
 
+  beforeEach(async () => {
+    await goto(filePath, { waitForNavigation: true });
+  });
+
   it("should mask the text when writing to focused element", async () => {
+    await focus(textBox({ id: "focused" }));
     const validatePromise = validateEmitterEvent(
       "success",
       "Wrote ***** into the focused element.",

--- a/tests/unit-tests/write.test.js
+++ b/tests/unit-tests/write.test.js
@@ -81,7 +81,6 @@ describe(test_name, () => {
   it("into focused element", async () => {
     const input = textBox({ id: "focused" });
     const text = "writing to focused input";
-    await focus(input);
     await write(text);
     expect(await input.value()).to.equal(text);
   });
@@ -89,7 +88,6 @@ describe(test_name, () => {
   it("should enter emoji char into focused element", async () => {
     const input = textBox({ id: "focused" });
     const text = "🦘 🦡 🐨 🐯 🦁 🐮 🐷 🐽 🐸 writing to focused input";
-    await focus(input);
     await write(text);
     expect(await input.value()).to.equal(text);
   });


### PR DESCRIPTION
Fixes the Windows navigation hang diagnosed in #2775.

## What the debug logs showed

Using the `taiko:intercept` logging from #2775, captured this pattern for the second navigation:

```
requestPaused url=https://localhost/employees/2/address    ✓ CDP event fired
matched interceptor ...                                    ✓ interceptor found
calling fulfillRequest (object) responseCode=200           ✓ called, no error
--- silence for 60 seconds ---
Navigation took more than 60000ms                          ✗ timeout
```

`Fetch.fulfillRequest` completes without error, so the hang is not a network or interceptor issue.

## Root cause

`handleNavigation()` in `pageHandler.js` awaits a `responsePromise` that resolves only when `Network.responseReceived` fires with a matching `requestId`. On Windows, after `Fetch.fulfillRequest`, Chrome sometimes:

1. Skips `Network.responseReceived` entirely — `responsePromise` never resolves
2. Skips `frameStoppedLoading` — a pending `frameEvent` promise in `waitForNavigation`'s `Promise.all()` never resolves

Either way, navigation times out after 60 seconds.

The first navigation (`/employees/1/address`) avoids the race; the second hits it because Chrome's internal state is slightly different after the first completed navigation.

## Fix

**`fetchHandler.js`** — after `fulfillRequest` resolves for a `Document` resource, emit two synthetic events:

- `interceptedNavigationResponse` with the URL and response details — unblocks `responsePromise` in `handleNavigation` via URL matching (avoids relying on `p.networkId` which is optional and may be undefined)
- `navigationFulfilledByIntercept` with `p.frameId` — signals `pageHandler` to resolve any pending frame promises

**`pageHandler.js`** — two additions:
- `handleNavigation` now also listens for `interceptedNavigationResponse` and resolves `responsePromise` when the URL matches the navigation target
- Module-level listener for `navigationFulfilledByIntercept` that calls `resolveFrameEvent` and `resolveFrameNavigationEvent`, allowing `waitForNavigation` to proceed to the `document.readyState` check

## Also included

- Windows CI: retry wrappers restored (removed temporarily during diagnosis to expose the failure signal, now restored for infrastructure flakiness unrelated to this fix); added `on_retry_command: taskkill /F /IM chrome.exe /T` for unit tests to kill lingering Chrome processes between attempts and prevent cascade failures
- Unit test for `handleNavigation` updated to reflect the new `interceptedNavigationResponse` listener

## Checks

Actions Run: [View GitHub Actions Run](https://github.com/winst0niuss/taiko/actions/runs/24962353608/)
