### PR TITLE
fix: resolve xhrEvent promise when Fetch intercept fulfils a navigation on Windows

### DIFF
--- a/packages/taiko/lib/handlers/fetchHandler.js
+++ b/packages/taiko/lib/handlers/fetchHandler.js
@@ -130,6 +130,7 @@ const handleInterceptor = (p) => {
             });
             eventHandler.emit("navigationFulfilledByIntercept", {
               frameId: p.frameId,
+              networkId: p.networkId,
             });
           }
         })

--- a/packages/taiko/lib/handlers/networkHandler.js
+++ b/packages/taiko/lib/handlers/networkHandler.js
@@ -23,6 +23,12 @@ const createdSessionListener = (client) => {
 };
 eventHandler.on("createdSession", createdSessionListener);
 
+eventHandler.on("navigationFulfilledByIntercept", ({ networkId }) => {
+  if (networkId) {
+    resolveXHREvent({ requestId: networkId });
+  }
+});
+
 const resetPromises = () => {
   requestPromises = {};
 };


### PR DESCRIPTION
## Problem

On Windows, Chrome does not fire `Network.loadingFinished` for **same-origin subsequent navigations** when `Fetch.fulfillRequest` is used to mock a Document navigation (e.g. navigating from `https://localhost/employees/1/address` to `https://localhost/employees/2/address`).

This leaves an `xhrEvent` promise in `doActionAwaitingNavigation`'s `promises` array that never resolves, causing `Promise.all(promises)` in `waitForNavigation` to hang until the 60s `navigationTimeout` fires.

The first navigation to a new origin works fine (Chrome fires `loadingFinished` for cross-origin navigations). Only subsequent same-origin navigations using Fetch intercept fail on Windows.

This issue was visible as a flaky CI failure on PR #2780.

## Root Cause

A partial fix already existed in `fetchHandler.js` — when `Fetch.fulfillRequest` resolves for a Document resource, it emits:
- `interceptedNavigationResponse` → unblocks `responsePromise` in `handleNavigation`
- `navigationFulfilledByIntercept` → resolves frame promises in `pageHandler.js`

But **nothing resolved the `xhrEvent` promise**, which is the remaining blocker.

## Fix

### `packages/taiko/lib/handlers/fetchHandler.js`

Include `networkId: p.networkId` in the `navigationFulfilledByIntercept` event emit. `p.networkId` is the `Fetch.requestPaused` field that carries the corresponding `Network.requestId`.

### `packages/taiko/lib/handlers/networkHandler.js`

Add a module-level listener for `navigationFulfilledByIntercept` that calls `resolveXHREvent({ requestId: networkId })`. This safely no-ops when `networkId` is absent or the `requestId` is not tracked, so double-resolution is not a concern.

## Testing

- All 1166 unit tests pass (`npm run test:unit`)
- Relevant tests: `tests/unit-tests/intercept.test.js`, `tests/unit-tests/handlers/networkHandler.test.js`