### PR TITLE
build: bump taiko inner package version to 1.5.0

### DIFF
--- a/packages/taiko/package.json
+++ b/packages/taiko/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "taiko",
-  "version": "1.4.9",
+  "version": "1.5.0",
   "description": "Taiko is a Node.js library for automating Chromium based browsers",
   "main": "bin/taiko.js",
   "bin": {


### PR DESCRIPTION
## Problem

The release workflow reads the version from `packages/taiko/package.json`, but PR #2783 only bumped the version in the root `package.json` (to `1.5.0`), leaving `packages/taiko/package.json` at `1.4.9`.

This caused the "Release on PR Merge" workflow to attempt creating a GitHub release for `v1.4.9`, which already exists, resulting in:
```
HTTP 422: Validation Failed
Release.tag_name already exists
```

## Fix

Bump `packages/taiko/package.json` version from `1.4.9` → `1.5.0` to match the root package.