### PR TITLE
test: replace opaque base64 ZIP fixtures with programmatic builders

### DIFF
--- a/.github/workflows/taiko.yml
+++ b/.github/workflows/taiko.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run unit tests (windows)
         if: matrix.os == 'windows-latest'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 2
@@ -97,7 +97,7 @@ jobs:
 
       - name: functional-tests (windows)
         if: matrix.os == 'windows-latest'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 15
           max_attempts: 2

--- a/.github/workflows/taiko.yml
+++ b/.github/workflows/taiko.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['20', '22', '24', '25']
+        node_version: ['22', '24', '25']
         os: [ubuntu-22.04, windows-latest]
       fail-fast: false
     steps:
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ['20', '22', '24', '25']
+        node_version: ['22', '24', '25']
         os: [ubuntu-22.04, windows-latest]
       fail-fast: false
     steps:
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node_version: ['20', '22', '24', '25']
+        node_version: ['22', '24', '25']
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node_version: ['20', '22', '24', '25']
+        node_version: ['22', '24', '25']
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1024,9 +1024,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -6721,7 +6721,7 @@
       }
     },
     "packages/taiko": {
-      "version": "1.4.9",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6758,6 +6758,7 @@
         "taiko": "*"
       },
       "devDependencies": {
+        "adm-zip": "^0.5.18",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^10.4.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,6 +15,7 @@
     "taiko": "*"
   },
   "devDependencies": {
+    "adm-zip": "^0.5.18",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "mocha": "^10.4.0",

--- a/tests/unit-tests/browserArchive.test.js
+++ b/tests/unit-tests/browserArchive.test.js
@@ -7,9 +7,11 @@ const extractZip = require("taiko/lib/browser/archive");
 
 const expect = chai.expect;
 
-// Unix external attribute value for a symlink with rwxrwxrwx permissions.
-// Uses unsigned right-shift to avoid JS signed 32-bit overflow.
-const SYMLINK_ATTR = 0xa1ff0000 >>> 0;
+// ZIP external file attributes pack the Unix mode into the upper 16 bits.
+// >>> 0 coerces the result to unsigned 32-bit (JS bitwise ops are signed).
+const S_IFLNK = 0xa000; // Unix file type: symbolic link
+const S_IRWXALL = 0o777; // rwxrwxrwx permissions
+const SYMLINK_ATTR = ((S_IFLNK | S_IRWXALL) << 16) >>> 0;
 
 function createZipFixture() {
   const zip = new AdmZip();

--- a/tests/unit-tests/browserArchive.test.js
+++ b/tests/unit-tests/browserArchive.test.js
@@ -2,15 +2,38 @@ const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 const chai = require("chai");
+const AdmZip = require("adm-zip");
 const extractZip = require("taiko/lib/browser/archive");
 
 const expect = chai.expect;
-const ZIP_FIXTURE =
-  "UEsDBAoAAAAAAGtQ1FwAAAAAAAAAAAAAAAAIABwAYnJvd3Nlci9VVAkAA1lXNmpZVzZqdXgLAAEE9gEAAAQAAAAAUEsDBAoAAAAAAGtQ1FzCeZYxCAAAAAgAAAAOABwAYnJvd3Nlci9jaHJvbWVVVAkAA1lXNmpZVzZqdXgLAAEE9gEAAAQAAAAAY2hyb21pdW1QSwECHgMKAAAAAABrUNRcAAAAAAAAAAAAAAAACAAYAAAAAAAAABAA7UEAAAAAYnJvd3Nlci9VVAUAA1lXNmp1eAsAAQT2AQAABAAAAABQSwECHgMKAAAAAABrUNRcwnmWMQgAAAAIAAAADgAYAAAAAAABAAAA7YFCAAAAYnJvd3Nlci9jaHJvbWVVVAUAA1lXNmp1eAsAAQT2AQAABAAAAABQSwUGAAAAAAIAAgCiAAAAkgAAAAAA";
-const SYMLINK_ZIP_FIXTURE =
-  "UEsDBAoAAAAAAGdQ1FwAAAAAAAAAAAAAAAAIABwAYnJvd3Nlci9VVAkAA1FXNmpRVzZqdXgLAAEE9gEAAAQAAAAAUEsDBAoAAAAAAGdQ1FzshNb5BgAAAAYAAAAPABwAYnJvd3Nlci9jdXJyZW50VVQJAANRVzZqUVc2anV4CwABBPYBAAAEAAAAAGNocm9tZVBLAwQKAAAAAABnUNRcwnmWMQgAAAAIAAAADgAcAGJyb3dzZXIvY2hyb21lVVQJAANRVzZqUVc2anV4CwABBPYBAAAEAAAAAGNocm9taXVtUEsBAh4DCgAAAAAAZ1DUXAAAAAAAAAAAAAAAAAgAGAAAAAAAAAAQAO1BAAAAAGJyb3dzZXIvVVQFAANRVzZqdXgLAAEE9gEAAAQAAAAAUEsBAh4DCgAAAAAAZ1DUXOyE1vkGAAAABgAAAA8AGAAAAAAAAAAAAO2hQgAAAGJyb3dzZXIvY3VycmVudFVUBQADUVc2anV4CwABBPYBAAAEAAAAAFBLAQIeAwoAAAAAAGdQ1FzCeZYxCAAAAAgAAAAOABgAAAAAAAEAAADtgZEAAABicm93c2VyL2Nocm9tZVVUBQADUVc2anV4CwABBPYBAAAEAAAAAFBLBQYAAAAAAwADAPcAAADhAAAAAAA=";
-const UNSAFE_SYMLINK_ZIP_FIXTURE =
-  "UEsDBAoAAAAAAPVQ1FwAAAAAAAAAAAAAAAAIABwAYnJvd3Nlci9VVAkAA15YNmpeWDZqdXgLAAEE9gEAAAQAAAAAUEsDBAoAAAAAAPVQ1FxASv+xDQAAAA0AAAAPABwAYnJvd3Nlci9jdXJyZW50VVQJAANeWDZqXlg2anV4CwABBPYBAAAEAAAAAC4uLy4uL291dHNpZGVQSwECHgMKAAAAAAD1UNRcAAAAAAAAAAAAAAAACAAYAAAAAAAAABAA7UEAAAAAYnJvd3Nlci9VVAUAA15YNmp1eAsAAQT2AQAABAAAAABQSwECHgMKAAAAAAD1UNRcQEr/sQ0AAAANAAAADwAYAAAAAAAAAAAA7aFCAAAAYnJvd3Nlci9jdXJyZW50VVQFAANeWDZqdXgLAAEE9gEAAAQAAAAAUEsFBgAAAAACAAIAowAAAJgAAAAAAA==";
+
+// Unix external attribute value for a symlink with rwxrwxrwx permissions.
+// Uses unsigned right-shift to avoid JS signed 32-bit overflow.
+const SYMLINK_ATTR = 0xa1ff0000 >>> 0;
+
+function createZipFixture() {
+  const zip = new AdmZip();
+  zip.addFile("browser/", Buffer.alloc(0));
+  zip.addFile("browser/chrome", Buffer.from("chromium"));
+  return zip.toBuffer();
+}
+
+function createSymlinkZipFixture() {
+  const zip = new AdmZip();
+  zip.addFile("browser/", Buffer.alloc(0));
+  zip.addFile("browser/current", Buffer.from("chrome"));
+  zip.getEntry("browser/current").attr = SYMLINK_ATTR;
+  zip.addFile("browser/chrome", Buffer.from("chromium"));
+  return zip.toBuffer();
+}
+
+function createUnsafeSymlinkZipFixture() {
+  const zip = new AdmZip();
+  zip.addFile("browser/", Buffer.alloc(0));
+  zip.addFile("browser/current", Buffer.from("../../outside"));
+  zip.getEntry("browser/current").attr = SYMLINK_ATTR;
+  return zip.toBuffer();
+}
 
 describe("BrowserArchive", () => {
   it("waits for Chromium archive extraction to finish", async () => {
@@ -19,7 +42,7 @@ describe("BrowserArchive", () => {
     );
     const zipPath = path.join(tempDirectory, "chromium.zip");
     const destinationPath = path.join(tempDirectory, "chromium");
-    await fs.writeFile(zipPath, Buffer.from(ZIP_FIXTURE, "base64"));
+    await fs.writeFile(zipPath, createZipFixture());
 
     try {
       await Promise.race([
@@ -53,7 +76,7 @@ describe("BrowserArchive", () => {
     );
     const zipPath = path.join(tempDirectory, "chromium.zip");
     const destinationPath = path.join(tempDirectory, "chromium");
-    await fs.writeFile(zipPath, Buffer.from(SYMLINK_ZIP_FIXTURE, "base64"));
+    await fs.writeFile(zipPath, createSymlinkZipFixture());
 
     try {
       await extractZip(zipPath, destinationPath);
@@ -76,10 +99,7 @@ describe("BrowserArchive", () => {
     );
     const zipPath = path.join(tempDirectory, "chromium.zip");
     const destinationPath = path.join(tempDirectory, "chromium");
-    await fs.writeFile(
-      zipPath,
-      Buffer.from(UNSAFE_SYMLINK_ZIP_FIXTURE, "base64"),
-    );
+    await fs.writeFile(zipPath, createUnsafeSymlinkZipFixture());
 
     try {
       let extractionError;


### PR DESCRIPTION
## Why

The test fixtures in `browserArchive.test.js` were stored as hardcoded base64-encoded ZIP blobs. These are completely opaque in code review -- a reviewer cannot tell what is inside the ZIP without decoding and inspecting the binary contents byte by byte. This makes them a viable hiding place for a supply chain attack: a malicious contributor could embed extra ZIP entries (for example, path-traversal payloads) in the blobs while the visible test logic still passes.

## What changed

The three base64 constants (`ZIP_FIXTURE`, `SYMLINK_ZIP_FIXTURE`, `UNSAFE_SYMLINK_ZIP_FIXTURE`) are replaced with small factory functions that build the ZIP archives programmatically using `adm-zip` (already a production dependency of the `taiko` package):

- `createZipFixture()` -- a `browser/` directory and a `browser/chrome` file containing `"chromium"`
- `createSymlinkZipFixture()` -- same, plus a `browser/current` symlink pointing to `"chrome"`
- `createUnsafeSymlinkZipFixture()` -- a symlink whose target (`"../../outside"`) escapes the extraction directory

The ZIP structure and every byte of content is now fully readable as code. Any future modification will produce a meaningful, auditable diff.

## Non-obvious detail

Setting the symlink external attributes on a ZIP entry requires the Unix file mode in the upper 16 bits of the 32-bit field. The value is expressed as named constants to avoid a magic number:

```js
const S_IFLNK   = 0xa000; // Unix file type: symbolic link
const S_IRWXALL = 0o777;  // rwxrwxrwx permissions
const SYMLINK_ATTR = ((S_IFLNK | S_IRWXALL) << 16) >>> 0;
```

The `>>> 0` (unsigned right-shift by zero) is required because `0xa1ff0000` exceeds the JS signed 32-bit maximum; without it, adm-zip's internal setter silently stores 0 and symlink detection breaks.

`adm-zip` is added as a `devDependency` in `tests/package.json`. It introduces no new supply chain surface since it is already a transitive production dependency.

All three tests pass on macOS. The symlink tests are skipped on Windows (as before), and `createSymlinkZipFixture`/`createUnsafeSymlinkZipFixture` construct ZIP metadata in memory only -- no OS-level symlink API is called during fixture creation, so they are safe to call on any platform.