### PR TITLE
fix: guard getExecutablePlugins against failed npm root spawn

### DIFF
--- a/packages/taiko/lib/plugins.js
+++ b/packages/taiko/lib/plugins.js
@@ -37,15 +37,17 @@ const getPlugins = () => {
   return taikoPluginNames;
 };
 
+const npmRootPath = (args) => {
+  const result = childProcess.spawnSync("npm", args);
+  if (result.error || result.stdout == null) {
+    return "";
+  }
+  return result.stdout.toString().trim();
+};
+
 const getExecutablePlugins = () => {
-  const pluginsGlobalPath = childProcess
-    .spawnSync("npm", ["root", "-g"])
-    .stdout.toString()
-    .trim();
-  const pluginsLocalPath = childProcess
-    .spawnSync("npm", ["root"])
-    .stdout.toString()
-    .trim();
+  const pluginsGlobalPath = npmRootPath(["root", "-g"]);
+  const pluginsLocalPath = npmRootPath(["root"]);
   const globalPlugins = getPluginsInstalledOn(pluginsGlobalPath);
   const localPlugins = getPluginsInstalledOn(pluginsLocalPath);
   const globalExecutablePlugin = filterExecutablePlugin(

--- a/tests/unit-tests/plugins.test.js
+++ b/tests/unit-tests/plugins.test.js
@@ -228,5 +228,17 @@ describe("Plugins", () => {
       };
       expect(PLUGINS.getExecutablePlugins()).to.be.deep.equal(expected);
     });
+
+    it("should not throw when npm root cannot be spawned", () => {
+      PLUGINS.__set__("childProcess", {
+        spawnSync: () => {
+          return { error: new Error("spawn npm ENOENT"), stdout: null };
+        },
+      });
+      PLUGINS.__set__("fs", {
+        existsSync: () => false,
+      });
+      expect(PLUGINS.getExecutablePlugins()).to.be.deep.equal({});
+    });
   });
 });


### PR DESCRIPTION
Fixes #2782.

When `npm` is not resolvable on `PATH` (common on a fresh Windows install), `childProcess.spawnSync("npm", ...)` returns `{ stdout: null, error: ... }`, so `getExecutablePlugins` crashes on `.stdout.toString()` and even `taiko -v` fails to run. This pulls the npm-root lookup into a small helper that returns an empty string when the spawn fails, which `getPluginsInstalledOn` already treats as "no plugins". Added a unit test that reproduces the ENOENT case.