### PR TITLE
Handle text nodes in writable checks

### DIFF
--- a/packages/taiko/lib/elements/element.js
+++ b/packages/taiko/lib/elements/element.js
@@ -91,12 +91,14 @@ class Element {
 
   async isWritable() {
     function getDetailsForWrittable() {
+      const elem =
+        this.nodeType === Node.TEXT_NODE ? this.parentElement : this;
       return {
-        tagName: this.tagName,
-        isContentEditable: this.isContentEditable,
-        disabled: this.disabled,
-        type: this.type,
-        readOnly: this.readOnly,
+        tagName: elem.tagName,
+        isContentEditable: elem.isContentEditable,
+        disabled: elem.disabled,
+        type: elem.type,
+        readOnly: elem.readOnly,
       };
     }
 

--- a/tests/unit-tests/elements/element.test.js
+++ b/tests/unit-tests/elements/element.test.js
@@ -33,6 +33,17 @@ const nodes = {
       getClientRects: () => [new DomRects(), new DomRects()],
     },
   },
+  91: {
+    nodeType: TEXT_NODE,
+    parentElement: {
+      tagName: "P",
+      isContentEditable: true,
+    },
+  },
+  92: {
+    tagName: "INPUT",
+    type: "text",
+  },
   100: {
     draggable: true,
   },
@@ -106,6 +117,20 @@ describe("Element", () => {
         runtimeHandler,
       );
       expect(await element.isDraggable()).to.be.false;
+    });
+  });
+
+  describe("isWritable", () => {
+    it("should use parent element details for TEXT_NODE", async () => {
+      const element = new Element(91, "element description", runtimeHandler);
+
+      expect(await element.isWritable()).to.be.true;
+    });
+
+    it("should identify writable input elements", async () => {
+      const element = new Element(92, "element description", runtimeHandler);
+
+      expect(await element.isWritable()).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Summary
- Resolve writable checks against the parent element when a text selector resolves to a text node
- Add unit coverage for contenteditable text-node writability

## Tests
- npx mocha tests/unit-tests/elements/element.test.js