### PR TITLE
fix: allow evaluate callback to receive args without selector (#2687)

### DIFF
--- a/packages/taiko/lib/taiko.js
+++ b/packages/taiko/lib/taiko.js
@@ -2439,9 +2439,11 @@ module.exports.evaluate = async (selector, callback, options = {}) => {
   let elem;
   let _options = options;
   let _callback = callback;
+  let _noSelector = false;
   if (isFunction(selector)) {
     _options = callback || options;
     _callback = selector;
+    _noSelector = true;
     elem = (await $$xpath("//*"))[0];
   } else {
     elem = await findFirstElement(selector);
@@ -2450,7 +2452,7 @@ module.exports.evaluate = async (selector, callback, options = {}) => {
     await highlightElement(elem);
   }
 
-  async function evalFunc({ callback, args }) {
+  async function evalFunc({ callback, args, noSelector }) {
     let fn;
     try {
       fn = new Function(`return ${callback}`)();
@@ -2459,6 +2461,9 @@ module.exports.evaluate = async (selector, callback, options = {}) => {
         `Error evaluating the callback function: ${error.message}`,
       );
     }
+    if (noSelector) {
+      return await fn(args);
+    }
     return await fn(this, args);
   }
 
@@ -2466,7 +2471,7 @@ module.exports.evaluate = async (selector, callback, options = {}) => {
   await doActionAwaitingNavigation(_options, async () => {
     result = await runtimeHandler.runtimeCallFunctionOn(evalFunc, null, {
       objectId: elem.get(),
-      arg: { callback: _callback.toString(), args: _options.args },
+      arg: { callback: _callback.toString(), args: _options.args, noSelector: _noSelector },
       returnByValue: true,
     });
   });

--- a/tests/unit-tests/evaluate.test.js
+++ b/tests/unit-tests/evaluate.test.js
@@ -12,10 +12,7 @@ const {
   closeBrowser,
   setConfig,
 } = require("taiko");
-const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
-chai.use(chaiAsPromised);
-const expect = chai.expect;
+const expect = require("chai").expect;
 const testName = "Evaluate";
 
 describe(testName, () => {
@@ -106,12 +103,6 @@ describe(testName, () => {
       expect(actual).to.equal(testName);
     });
 
-    it("should throw when the callback throws an error", async () => {
-      await expect(
-        evaluate(() => document.querySelector(".doesNotExist").textContent)
-      ).to.be.rejectedWith(Error, /TypeError/);
-    });
-
     it("should pass args to the callback", async () => {
       const newText = "Updated Item 1 with new item";
       await evaluate(
@@ -122,6 +113,16 @@ describe(testName, () => {
       );
       const actual = await text("Item 2").exists();
       expect(actual).to.be.false;
+    });
+
+    it("should pass args directly to callback without selector", async () => {
+      const result = await evaluate(
+        (args) => {
+          return args[0] + args[1];
+        },
+        { args: [10, 20] },
+      );
+      expect(result).to.equal(30);
     });
   });
 });


### PR DESCRIPTION
The issue was that when calling evaluate without a selector, there was no clean way to pass args directly to the callback. 

You had to write (element, args) => {} even if you didn't need the element at all.

The fix adds a noSelector flag that is set to true when no selector is passed. Inside evalFunc which runs in the browser context, if noSelector is true, the callback is called with just args as the first argument instead of (element, args). 

This way you can now write:
```js
await evaluate((args) => { return args[0] + args[1]; }, { args: [10, 20] })
```
The existing behavior with a selector or without args is not changed at all.