### PR TITLE
Support contenteditable elements with text selector

### DIFF
--- a/packages/taiko/lib/actions/focus.js
+++ b/packages/taiko/lib/actions/focus.js
@@ -21,7 +21,11 @@ const focus = async (selector, options = {}, highlight = false) => {
       objectId: elem.get(),
     });
     function focusElement() {
-      this.focus();
+      let elem = this;
+      if (this.nodeType === Node.TEXT_NODE) {
+        elem = this.parentElement;
+      }
+      elem.focus();
       return true;
     }
   });

--- a/packages/taiko/lib/api.json
+++ b/packages/taiko/lib/api.json
@@ -51,7 +51,7 @@
           "index": 423
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/valueWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\valueWrapper.js"
     },
     "augments": [
       {
@@ -121,7 +121,7 @@
                 "index": 421
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/valueWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\valueWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -237,7 +237,7 @@
           "index": 649
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/imageWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\imageWrapper.js"
     },
     "augments": [
       {
@@ -363,7 +363,7 @@
           "index": 645
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/linkWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\linkWrapper.js"
     },
     "augments": [
       {
@@ -489,7 +489,7 @@
           "index": 659
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/listItemWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\listItemWrapper.js"
     },
     "augments": [
       {
@@ -615,7 +615,7 @@
           "index": 2168
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/tableCellWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\tableCellWrapper.js"
     },
     "augments": [
       {
@@ -820,7 +820,7 @@
           "index": 2157
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/dollarWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\dollarWrapper.js"
     },
     "augments": [
       {
@@ -956,7 +956,7 @@
           "index": 8261
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
     },
     "augments": [],
     "examples": [],
@@ -1075,7 +1075,7 @@
                 "index": 1846
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -1284,7 +1284,7 @@
                 "index": 2242
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -1474,7 +1474,7 @@
                 "index": 3314
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -1662,7 +1662,7 @@
                 "index": 3679
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -1816,7 +1816,7 @@
                 "index": 5006
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -1998,7 +1998,7 @@
                 "index": 5483
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -2195,7 +2195,7 @@
                 "index": 6046
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -2372,7 +2372,7 @@
                 "index": 6360
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -2550,7 +2550,7 @@
                 "index": 7413
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -2773,7 +2773,7 @@
                 "index": 8259
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/elementWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\elementWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -3231,7 +3231,7 @@
           "index": 1760
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/textWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\textWrapper.js"
     },
     "augments": [
       {
@@ -3353,7 +3353,7 @@
           "index": 2774
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/dropDownWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\dropDownWrapper.js"
     },
     "augments": [
       {
@@ -3472,7 +3472,7 @@
                 "index": 2108
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/dropDownWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\dropDownWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -3645,7 +3645,7 @@
                 "index": 2772
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/dropDownWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\dropDownWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -3835,7 +3835,7 @@
           "index": 2355
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/colorWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\colorWrapper.js"
     },
     "augments": [
       {
@@ -3979,7 +3979,7 @@
                 "index": 2353
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/colorWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\colorWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -4169,7 +4169,7 @@
           "index": 2292
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/fileFieldWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\fileFieldWrapper.js"
     },
     "augments": [
       {
@@ -4313,7 +4313,7 @@
                 "index": 2290
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/fileFieldWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\fileFieldWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -4519,7 +4519,7 @@
           "index": 2479
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/rangeWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\rangeWrapper.js"
     },
     "augments": [
       {
@@ -4619,7 +4619,7 @@
                 "index": 1934
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/rangeWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\rangeWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -4776,7 +4776,7 @@
                 "index": 2477
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/rangeWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\rangeWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -5094,7 +5094,7 @@
           "index": 2981
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/buttonWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\buttonWrapper.js"
     },
     "augments": [
       {
@@ -5216,7 +5216,7 @@
           "index": 3413
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/checkBoxWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\checkBoxWrapper.js"
     },
     "augments": [
       {
@@ -5320,7 +5320,7 @@
                 "index": 2448
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/checkBoxWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\checkBoxWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -5430,7 +5430,7 @@
                 "index": 2647
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/checkBoxWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\checkBoxWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -5518,7 +5518,7 @@
                 "index": 2852
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/checkBoxWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\checkBoxWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -5655,7 +5655,7 @@
                 "index": 3411
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/checkBoxWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\checkBoxWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -5849,7 +5849,7 @@
           "index": 3453
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/radioButtonWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\radioButtonWrapper.js"
     },
     "augments": [
       {
@@ -5953,7 +5953,7 @@
                 "index": 2472
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/radioButtonWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\radioButtonWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -6063,7 +6063,7 @@
                 "index": 2668
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/radioButtonWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\radioButtonWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -6151,7 +6151,7 @@
                 "index": 2869
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/radioButtonWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\radioButtonWrapper.js"
           },
           "augments": [],
           "examples": [
@@ -6288,7 +6288,7 @@
                 "index": 3451
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/radioButtonWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\radioButtonWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -6590,7 +6590,7 @@
           "index": 3616
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/timeFieldWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\timeFieldWrapper.js"
     },
     "augments": [
       {
@@ -6690,7 +6690,7 @@
                 "index": 3034
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/timeFieldWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\timeFieldWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -6849,7 +6849,7 @@
                 "index": 3614
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/timeFieldWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\timeFieldWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -7028,7 +7028,7 @@
           "index": 3696
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/textBoxWrapper.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\textBoxWrapper.js"
     },
     "augments": [
       {
@@ -7172,7 +7172,7 @@
                 "index": 3694
               }
             },
-            "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/elementWrapper/textBoxWrapper.js"
+            "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\elementWrapper\\textBoxWrapper.js"
           },
           "augments": [],
           "examples": [],
@@ -7595,7 +7595,7 @@
           "index": 5672
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -8055,7 +8055,7 @@
           "index": 6133
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -8194,7 +8194,7 @@
           "index": 6662
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [],
@@ -8338,7 +8338,7 @@
           "index": 9337
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -8581,7 +8581,7 @@
           "index": 10704
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -8846,7 +8846,7 @@
           "index": 11821
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -9021,7 +9021,7 @@
           "index": 12231
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -9190,7 +9190,7 @@
           "index": 12993
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -9349,7 +9349,7 @@
           "index": 13459
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -9569,7 +9569,7 @@
           "index": 15746
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -9998,7 +9998,7 @@
           "index": 18007
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -10319,7 +10319,7 @@
           "index": 18871
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -10484,7 +10484,7 @@
           "index": 20786
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -10678,7 +10678,7 @@
           "index": 21451
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -10872,7 +10872,7 @@
           "index": 21777
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -11128,7 +11128,7 @@
           "index": 23411
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -11572,7 +11572,7 @@
           "index": 24907
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -11821,7 +11821,7 @@
           "index": 25521
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -11989,7 +11989,7 @@
           "index": 25998
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -12211,7 +12211,7 @@
           "index": 26575
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -12547,7 +12547,7 @@
           "index": 28620
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -12973,7 +12973,7 @@
           "index": 30375
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -13355,7 +13355,7 @@
           "index": 31435
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -13687,7 +13687,7 @@
           "index": 32510
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -14156,7 +14156,7 @@
           "index": 38634
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -14727,7 +14727,7 @@
           "index": 40004
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -15081,7 +15081,7 @@
           "index": 41217
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -15434,7 +15434,7 @@
           "index": 42341
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -15698,7 +15698,7 @@
           "index": 43515
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -15961,7 +15961,7 @@
           "index": 44575
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -16323,7 +16323,7 @@
           "index": 46195
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -16823,7 +16823,7 @@
           "index": 47939
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -17191,7 +17191,7 @@
           "index": 48717
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -17516,7 +17516,7 @@
           "index": 50183
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -17929,7 +17929,7 @@
           "index": 51219
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -18133,7 +18133,7 @@
           "index": 51912
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -18377,7 +18377,7 @@
           "index": 53499
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -18844,7 +18844,7 @@
           "index": 55784
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -19303,7 +19303,7 @@
           "index": 56692
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -19535,7 +19535,7 @@
           "index": 57598
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -19767,7 +19767,7 @@
           "index": 58482
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -19999,7 +19999,7 @@
           "index": 59375
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -20265,7 +20265,7 @@
           "index": 60821
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -20623,7 +20623,7 @@
           "index": 62205
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -20986,7 +20986,7 @@
           "index": 63125
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -21249,7 +21249,7 @@
           "index": 64034
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -21527,7 +21527,7 @@
           "index": 64907
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -21813,7 +21813,7 @@
           "index": 65870
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -22091,7 +22091,7 @@
           "index": 66873
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -22369,7 +22369,7 @@
           "index": 67714
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -22649,7 +22649,7 @@
           "index": 68876
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -22907,7 +22907,7 @@
           "index": 69851
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -23143,7 +23143,7 @@
           "index": 70746
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -23410,7 +23410,7 @@
           "index": 72229
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -23708,7 +23708,7 @@
           "index": 73860
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -23962,7 +23962,7 @@
           "index": 75211
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -24208,7 +24208,7 @@
           "index": 76340
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -24439,7 +24439,7 @@
           "index": 77207
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -24696,7 +24696,7 @@
           "index": 78051
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -24950,7 +24950,7 @@
           "index": 78923
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -25140,7 +25140,7 @@
           "index": 79640
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -25330,7 +25330,7 @@
           "index": 80323
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -25520,7 +25520,7 @@
           "index": 81006
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -25710,7 +25710,7 @@
           "index": 82256
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -25901,7 +25901,7 @@
           "index": 83256
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -26084,7 +26084,7 @@
           "index": 84424
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -26297,7 +26297,7 @@
           "index": 85692
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -26490,7 +26490,7 @@
           "index": 86928
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -26665,7 +26665,7 @@
           "index": 87405
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -26931,12 +26931,12 @@
           "index": 89383
         },
         "end": {
-          "line": 2479,
+          "line": 2488,
           "column": 2,
-          "index": 90530
+          "index": 90808
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -27332,30 +27332,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2481,
+        "line": 2490,
         "column": 0,
-        "index": 90532
+        "index": 90810
       },
       "end": {
-        "line": 2489,
+        "line": 2498,
         "column": 3,
-        "index": 90841
+        "index": 91119
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2490,
+          "line": 2499,
           "column": 0,
-          "index": 90842
+          "index": 91120
         },
         "end": {
-          "line": 2490,
+          "line": 2499,
           "column": 37,
-          "index": 90879
+          "index": 91157
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -27368,7 +27368,7 @@
       {
         "title": "param",
         "name": "value",
-        "lineNumber": 2490
+        "lineNumber": 2499
       },
       {
         "title": "param",
@@ -27521,30 +27521,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2492,
+        "line": 2501,
         "column": 0,
-        "index": 90881
+        "index": 91159
       },
       "end": {
-        "line": 2500,
+        "line": 2509,
         "column": 3,
-        "index": 91182
+        "index": 91460
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2501,
+          "line": 2510,
           "column": 0,
-          "index": 91183
+          "index": 91461
         },
         "end": {
-          "line": 2501,
+          "line": 2510,
           "column": 39,
-          "index": 91222
+          "index": 91500
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -27557,7 +27557,7 @@
       {
         "title": "param",
         "name": "value",
-        "lineNumber": 2501
+        "lineNumber": 2510
       },
       {
         "title": "param",
@@ -27709,30 +27709,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2562,
+        "line": 2571,
         "column": 0,
-        "index": 92823
+        "index": 93101
       },
       "end": {
-        "line": 2572,
+        "line": 2581,
         "column": 3,
-        "index": 93135
+        "index": 93413
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2573,
+          "line": 2582,
           "column": 0,
-          "index": 93136
+          "index": 93414
         },
         "end": {
-          "line": 2576,
+          "line": 2585,
           "column": 2,
-          "index": 93289
+          "index": 93567
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -27873,30 +27873,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2578,
+        "line": 2587,
         "column": 0,
-        "index": 93291
+        "index": 93569
       },
       "end": {
-        "line": 2585,
+        "line": 2594,
         "column": 3,
-        "index": 93469
+        "index": 93747
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2586,
+          "line": 2595,
           "column": 0,
-          "index": 93470
+          "index": 93748
         },
         "end": {
-          "line": 2589,
+          "line": 2598,
           "column": 2,
-          "index": 93611
+          "index": 93889
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -28088,30 +28088,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2655,
+        "line": 2664,
         "column": 0,
-        "index": 95469
+        "index": 95747
       },
       "end": {
-        "line": 2676,
+        "line": 2685,
         "column": 3,
-        "index": 97154
+        "index": 97432
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2677,
+          "line": 2686,
           "column": 0,
-          "index": 97155
+          "index": 97433
         },
         "end": {
-          "line": 2677,
+          "line": 2686,
           "column": 37,
-          "index": 97192
+          "index": 97470
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -28799,30 +28799,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2679,
+        "line": 2688,
         "column": 0,
-        "index": 97194
+        "index": 97472
       },
       "end": {
-        "line": 2704,
+        "line": 2713,
         "column": 3,
-        "index": 99486
+        "index": 99764
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2705,
+          "line": 2714,
           "column": 0,
-          "index": 99487
+          "index": 99765
         },
         "end": {
-          "line": 2705,
+          "line": 2714,
           "column": 37,
-          "index": 99524
+          "index": 99802
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -29567,30 +29567,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2908,
+        "line": 2917,
         "column": 0,
-        "index": 103682
+        "index": 103960
       },
       "end": {
-        "line": 2918,
+        "line": 2927,
         "column": 3,
-        "index": 104025
+        "index": 104303
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2919,
+          "line": 2928,
           "column": 0,
-          "index": 104026
+          "index": 104304
         },
         "end": {
-          "line": 2931,
+          "line": 2940,
           "column": 2,
-          "index": 104463
+          "index": 104741
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -29725,7 +29725,7 @@
           "index": 33449
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -29871,7 +29871,7 @@
           "index": 33865
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -30029,30 +30029,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2503,
+        "line": 2512,
         "column": 0,
-        "index": 91224
+        "index": 91502
       },
       "end": {
-        "line": 2519,
+        "line": 2528,
         "column": 3,
-        "index": 91719
+        "index": 91997
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2521,
+          "line": 2530,
           "column": 0,
-          "index": 91721
+          "index": 91999
         },
         "end": {
-          "line": 2558,
+          "line": 2567,
           "column": 2,
-          "index": 92786
+          "index": 93064
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -30129,7 +30129,7 @@
       {
         "title": "param",
         "name": "options",
-        "lineNumber": 2521,
+        "lineNumber": 2530,
         "default": "{}"
       },
       {
@@ -30234,30 +30234,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2591,
+        "line": 2600,
         "column": 0,
-        "index": 93613
+        "index": 93891
       },
       "end": {
-        "line": 2605,
+        "line": 2614,
         "column": 3,
-        "index": 93945
+        "index": 94223
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2613,
+          "line": 2622,
           "column": 0,
-          "index": 94149
+          "index": 94427
         },
         "end": {
-          "line": 2626,
+          "line": 2635,
           "column": 2,
-          "index": 94506
+          "index": 94784
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -30330,30 +30330,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2607,
+        "line": 2616,
         "column": 0,
-        "index": 93947
+        "index": 94225
       },
       "end": {
-        "line": 2612,
+        "line": 2621,
         "column": 3,
-        "index": 94148
+        "index": 94426
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2613,
+          "line": 2622,
           "column": 0,
-          "index": 94149
+          "index": 94427
         },
         "end": {
-          "line": 2626,
+          "line": 2635,
           "column": 2,
-          "index": 94506
+          "index": 94784
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [],
@@ -30362,7 +30362,7 @@
       {
         "title": "param",
         "name": "id",
-        "lineNumber": 2613
+        "lineNumber": 2622
       },
       {
         "title": "param",
@@ -30488,30 +30488,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2755,
+        "line": 2764,
         "column": 0,
-        "index": 100795
+        "index": 101073
       },
       "end": {
-        "line": 2769,
+        "line": 2778,
         "column": 3,
-        "index": 101044
+        "index": 101322
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2803,
+          "line": 2812,
           "column": 0,
-          "index": 101736
+          "index": 102014
         },
         "end": {
-          "line": 2803,
+          "line": 2812,
           "column": 21,
-          "index": 101757
+          "index": 102035
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -30663,30 +30663,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2771,
+        "line": 2780,
         "column": 0,
-        "index": 101046
+        "index": 101324
       },
       "end": {
-        "line": 2790,
+        "line": 2799,
         "column": 3,
-        "index": 101528
+        "index": 101806
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2803,
+          "line": 2812,
           "column": 0,
-          "index": 101736
+          "index": 102014
         },
         "end": {
-          "line": 2803,
+          "line": 2812,
           "column": 21,
-          "index": 101757
+          "index": 102035
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [
@@ -30841,30 +30841,30 @@
     ],
     "loc": {
       "start": {
-        "line": 2792,
+        "line": 2801,
         "column": 0,
-        "index": 101530
+        "index": 101808
       },
       "end": {
-        "line": 2801,
+        "line": 2810,
         "column": 3,
-        "index": 101734
+        "index": 102012
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 2803,
+          "line": 2812,
           "column": 0,
-          "index": 101736
+          "index": 102014
         },
         "end": {
-          "line": 2803,
+          "line": 2812,
           "column": 21,
-          "index": 101757
+          "index": 102035
         }
       },
-      "file": "/Users/zabilcm/projects/taiko/packages/taiko/lib/taiko.js"
+      "file": "C:\\Users\\anshi\\.gemini\\antigravity-ide\\scratch\\taiko\\packages\\taiko\\lib\\taiko.js"
     },
     "augments": [],
     "examples": [

--- a/packages/taiko/lib/elements/element.js
+++ b/packages/taiko/lib/elements/element.js
@@ -91,12 +91,16 @@ class Element {
 
   async isWritable() {
     function getDetailsForWrittable() {
+      let elem = this;
+      if (this.nodeType === Node.TEXT_NODE) {
+        elem = this.parentElement;
+      }
       return {
-        tagName: this.tagName,
-        isContentEditable: this.isContentEditable,
-        disabled: this.disabled,
-        type: this.type,
-        readOnly: this.readOnly,
+        tagName: elem.tagName,
+        isContentEditable: elem.isContentEditable,
+        disabled: elem.disabled,
+        type: elem.type,
+        readOnly: elem.readOnly,
       };
     }
 

--- a/tests/unit-tests/write.test.js
+++ b/tests/unit-tests/write.test.js
@@ -11,6 +11,7 @@ const {
   into,
   focus,
   setConfig,
+  text,
 } = require("taiko");
 const { descEvent } = require("taiko/lib/helper");
 const { createHtml, removeFile, openBrowserArgs } = require("./test-util");
@@ -54,6 +55,9 @@ const innerHtml = `
         document.getElementById('disabled').disabled = false;
       }, 100);
     </script>
+    <div>
+      <div id='contenteditable' contenteditable='true'>This is a paragraph is editable.</div>
+    </div>
   </div>`;
 
 describe(test_name, () => {
@@ -146,6 +150,11 @@ describe(test_name, () => {
     const text = "Shadow text updated";
     await write(text, into(input));
     expect(await input.value()).to.equal(text);
+  });
+
+  it("should write into contenteditable element", async () => {
+    await write("Hello", into(text("This is a paragraph is editable.")));
+    expect(await text("HelloThis is a paragraph is editable.").exists()).to.be.true;
   });
 
   describe("write test on multiple similar elements", () => {


### PR DESCRIPTION
Adds support for writing into `contenteditable` elements using the `text()` selector.

### Changes:
- **`element.js`**: Checks the `parentElement` of a `TEXT_NODE` to correctly determine if it is writable (`isContentEditable`).
- **`focus.js`**: Shifts focus to the `parentElement` if the targeted element is a `TEXT_NODE`.
- **`write.test.js`**: Added a unit test to verify writing into `contenteditable` via `text()`.
